### PR TITLE
security: harden workflows and add security policy

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,14 +8,20 @@ on:
     branches: [main, develop]
     paths: ['.github/workflows/**']
 
+permissions: {}
+
 jobs:
   actionlint:
     name: Lint GitHub Actions
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run actionlint
         uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,22 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions: {}
+
 jobs:
   build-and-test:
     name: Build, Test, and Quality
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -63,12 +69,16 @@ jobs:
     name: Desktop Tests (Xvfb)
     needs: build-and-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
@@ -106,6 +116,8 @@ jobs:
   security:
     name: Security (OWASP + Enforcer)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'push'
     env:
       GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
@@ -113,6 +125,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,11 +8,14 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
+permissions: {}
+
 jobs:
   analyze:
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     env:
       GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
@@ -20,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions: {}
+
 jobs:
   gitleaks:
     name: Secret Detection
@@ -19,6 +21,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -8,6 +8,8 @@ on:
     branches: [main, develop]
     paths: ['**/Dockerfile*']
 
+permissions: {}
+
 jobs:
   hadolint:
     name: Dockerfile Linting
@@ -19,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run Hadolint on docker/Dockerfile
         uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -17,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,13 +6,14 @@ on:
   schedule:
     - cron: '0 6 * * 1'
 
-permissions: read-all
+permissions: {}
 
 jobs:
   scorecard:
     name: OpenSSF Scorecard
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
       id-token: write
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -8,6 +8,8 @@ on:
     branches: [main, develop]
     paths: ['.github/workflows/**']
 
+permissions: {}
+
 jobs:
   zizmor:
     name: Zizmor (Actions Security)
@@ -19,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install zizmor
         run: pipx install zizmor

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through
+[GitHub Security Advisories](https://github.com/rygel/outerstellar-platform/security/advisories/new).
+
+**Do not open public issues for security vulnerabilities.**
+
+### What to expect
+
+- **Acknowledgement:** within 48 hours of your report.
+- **Resolution target:** within 30 days of acknowledgement.
+- **Disclosure:** coordinated disclosure after a fix is available.
+
+We appreciate your efforts to responsibly disclose your findings.


### PR DESCRIPTION
## Summary
- Add top-level `permissions: {}` to all 8 workflows (least privilege default)
- Add job-level permissions with only required scopes
- Add `persist-credentials: false` to all checkout steps (prevents credential leakage)
- Add `SECURITY.md` with vulnerability reporting guidelines

Addresses OSSF Scorecard `TokenPermissionsID` and `SecurityPolicyID` findings,
and zizmor `artipacked` and `excessive-permissions` findings.

## Test plan
- [ ] CI passes
- [ ] OSSF Scorecard score improves on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)