### PR TITLE
fix: disable ktlint import ordering to resolve ktfmt conflict

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,5 +17,9 @@ trim_trailing_whitespace = false
 [*.xml]
 indent_size = 4
 
+[*.{kt,kts}]
+# Disable ktlint import ordering — ktfmt (via Spotless) already handles import formatting
+ktlint_standard_import-ordering = disabled
+
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
## Summary
- Disable ktlint's `import-ordering` rule via `.editorconfig` to resolve the conflict between ktfmt (Spotless) and detekt's ImportOrdering wrapper
- ktfmt uses ASCII-sorted imports; detekt's ktlint wrapper enforces IntelliJ convention (java/javax/kotlin at end) — the two tools fight each other on every format

## Test plan
- [x] `mvn verify` passes locally on all modules (core, security, persistence, web)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)