### PR TITLE
fix: E2E container auth for GitHub Packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,12 +144,14 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure Maven for GitHub Packages
-        env:
-          ACTOR: ${{ github.actor }}
-        run: |
-          mkdir -p "$HOME/.m2"
-          printf '<settings><servers><server><id>github-rygel</id><username>%s</username><password>%s</password></server></servers></settings>' "$ACTOR" "$GH_PACKAGES_TOKEN" > "$HOME/.m2/settings.xml"
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          server-id: github-rygel
+          server-username: GITHUB_ACTOR
+          server-password: GH_PACKAGES_TOKEN
 
       - name: Restore build output
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
         run: mvn install -N -q -s /github/home/.m2/settings.xml
 
       - name: Install cached modules
-        run: mvn install -pl core,persistence-jooq,api-client,security,web -DskipTests -q -s /github/home/.m2/settings.xml
+        run: mvn install -pl core,persistence-jooq,api-client,security,web -DskipTests -Dexec.skip=true -q -s /github/home/.m2/settings.xml
 
       - name: Run E2E tests
         run: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,17 +148,17 @@ jobs:
       - name: Configure Maven for GitHub Packages
         run: |
           mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml << 'SETTINGS'
+          cat > ~/.m2/settings.xml <<EOF
           <settings>
             <servers>
               <server>
                 <id>github-rygel</id>
-                <username>${env.GITHUB_ACTOR}</username>
-                <password>${env.GH_PACKAGES_TOKEN}</password>
+                <username>${GITHUB_ACTOR}</username>
+                <password>${GH_PACKAGES_TOKEN}</password>
               </server>
             </servers>
           </settings>
-          SETTINGS
+          EOF
 
       - name: Restore build output
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright/java:v1.58.0-noble
-    environment: ci
     permissions:
       contents: read
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,21 +144,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up JDK 21 and Maven settings
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+      - name: Configure Maven settings for GitHub Packages
+        uses: s4u/maven-settings-action@v3.1.0
         with:
-          java-version: '21'
-          distribution: 'temurin'
-          server-id: github-rygel
-          server-username: GITHUB_ACTOR
-          server-password: GH_PACKAGES_TOKEN
-
-      - name: Copy settings.xml to Maven home
-        run: |
-          if [ -f /github/home/.m2/settings.xml ] && [ ! -f "$HOME/.m2/settings.xml" ]; then
-            mkdir -p "$HOME/.m2"
-            cp /github/home/.m2/settings.xml "$HOME/.m2/settings.xml"
-          fi
+          servers: '[{"id": "github-rygel", "username": "${{ github.actor }}", "password": "${{ secrets.GH_PACKAGES_TOKEN }}"}]'
 
       - name: Restore build output
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,8 @@ jobs:
         env:
           ACTOR: ${{ github.actor }}
         run: |
-          mkdir -p $HOME/.m2
-          printf '<settings><servers><server><id>github-rygel</id><username>%s</username><password>%s</password></server></servers></settings>' "$ACTOR" "$GH_PACKAGES_TOKEN" > $HOME/.m2/settings.xml
+          mkdir -p "$HOME/.m2"
+          printf '<settings><servers><server><id>github-rygel</id><username>%s</username><password>%s</password></server></servers></settings>' "$ACTOR" "$GH_PACKAGES_TOKEN" > "$HOME/.m2/settings.xml"
 
       - name: Restore build output
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,19 +146,11 @@ jobs:
           persist-credentials: false
 
       - name: Configure Maven for GitHub Packages
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
-          mkdir -p ~/.m2
-          cat > ~/.m2/settings.xml <<EOF
-          <settings>
-            <servers>
-              <server>
-                <id>github-rygel</id>
-                <username>${GITHUB_ACTOR}</username>
-                <password>${GH_PACKAGES_TOKEN}</password>
-              </server>
-            </servers>
-          </settings>
-          EOF
+          mkdir -p $HOME/.m2
+          printf '<settings><servers><server><id>github-rygel</id><username>%s</username><password>%s</password></server></servers></settings>' "$ACTOR" "$GH_PACKAGES_TOKEN" > $HOME/.m2/settings.xml
 
       - name: Restore build output
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up JDK 21
+      - name: Set up JDK 21 and Maven settings
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '21'
@@ -152,6 +152,13 @@ jobs:
           server-id: github-rygel
           server-username: GITHUB_ACTOR
           server-password: GH_PACKAGES_TOKEN
+
+      - name: Copy settings.xml to Maven home
+        run: |
+          if [ -f /github/home/.m2/settings.xml ] && [ ! -f "$HOME/.m2/settings.xml" ]; then
+            mkdir -p "$HOME/.m2"
+            cp /github/home/.m2/settings.xml "$HOME/.m2/settings.xml"
+          fi
 
       - name: Restore build output
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,7 @@ jobs:
           -Dspotless.apply.skip=true
           -Djacoco.skip=true
           -Ddetekt.skip=true
+          -Dexec.skip=true
 
   security:
     name: Security (OWASP + Enforcer)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,15 +145,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up JDK 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
-        with:
-          java-version: '21'
-          distribution: 'temurin'
-          cache: 'maven'
-          server-id: github-rygel
-          server-username: GITHUB_ACTOR
-          server-password: GH_PACKAGES_TOKEN
+      - name: Configure Maven for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml << 'SETTINGS'
+          <settings>
+            <servers>
+              <server>
+                <id>github-rygel</id>
+                <username>${env.GITHUB_ACTOR}</username>
+                <password>${env.GH_PACKAGES_TOKEN}</password>
+              </server>
+            </servers>
+          </settings>
+          SETTINGS
 
       - name: Restore build output
         uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,14 +161,15 @@ jobs:
           key: build-${{ github.sha }}
 
       - name: Install parent POM locally
-        run: mvn install -N -q
+        run: mvn install -N -q -s /github/home/.m2/settings.xml
 
       - name: Install cached modules
-        run: mvn install -pl core,persistence-jooq,api-client,security,web -DskipTests -q
+        run: mvn install -pl core,persistence-jooq,api-client,security,web -DskipTests -q -s /github/home/.m2/settings.xml
 
       - name: Run E2E tests
         run: >
           mvn test -pl web
+          -s /github/home/.m2/settings.xml
           -Dgroups=e2e
           -DexcludedGroups=
           -Denforcer.skip=true


### PR DESCRIPTION
## Summary
The Playwright container job failed with 401 because setup-java conflicts
with the container's built-in JDK. Generate Maven settings.xml manually
with GitHub Packages credentials.

## Test plan
- [ ] Playwright E2E Tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)