### PR TITLE
ci: add automated main→develop sync workflow

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -1,0 +1,25 @@
+name: Sync main → develop
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    environment: ci
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PACKAGES_TOKEN }}
+          persist-credentials: false
+
+      - name: Merge main into develop
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${{ secrets.GH_PACKAGES_TOKEN }}@github.com/${{ github.repository }}.git"
+          git checkout develop
+          git merge main --no-edit
+          git push origin develop


### PR DESCRIPTION
## Summary
Automatically merges main into develop after every push to main. No manual sync PRs needed anymore. Identical to the framework workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)