### PR TITLE
fix: downgrade Kotlin 2.3.20 → 2.3.10 for CodeQL compatibility

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,6 @@ jobs:
   analyze:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
-    # CodeQL does not yet support Kotlin 2.3.20 — allow failure until support lands
-    continue-on-error: true
     permissions:
       security-events: write
     env:

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
-        <kotlin.version>2.3.20</kotlin.version>
+        <kotlin.version>2.3.10</kotlin.version>
         <outerstellar.version>1.0.3</outerstellar.version>
         <http4k.version>6.36.0.0</http4k.version>
         <flyway.version>12.1.1</flyway.version>
@@ -438,6 +438,12 @@
                 <groupId>org.simplejavamail</groupId>
                 <artifactId>simple-java-mail</artifactId>
                 <version>${simplejavamail.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.github.bbottema</groupId>
+                        <artifactId>jetbrains-runtime-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.konform</groupId>


### PR DESCRIPTION
## Summary
- Downgrade Kotlin from 2.3.20 to 2.3.10 (patch release, minimal risk)
- CodeQL does not support Kotlin >= 2.3.20 yet
- Remove `continue-on-error` from CodeQL workflow — it should now pass

## Test plan
- [x] `mvn verify` passes locally (505 tests, 0 failures, all quality checks clean)
- [ ] CodeQL Analysis passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)