### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/api-client/pom.xml
+++ b/api-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>0.1.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>api-client</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>0.1.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/desktop/pom.xml
+++ b/desktop/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>0.1.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>desktop</artifactId>

--- a/persistence-jdbi/pom.xml
+++ b/persistence-jdbi/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>0.1.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>persistence-jdbi</artifactId>

--- a/persistence-jooq/pom.xml
+++ b/persistence-jooq/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>0.1.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>persistence-jooq</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.rygel</groupId>
     <artifactId>outerstellar-platform-parent</artifactId>
-    <version>0.1.0</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <name>Outerstellar Platform</name>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>0.1.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>security</artifactId>

--- a/seed/pom.xml
+++ b/seed/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>0.1.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>seed</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>0.1.0</version>
+        <version>1.1.0</version>
     </parent>
 
     <artifactId>web</artifactId>


### PR DESCRIPTION
Version bump from 0.1.0 to 1.1.0 to maintain continuity with previous releases.