### PR TITLE
chore: CI efficiency, code improvements, and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false
+
+[*.xml]
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build, Test, and Quality
@@ -43,7 +47,7 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Build and run all checks
-        run: mvn clean verify -pl core,persistence-jooq,persistence-jdbi,api-client,security,web,seed
+        run: mvn clean verify -pl core,persistence-jooq,persistence-jdbi,api-client,security,web
 
       - name: Cache build output for desktop tests
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
@@ -124,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
     env:
       GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: CodeQL Analysis

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,20 @@
+# TODO
+
+## Security
+- [ ] Add Jazzer fuzz tests for high-risk surfaces (sync API payloads, OAuth callback parsing, i18n message resolution)
+- [ ] Register on [OpenSSF CII Best Practices](https://www.bestpractices.dev/) and complete self-assessment
+
+## Quality
+- [ ] Review EI_EXPOSE_REP global SpotBugs exclusion — investigate if Kotlin immutable List bytecode can be handled without global suppression
+- [ ] Add PostgreSQL integration test profile to CI (`-Ptest-postgres` with Podman)
+
+## Platform Release
+- [ ] Merge develop → main and release v0.1.0
+- [ ] Publish to GitHub Packages
+
+## MAIA Rebase
+- [ ] Rebase MAIA onto outerstellar-platform (feat/platform-rebase branch)
+- [ ] Implement MaiaCrmPlugin against PlatformPlugin interface
+- [ ] Delete duplicated security, auth, layout, filter code from MAIA
+- [ ] Migrate CRM Flyway migrations to plugin migration location
+- [ ] Layout engine performance improvements (cache ThemeCatalog CSS, nav link caching)

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/AdminWebModule.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/AdminWebModule.kt
@@ -1,0 +1,14 @@
+package io.github.rygel.outerstellar.platform.di
+
+import io.github.rygel.outerstellar.platform.persistence.JooqNotificationRepository
+import io.github.rygel.outerstellar.platform.persistence.NotificationRepository
+import io.github.rygel.outerstellar.platform.service.NotificationService
+import io.github.rygel.outerstellar.platform.web.AdminPageFactory
+import org.koin.dsl.module
+
+val adminWebModule
+    get() = module {
+        single<NotificationRepository> { JooqNotificationRepository(get()) }
+        single { NotificationService(get()) }
+        single { AdminPageFactory(get(), get()) }
+    }

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/WebModule.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/WebModule.kt
@@ -34,13 +34,12 @@ import org.koin.dsl.module
 
 val webModule
     get() = module {
+        includes(adminWebModule)
         single { AppConfig.fromEnvironment() }
         single(named("jdbcUrl")) { get<AppConfig>().jdbcUrl }
         single(named("serverBaseUrl")) { "http://localhost:8080" }
         single(named("appBaseUrl")) { get<AppConfig>().appBaseUrl }
         single<TemplateRenderer> { createRenderer() }
-        single<NotificationRepository> { JooqNotificationRepository(get()) }
-        single { NotificationService(get()) }
         single { WebPageFactory(get(), get(), get(), get(), get()) }
         single { SyncApi(get(), get(), get()) }
         single<MessageCache> {

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebPageFactory.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebPageFactory.kt
@@ -365,7 +365,7 @@ private const val MIN_PASSWORD_LENGTH = 8
 
 private val gravatarCache = java.util.concurrent.ConcurrentHashMap<String, String>()
 
-internal fun gravatarUrl(email: String, customUrl: String?): String {
+fun gravatarUrl(email: String, customUrl: String?): String {
     if (!customUrl.isNullOrBlank()) return customUrl
     return gravatarCache.computeIfAbsent(email.trim().lowercase()) { normalized ->
         val hash =


### PR DESCRIPTION
## Summary
1. **Concurrency control**: Cancel stale CI/CodeQL runs when new push arrives
2. **OWASP**: Only run on main/develop pushes, not every PR
3. **Remove seed from CI**: No tests, utility-only module
4. **gravatarUrl**: Change from `internal` to package-level function
5. **Split WebModule**: Extract AdminWebModule (NotificationRepository, NotificationService, AdminPageFactory)
6. **Add .editorconfig**: Consistent formatting across editors
8. **Add docs/TODO.md**: Track pending improvements

## Test plan
- [x] Compiles locally
- [x] 505 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)