### PR TITLE
ci: target Dependabot PRs to develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,18 +2,21 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Add `target-branch: develop` to all Dependabot ecosystems (Maven, GitHub Actions, npm)
- Dependabot PRs were going directly to main, bypassing the develop→main git flow

## Test plan
- [ ] Verify next Dependabot PR targets develop instead of main

🤖 Generated with [Claude Code](https://claude.com/claude-code)