### PR TITLE
release: v1.2.5

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,8 +22,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    env:
-      GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -37,9 +35,11 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: 'maven'
-          server-id: github-rygel
-          server-username: GITHUB_ACTOR
-          server-password: GH_PACKAGES_TOKEN
+
+      - name: Configure Maven settings for GitHub Packages
+        uses: s4u/maven-settings-action@64e42c454dbd42ef6370ac8539685755aedd205b # v3.1.0
+        with:
+          servers: '[{"id": "github-rygel", "username": "${{ github.actor }}", "password": "${{ secrets.GH_PACKAGES_TOKEN }}"}]'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@256d634097be96e792d6764f9edaefc4320557b1 # v4
@@ -48,7 +48,7 @@ jobs:
           build-mode: manual
 
       - name: Build
-        run: mvn compile -Pfast -q
+        run: mvn compile -q
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@256d634097be96e792d6764f9edaefc4320557b1 # v4

--- a/pom.xml
+++ b/pom.xml
@@ -539,6 +539,8 @@
                         <argLine>@{argLine} -XX:+EnableDynamicAgentLoading -Xshare:off</argLine>
                         <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
                         <reuseForks>true</reuseForks>
+                        <parallel>classes</parallel>
+                        <threadCount>4</threadCount>
                         <excludedGroups>${surefire.excluded.groups}</excludedGroups>
                         <groups>${surefire.groups}</groups>
                         <systemPropertyVariables>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -256,6 +256,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Web tests share an in-memory H2 database — parallel execution would cause races -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <parallel>none</parallel>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
@@ -54,11 +54,11 @@ import org.http4k.routing.RoutingHttpHandler
 import org.http4k.routing.bind
 import org.http4k.routing.routes
 import org.http4k.routing.static
-import org.http4k.routing.websocket.bind as wsBind
 import org.http4k.routing.websockets
 import org.http4k.server.PolyHandler
 import org.http4k.template.TemplateRenderer
 import org.slf4j.LoggerFactory
+import org.http4k.routing.websocket.bind as wsBind
 
 private val logger = LoggerFactory.getLogger("io.github.rygel.outerstellar.platform.App")
 
@@ -163,15 +163,17 @@ private fun assembleHttpHandler(
     val componentRoutes = buildComponentRoutes(appLabel, pageFactory, jteRenderer)
     val baseApp = buildBaseApp(excludedRoutes, adminRoutes, apiRoutes, uiRoutes, componentRoutes, userRepository)
     return buildFilterChain(
-            config,
-            userRepository,
-            analytics,
-            jwtService,
-            plugin,
-            activityUpdater,
-            pageFactory,
-            jteRenderer,
-        )
+        config,
+        userRepository,
+        securityService,
+        analytics,
+        notificationService,
+        jwtService,
+        plugin,
+        activityUpdater,
+        pageFactory,
+        jteRenderer,
+    )
         .then(baseApp)
 }
 
@@ -179,7 +181,8 @@ private fun buildBearerSecurityPair(
     securityService: SecurityService
 ): Pair<org.http4k.security.Security, org.http4k.security.Security> {
     val bearerAuthFilter = Filter { next ->
-        { req ->
+        {
+                req ->
             val token = req.header("Authorization")?.removePrefix("Bearer ")
             if (token == null) {
                 Response(Status.UNAUTHORIZED).body("API token required")
@@ -284,10 +287,10 @@ private fun buildUiRoutes(
     routes += AuthRoutes(pageFactory, jteRenderer, securityService, config.sessionCookieSecure, analytics).routes
     routes +=
         OAuthRoutes(
-                providers = mapOf("apple" to AppleOAuthProvider()),
-                securityService = securityService,
-                sessionCookieSecure = config.sessionCookieSecure,
-            )
+            providers = mapOf("apple" to AppleOAuthProvider()),
+            securityService = securityService,
+            sessionCookieSecure = config.sessionCookieSecure,
+        )
             .routes
     routes += ErrorRoutes(pageFactory, jteRenderer).routes
     routes += SearchRoutes(pageFactory, jteRenderer, emptyList()).routes
@@ -402,31 +405,52 @@ private fun buildHealthResponse(userRepository: UserRepository): Response {
 private fun buildFilterChain(
     config: AppConfig,
     userRepository: UserRepository,
+    securityService: SecurityService,
     analytics: io.github.rygel.outerstellar.platform.analytics.AnalyticsService,
+    notificationService: io.github.rygel.outerstellar.platform.service.NotificationService?,
     jwtService: io.github.rygel.outerstellar.platform.security.JwtService?,
     plugin: PlatformPlugin?,
     activityUpdater: io.github.rygel.outerstellar.platform.security.AsyncActivityUpdater?,
     pageFactory: WebPageFactory,
     jteRenderer: org.http4k.template.TemplateRenderer,
-): Filter =
-    Filters.correlationId
-        .then(Filters.cors(config.corsOrigins))
-        .then(etagCachingFilter)
-        .then(staticCacheControlFilter)
-        .then(Filters.securityHeaders(config.cspPolicy))
-        .then(Filters.telemetry)
-        .then(rateLimitFilter())
-        .then(Filters.csrfProtection(config.sessionCookieSecure, config.csrfEnabled))
-        .then(Filters.devAutoLogin(config.devMode, userRepository))
-        .then(
-            Filters.stateFilter(
-                config.devDashboardEnabled,
-                userRepository,
-                config.version,
-                jwtService,
-                plugin?.navItems ?: emptyList(),
+): Filter {
+    var chain =
+        Filters.correlationId
+            .then(Filters.cors(config.corsOrigins))
+            .then(etagCachingFilter)
+            .then(staticCacheControlFilter)
+            .then(Filters.securityHeaders(config.cspPolicy))
+            .then(Filters.telemetry)
+            .then(rateLimitFilter())
+            .then(Filters.csrfProtection(config.sessionCookieSecure, config.csrfEnabled))
+            .then(Filters.devAutoLogin(config.devMode, userRepository))
+            .then(
+                Filters.stateFilter(
+                    config.devDashboardEnabled,
+                    userRepository,
+                    config.version,
+                    jwtService,
+                    plugin?.navItems ?: emptyList(),
+                )
             )
-        )
+
+    if (plugin != null) {
+        val pluginContext =
+            PluginContext(
+                jteRenderer,
+                config,
+                securityService,
+                userRepository,
+                analytics,
+                notificationService,
+                pageFactory,
+            )
+        for (filter in plugin.filters(pluginContext)) {
+            chain = chain.then(filter)
+        }
+    }
+
+    return chain
         .then(analyticsPageViewFilter(analytics))
         .then(
             Filters.sessionTimeout(
@@ -440,3 +464,4 @@ private fun buildFilterChain(
         .then(Filters.requestLogging)
         .then(Filters.serverMetrics)
         .then(Filters.globalErrorHandler(pageFactory, jteRenderer))
+}

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/Main.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/Main.kt
@@ -9,9 +9,6 @@ import io.github.rygel.outerstellar.platform.security.PasswordEncoder
 import io.github.rygel.outerstellar.platform.security.UserRepository
 import io.github.rygel.outerstellar.platform.security.securityModule
 import io.github.rygel.outerstellar.platform.service.OutboxProcessor
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.TimeUnit
 import org.http4k.server.Http4kServer
 import org.http4k.server.Jetty
 import org.http4k.server.PolyHandler
@@ -21,6 +18,9 @@ import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 import org.koin.core.qualifier.named
 import org.slf4j.LoggerFactory
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 
 private const val OUTBOX_INTERVAL_SECONDS = 30L
 private const val SHUTDOWN_TIMEOUT_SECONDS = 5L

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfra.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfra.kt
@@ -4,14 +4,14 @@ import gg.jte.TemplateEngine
 import gg.jte.output.StringOutput
 import gg.jte.resolve.DirectoryCodeResolver
 import gg.jte.resolve.ResourceCodeResolver
-import java.nio.file.Files
-import java.nio.file.Path
 import org.http4k.core.ContentType
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.template.TemplateRenderer
 import org.http4k.template.ViewModel
 import org.http4k.template.ViewNotFound
+import java.nio.file.Files
+import java.nio.file.Path
 
 fun TemplateRenderer.render(viewModel: ViewModel, status: Status = Status.OK): Response =
     Response(status)

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AdminPageFactory.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AdminPageFactory.kt
@@ -27,40 +27,40 @@ class AdminPageFactory(
         return Page(
             shell = shell,
             data =
-                UserAdminPage(
-                    title = i18n.translate("web.admin.users.title"),
-                    description = i18n.translate("web.admin.users.description"),
-                    users =
-                        pageUsers.map { u ->
-                            UserAdminRow(
-                                id = u.id,
-                                username = u.username,
-                                email = u.email,
-                                role = u.role,
-                                enabled = u.enabled,
-                                toggleEnabledUrl = ctx.url("/admin/users/${u.id}/toggle-enabled"),
-                                toggleRoleUrl = ctx.url("/admin/users/${u.id}/toggle-role"),
-                                isSelf = u.id == currentUserId,
-                            )
-                        },
-                    currentPage = currentPage,
-                    hasPrevious = hasPrevious,
-                    hasNext = hasNext,
-                    previousUrl = previousUrl,
-                    nextUrl = nextUrl,
-                    headerUsername = i18n.translate("web.admin.users.header.username"),
-                    headerEmail = i18n.translate("web.admin.users.header.email"),
-                    headerRole = i18n.translate("web.admin.users.header.role"),
-                    headerEnabled = i18n.translate("web.admin.users.header.enabled"),
-                    headerActions = i18n.translate("web.admin.users.header.actions"),
-                    actionDisable = i18n.translate("web.admin.users.action.disable"),
-                    actionEnable = i18n.translate("web.admin.users.action.enable"),
-                    actionDemote = i18n.translate("web.admin.users.action.demote"),
-                    actionPromote = i18n.translate("web.admin.users.action.promote"),
-                    selfLabel = i18n.translate("web.admin.users.self"),
-                    previousLabel = i18n.translate("web.admin.pagination.previous"),
-                    nextLabel = i18n.translate("web.admin.pagination.next"),
-                ),
+            UserAdminPage(
+                title = i18n.translate("web.admin.users.title"),
+                description = i18n.translate("web.admin.users.description"),
+                users =
+                pageUsers.map { u ->
+                    UserAdminRow(
+                        id = u.id,
+                        username = u.username,
+                        email = u.email,
+                        role = u.role,
+                        enabled = u.enabled,
+                        toggleEnabledUrl = ctx.url("/admin/users/${u.id}/toggle-enabled"),
+                        toggleRoleUrl = ctx.url("/admin/users/${u.id}/toggle-role"),
+                        isSelf = u.id == currentUserId,
+                    )
+                },
+                currentPage = currentPage,
+                hasPrevious = hasPrevious,
+                hasNext = hasNext,
+                previousUrl = previousUrl,
+                nextUrl = nextUrl,
+                headerUsername = i18n.translate("web.admin.users.header.username"),
+                headerEmail = i18n.translate("web.admin.users.header.email"),
+                headerRole = i18n.translate("web.admin.users.header.role"),
+                headerEnabled = i18n.translate("web.admin.users.header.enabled"),
+                headerActions = i18n.translate("web.admin.users.header.actions"),
+                actionDisable = i18n.translate("web.admin.users.action.disable"),
+                actionEnable = i18n.translate("web.admin.users.action.enable"),
+                actionDemote = i18n.translate("web.admin.users.action.demote"),
+                actionPromote = i18n.translate("web.admin.users.action.promote"),
+                selfLabel = i18n.translate("web.admin.users.self"),
+                previousLabel = i18n.translate("web.admin.pagination.previous"),
+                nextLabel = i18n.translate("web.admin.pagination.next"),
+            ),
         )
     }
 
@@ -79,31 +79,31 @@ class AdminPageFactory(
         return Page(
             shell = shell,
             data =
-                AuditLogPage(
-                    title = i18n.translate("web.admin.audit.title"),
-                    entries =
-                        pageEntries.map { e ->
-                            AuditEntryViewModel(
-                                actorUsername = e.actorUsername ?: "",
-                                targetUsername = e.targetUsername ?: "",
-                                action = e.action,
-                                detail = e.detail ?: "",
-                                timestamp = e.createdAt.toString(),
-                            )
-                        },
-                    currentPage = currentPage,
-                    hasPrevious = hasPrevious,
-                    hasNext = hasNext,
-                    previousUrl = previousUrl,
-                    nextUrl = nextUrl,
-                    headerWhen = i18n.translate("web.admin.audit.header.when"),
-                    headerActor = i18n.translate("web.admin.audit.header.actor"),
-                    headerAction = i18n.translate("web.admin.audit.header.action"),
-                    headerTarget = i18n.translate("web.admin.audit.header.target"),
-                    headerDetail = i18n.translate("web.admin.audit.header.detail"),
-                    previousLabel = i18n.translate("web.admin.pagination.previous"),
-                    nextLabel = i18n.translate("web.admin.pagination.next"),
-                ),
+            AuditLogPage(
+                title = i18n.translate("web.admin.audit.title"),
+                entries =
+                pageEntries.map { e ->
+                    AuditEntryViewModel(
+                        actorUsername = e.actorUsername ?: "",
+                        targetUsername = e.targetUsername ?: "",
+                        action = e.action,
+                        detail = e.detail ?: "",
+                        timestamp = e.createdAt.toString(),
+                    )
+                },
+                currentPage = currentPage,
+                hasPrevious = hasPrevious,
+                hasNext = hasNext,
+                previousUrl = previousUrl,
+                nextUrl = nextUrl,
+                headerWhen = i18n.translate("web.admin.audit.header.when"),
+                headerActor = i18n.translate("web.admin.audit.header.actor"),
+                headerAction = i18n.translate("web.admin.audit.header.action"),
+                headerTarget = i18n.translate("web.admin.audit.header.target"),
+                headerDetail = i18n.translate("web.admin.audit.header.detail"),
+                previousLabel = i18n.translate("web.admin.pagination.previous"),
+                nextLabel = i18n.translate("web.admin.pagination.next"),
+            ),
         )
     }
 
@@ -116,28 +116,28 @@ class AdminPageFactory(
         return Page(
             shell = shell,
             data =
-                ApiKeysPage(
-                    title = i18n.translate("web.apikeys.title"),
-                    keys = keys,
-                    createUrl = ctx.url("/auth/api-keys/create"),
-                    newKey = newKey,
-                    newKeyName = newKeyName,
-                    description = i18n.translate("web.apikeys.description"),
-                    newKeyBanner = i18n.translate("web.apikeys.created"),
-                    createLabel = i18n.translate("web.apikeys.create"),
-                    keyNameLabel = i18n.translate("web.apikeys.name"),
-                    keyNamePlaceholder = i18n.translate("web.apikeys.name.placeholder"),
-                    yourKeysHeading = i18n.translate("web.apikeys.your.keys"),
-                    emptyLabel = i18n.translate("web.apikeys.empty"),
-                    headerPrefix = i18n.translate("web.apikeys.table.prefix"),
-                    headerName = i18n.translate("web.apikeys.table.name"),
-                    headerCreated = i18n.translate("web.apikeys.table.created"),
-                    headerLastUsed = i18n.translate("web.apikeys.table.last.used"),
-                    headerActions = i18n.translate("web.apikeys.table.actions"),
-                    neverLabel = i18n.translate("web.apikeys.table.never"),
-                    deleteConfirm = i18n.translate("web.apikeys.delete.confirm"),
-                    deleteLabel = i18n.translate("web.apikeys.delete"),
-                ),
+            ApiKeysPage(
+                title = i18n.translate("web.apikeys.title"),
+                keys = keys,
+                createUrl = ctx.url("/auth/api-keys/create"),
+                newKey = newKey,
+                newKeyName = newKeyName,
+                description = i18n.translate("web.apikeys.description"),
+                newKeyBanner = i18n.translate("web.apikeys.created"),
+                createLabel = i18n.translate("web.apikeys.create"),
+                keyNameLabel = i18n.translate("web.apikeys.name"),
+                keyNamePlaceholder = i18n.translate("web.apikeys.name.placeholder"),
+                yourKeysHeading = i18n.translate("web.apikeys.your.keys"),
+                emptyLabel = i18n.translate("web.apikeys.empty"),
+                headerPrefix = i18n.translate("web.apikeys.table.prefix"),
+                headerName = i18n.translate("web.apikeys.table.name"),
+                headerCreated = i18n.translate("web.apikeys.table.created"),
+                headerLastUsed = i18n.translate("web.apikeys.table.last.used"),
+                headerActions = i18n.translate("web.apikeys.table.actions"),
+                neverLabel = i18n.translate("web.apikeys.table.never"),
+                deleteConfirm = i18n.translate("web.apikeys.delete.confirm"),
+                deleteLabel = i18n.translate("web.apikeys.delete"),
+            ),
         )
     }
 
@@ -150,34 +150,34 @@ class AdminPageFactory(
         return Page(
             shell = shell,
             data =
-                ProfilePage(
-                    title = i18n.translate("web.profile.title"),
-                    username = user.username,
-                    email = user.email,
-                    role = user.role.name,
-                    avatarUrl = avatarUrl,
-                    submitUrl = ctx.url("/auth/components/profile-update"),
-                    usernameLabel = i18n.translate("web.profile.username"),
-                    usernamePlaceholder = i18n.translate("web.profile.username.placeholder"),
-                    emailLabel = i18n.translate("web.profile.email"),
-                    emailPlaceholder = i18n.translate("web.profile.email.placeholder"),
-                    avatarLabel = i18n.translate("web.profile.avatar"),
-                    avatarPlaceholder = i18n.translate("web.profile.avatar.placeholder"),
-                    submitLabel = i18n.translate("web.profile.submit"),
-                    emailNotificationsEnabled = user.emailNotificationsEnabled,
-                    pushNotificationsEnabled = user.pushNotificationsEnabled,
-                    notificationPrefsUrl = ctx.url("/auth/notification-preferences"),
-                    notificationPrefsLabel = i18n.translate("web.profile.notif.prefs"),
-                    emailNotifLabel = i18n.translate("web.profile.notif.email"),
-                    pushNotifLabel = i18n.translate("web.profile.notif.push"),
-                    savePrefsLabel = i18n.translate("web.profile.notif.save"),
-                    deleteAccountUrl = ctx.url("/auth/account/delete"),
-                    dangerZoneLabel = i18n.translate("web.profile.danger.zone"),
-                    deleteAccountLabel = i18n.translate("web.profile.delete.account"),
-                    deleteAccountDescription = i18n.translate("web.profile.delete.account.description"),
-                    deleteAccountConfirmLabel = i18n.translate("web.profile.delete.confirm"),
-                    deleteAccountCancelLabel = i18n.translate("web.profile.delete.cancel"),
-                ),
+            ProfilePage(
+                title = i18n.translate("web.profile.title"),
+                username = user.username,
+                email = user.email,
+                role = user.role.name,
+                avatarUrl = avatarUrl,
+                submitUrl = ctx.url("/auth/components/profile-update"),
+                usernameLabel = i18n.translate("web.profile.username"),
+                usernamePlaceholder = i18n.translate("web.profile.username.placeholder"),
+                emailLabel = i18n.translate("web.profile.email"),
+                emailPlaceholder = i18n.translate("web.profile.email.placeholder"),
+                avatarLabel = i18n.translate("web.profile.avatar"),
+                avatarPlaceholder = i18n.translate("web.profile.avatar.placeholder"),
+                submitLabel = i18n.translate("web.profile.submit"),
+                emailNotificationsEnabled = user.emailNotificationsEnabled,
+                pushNotificationsEnabled = user.pushNotificationsEnabled,
+                notificationPrefsUrl = ctx.url("/auth/notification-preferences"),
+                notificationPrefsLabel = i18n.translate("web.profile.notif.prefs"),
+                emailNotifLabel = i18n.translate("web.profile.notif.email"),
+                pushNotifLabel = i18n.translate("web.profile.notif.push"),
+                savePrefsLabel = i18n.translate("web.profile.notif.save"),
+                deleteAccountUrl = ctx.url("/auth/account/delete"),
+                dangerZoneLabel = i18n.translate("web.profile.danger.zone"),
+                deleteAccountLabel = i18n.translate("web.profile.delete.account"),
+                deleteAccountDescription = i18n.translate("web.profile.delete.account.description"),
+                deleteAccountConfirmLabel = i18n.translate("web.profile.delete.confirm"),
+                deleteAccountCancelLabel = i18n.translate("web.profile.delete.cancel"),
+            ),
         )
     }
 
@@ -192,28 +192,28 @@ class AdminPageFactory(
         return Page(
             shell = shell,
             data =
-                NotificationsPage(
-                    title = i18n.translate("web.notifications.title"),
-                    description = i18n.translate("web.notifications.description"),
-                    notifications =
-                        notifications.map { n ->
-                            NotificationViewModel(
-                                id = n.id.toString(),
-                                title = n.title,
-                                body = n.body,
-                                type = n.type,
-                                read = n.isRead,
-                                timeAgo = formatTimeAgo(n.createdAt),
-                                markReadUrl = ctx.url("/notifications/${n.id}/read"),
-                            )
-                        },
-                    unreadCount = unreadCount,
-                    markAllReadUrl = ctx.url("/notifications/read-all"),
-                    emptyLabel = i18n.translate("web.notifications.empty"),
-                    markAllReadLabel = i18n.translate("web.notifications.mark.all.read"),
-                    markReadLabel = i18n.translate("web.notifications.mark.read"),
-                    readLabel = i18n.translate("web.notifications.read"),
-                ),
+            NotificationsPage(
+                title = i18n.translate("web.notifications.title"),
+                description = i18n.translate("web.notifications.description"),
+                notifications =
+                notifications.map { n ->
+                    NotificationViewModel(
+                        id = n.id.toString(),
+                        title = n.title,
+                        body = n.body,
+                        type = n.type,
+                        read = n.isRead,
+                        timeAgo = formatTimeAgo(n.createdAt),
+                        markReadUrl = ctx.url("/notifications/${n.id}/read"),
+                    )
+                },
+                unreadCount = unreadCount,
+                markAllReadUrl = ctx.url("/notifications/read-all"),
+                emptyLabel = i18n.translate("web.notifications.empty"),
+                markAllReadLabel = i18n.translate("web.notifications.mark.all.read"),
+                markReadLabel = i18n.translate("web.notifications.mark.read"),
+                readLabel = i18n.translate("web.notifications.read"),
+            ),
         )
     }
 

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AuthApi.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AuthApi.kt
@@ -105,7 +105,8 @@ class AuthApi(private val securityService: SecurityService) : ServerRoutes {
                 } bindContract
                 DELETE to
                 { id ->
-                    { request ->
+                    {
+                            request ->
                         val user = SecurityRules.USER_KEY(request)!!
                         securityService.deleteApiKey(user.id, id)
                         Response(Status.OK).body("API key deleted")

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AuthRoutes.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AuthRoutes.kt
@@ -47,7 +47,8 @@ class AuthRoutes(
                 } bindContract
                 GET to
                 { mode ->
-                    { request: org.http4k.core.Request ->
+                    {
+                            request: org.http4k.core.Request ->
                         renderer.render(pageFactory.buildAuthForm(request.webContext, mode))
                     }
                 },
@@ -403,7 +404,8 @@ class AuthRoutes(
                 } bindContract
                 POST to
                 { id, _ ->
-                    { request: org.http4k.core.Request ->
+                    {
+                            request: org.http4k.core.Request ->
                         val ctx = request.webContext
                         val user = ctx.user
                         if (user == null) {

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ContactsRoutes.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ContactsRoutes.kt
@@ -74,7 +74,10 @@ class ContactsRoutes(
                 } bindContract
                 GET to
                 { syncId: String, _ ->
-                    { request: Request -> renderer.render(pageFactory.buildContactForm(request.webContext, syncId)) }
+                    {
+                            request: Request ->
+                        renderer.render(pageFactory.buildContactForm(request.webContext, syncId))
+                    }
                 },
             "/contacts" / syncIdPath / "update" meta
                 {
@@ -82,7 +85,8 @@ class ContactsRoutes(
                 } bindContract
                 POST to
                 { syncId: String, _ ->
-                    { request: Request ->
+                    {
+                            request: Request ->
                         val ctx = request.webContext
                         val params = request.bodyAsForm()
                         val existing =
@@ -110,7 +114,8 @@ class ContactsRoutes(
                 } bindContract
                 POST to
                 { syncId: String, _ ->
-                    { _: Request ->
+                    {
+                            _: Request ->
                         contactService?.deleteContact(syncId)
                         Response(Status.OK).body("")
                     }

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/DevDashboardRoutes.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/DevDashboardRoutes.kt
@@ -33,11 +33,11 @@ class DevDashboardRoutes(
                                 metrics = "Prometheus export would go here",
                                 cacheStats = cache.getStats(),
                                 outboxStats =
-                                    OutboxStatsViewModel(
-                                        pending = outboxStats["PENDING"] ?: 0,
-                                        processed = outboxStats["PROCESSED"] ?: 0,
-                                        failed = outboxStats["FAILED"] ?: 0,
-                                    ),
+                                OutboxStatsViewModel(
+                                    pending = outboxStats["PENDING"] ?: 0,
+                                    processed = outboxStats["PROCESSED"] ?: 0,
+                                    failed = outboxStats["FAILED"] ?: 0,
+                                ),
                                 telemetryStatus = "Enabled",
                             )
                         renderer.render(viewModel)

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ErrorRoutes.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ErrorRoutes.kt
@@ -20,7 +20,8 @@ class ErrorRoutes(private val pageFactory: WebPageFactory, private val renderer:
                 } bindContract
                 GET to
                 { kind ->
-                    { request: org.http4k.core.Request ->
+                    {
+                            request: org.http4k.core.Request ->
                         renderer.render(pageFactory.buildErrorPage(request.webContext, kind))
                     }
                 },
@@ -30,7 +31,8 @@ class ErrorRoutes(private val pageFactory: WebPageFactory, private val renderer:
                 } bindContract
                 GET to
                 { kind ->
-                    { request: org.http4k.core.Request ->
+                    {
+                            request: org.http4k.core.Request ->
                         val help = pageFactory.buildErrorHelp(request.webContext, kind)
                         renderer.render(help)
                     }

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -7,9 +7,6 @@ import io.github.rygel.outerstellar.platform.model.ValidationException
 import io.github.rygel.outerstellar.platform.security.SecurityRules
 import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRepository
-import java.time.Duration
-import java.time.Instant
-import java.util.UUID
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
@@ -29,6 +26,9 @@ import org.http4k.format.Jackson
 import org.http4k.template.TemplateRenderer
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
 
 private const val COOKIE_MAX_AGE_DAYS = 365L
 private const val REQUEST_ID_HEADER = "X-Request-Id"
@@ -47,7 +47,8 @@ private fun isNonPagePath(path: String): Boolean =
 
 /** Adds ETag headers based on response body hash and returns 304 Not Modified when matched. */
 val etagCachingFilter: Filter = Filter { next: HttpHandler ->
-    { request ->
+    {
+            request ->
         val response = next(request)
         if (response.status == Status.OK && response.header("ETag") == null) {
             val body = response.bodyString()
@@ -67,7 +68,8 @@ val etagCachingFilter: Filter = Filter { next: HttpHandler ->
 
 /** Adds Cache-Control headers for static assets (CSS, JS, images, fonts). */
 val staticCacheControlFilter: Filter = Filter { next: HttpHandler ->
-    { request ->
+    {
+            request ->
         val response = next(request)
         if (isStaticAsset(request.uri.path)) {
             response.header("Cache-Control", "public, max-age=$STATIC_ASSET_MAX_AGE, immutable")
@@ -78,7 +80,8 @@ val staticCacheControlFilter: Filter = Filter { next: HttpHandler ->
 }
 
 fun analyticsPageViewFilter(analytics: AnalyticsService): Filter = Filter { next ->
-    { request ->
+    {
+            request ->
         val response = next(request)
         val isTrackablePage = request.method == Method.GET && !isNonPagePath(request.uri.path)
         if (isTrackablePage) {
@@ -127,7 +130,8 @@ object Filters {
     private val logger = LoggerFactory.getLogger(Filters::class.java)
 
     val correlationId: Filter = Filter { next: HttpHandler ->
-        { request ->
+        {
+                request ->
             val requestId = request.header(REQUEST_ID_HEADER) ?: java.util.UUID.randomUUID().toString()
             MDC.put("requestId", requestId.take(LOG_ID_LENGTH))
             MDC.put("method", request.method.name)
@@ -142,7 +146,8 @@ object Filters {
     }
 
     fun cors(allowedOrigins: String): Filter = Filter { next: HttpHandler ->
-        { request ->
+        {
+                request ->
             if (request.method == org.http4k.core.Method.OPTIONS) {
                 Response(Status.NO_CONTENT)
                     .header("Access-Control-Allow-Origin", allowedOrigins)
@@ -159,7 +164,8 @@ object Filters {
     }
 
     fun securityHeaders(cspPolicy: String = DEFAULT_CSP_POLICY): Filter = Filter { next: HttpHandler ->
-        { request ->
+        {
+                request ->
             next(request)
                 .header("X-Content-Type-Options", "nosniff")
                 .header("X-Frame-Options", "DENY")
@@ -176,7 +182,8 @@ object Filters {
     }
 
     val requestLogging: Filter = Filter { next: HttpHandler ->
-        { request ->
+        {
+                request ->
             val start = System.currentTimeMillis()
             val response = next(request)
             val duration = System.currentTimeMillis() - start
@@ -200,7 +207,8 @@ object Filters {
     val telemetry: Filter = ServerFilters.OpenTelemetryTracing(Telemetry.openTelemetry)
 
     fun devAutoLogin(enabled: Boolean, userRepository: UserRepository): Filter = Filter { next ->
-        { request ->
+        {
+                request ->
             if (enabled && request.cookie(WebContext.SESSION_COOKIE) == null) {
                 val admin = userRepository.findByUsername("admin")
                 if (admin != null) {
@@ -227,7 +235,8 @@ object Filters {
         jwtService: io.github.rygel.outerstellar.platform.security.JwtService? = null,
         pluginNavItems: List<PluginNavItem> = emptyList(),
     ): Filter = Filter { next: HttpHandler ->
-        { request ->
+        {
+                request ->
             val context =
                 WebContext(request, devDashboardEnabled, userRepository, appVersion, jwtService, pluginNavItems)
             val contextUser =
@@ -284,7 +293,8 @@ object Filters {
         sessionCookieSecure: Boolean,
         activityUpdater: io.github.rygel.outerstellar.platform.security.AsyncActivityUpdater? = null,
     ): Filter = Filter { next: HttpHandler ->
-        { request ->
+        {
+                request ->
             val user =
                 try {
                     request.webContext.user
@@ -319,7 +329,8 @@ object Filters {
 
     // Bridge WebContext user into SecurityRules
     val securityFilter: Filter = Filter { next: HttpHandler ->
-        { request ->
+        {
+                request ->
             val user =
                 try {
                     request.webContext.user
@@ -339,7 +350,8 @@ object Filters {
      * - Exempts `/api/v1/` routes (Bearer-token auth) and `/oauth/` routes.
      */
     fun csrfProtection(sessionCookieSecure: Boolean, enabled: Boolean = true): Filter = Filter { next ->
-        { request ->
+        {
+                request ->
             if (!enabled) return@Filter next(request)
 
             val unsafeMethods = setOf(Method.POST, Method.PUT, Method.DELETE, Method.PATCH)
@@ -399,7 +411,8 @@ object Filters {
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     fun globalErrorHandler(pageFactory: WebPageFactory, renderer: TemplateRenderer): Filter =
         Filter { next: HttpHandler ->
-            { request ->
+            {
+                    request ->
                 try {
                     val response = next(request)
                     if (response.status == Status.NOT_FOUND) {

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/HomeRoutes.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/HomeRoutes.kt
@@ -74,7 +74,8 @@ class HomeRoutes(
                 } bindContract
                 POST to
                 { syncId ->
-                    { request: org.http4k.core.Request ->
+                    {
+                            request: org.http4k.core.Request ->
                         messageService.restore(syncId)
                         Response(Status.FOUND).header("location", request.webContext.url("/messages/trash"))
                     }
@@ -85,7 +86,8 @@ class HomeRoutes(
                 } bindContract
                 GET to
                 { syncId ->
-                    { request: org.http4k.core.Request ->
+                    {
+                            request: org.http4k.core.Request ->
                         val viewModel = pageFactory.buildConflictResolveModal(request.webContext, syncId)
                         renderer.render(viewModel)
                     }
@@ -96,7 +98,8 @@ class HomeRoutes(
                 } bindContract
                 POST to
                 { syncId ->
-                    { request: org.http4k.core.Request ->
+                    {
+                            request: org.http4k.core.Request ->
                         val strategy = ConflictStrategy.fromString(request.form("strategy") ?: "server")
                         messageService.resolveConflict(syncId, strategy)
                         Response(Status.OK).header("HX-Trigger", "refresh")

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/MessageListComponent.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/MessageListComponent.kt
@@ -87,9 +87,9 @@ class MessageListComponent(private val messageService: MessageService) : WebComp
                     previousUrl = metadata.previousPage?.let { createUrl(it) },
                     nextUrl = metadata.nextPage?.let { createUrl(it) },
                     pages =
-                        (1..metadata.totalPages).map { p ->
-                            PageNumberViewModel(p, createUrl(p), p == metadata.currentPage)
-                        },
+                    (1..metadata.totalPages).map { p ->
+                        PageNumberViewModel(p, createUrl(p), p == metadata.currentPage)
+                    },
                 )
             } else {
                 null
@@ -100,11 +100,11 @@ class MessageListComponent(private val messageService: MessageService) : WebComp
         return MessageListViewModel(
             messages = items,
             emptyMessage =
-                if (isTrash) {
-                    i18n.translate("web.trash.empty")
-                } else {
-                    i18n.translate("web.home.list.empty")
-                },
+            if (isTrash) {
+                i18n.translate("web.trash.empty")
+            } else {
+                i18n.translate("web.home.list.empty")
+            },
             deleteUrl = ctx.url("/messages"),
             restoreUrl = ctx.url("/messages/restore"),
             refreshUrl = currentUrl,

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/NotificationApi.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/NotificationApi.kt
@@ -3,7 +3,6 @@ package io.github.rygel.outerstellar.platform.web
 import io.github.rygel.outerstellar.platform.persistence.Notification
 import io.github.rygel.outerstellar.platform.security.SecurityRules
 import io.github.rygel.outerstellar.platform.service.NotificationService
-import java.util.UUID
 import org.http4k.contract.ContractRoute
 import org.http4k.contract.bindContract
 import org.http4k.contract.div
@@ -17,6 +16,7 @@ import org.http4k.core.with
 import org.http4k.format.Jackson.auto
 import org.http4k.lens.Path
 import org.http4k.lens.string
+import java.util.UUID
 
 data class NotificationDto(
     val id: String,
@@ -70,7 +70,8 @@ class NotificationApi(private val notificationService: NotificationService) : Se
                 } bindContract
                 PUT to
                 { notificationId, _ ->
-                    { request ->
+                    {
+                            request ->
                         val user = SecurityRules.USER_KEY(request)!!
                         try {
                             notificationService.markRead(UUID.fromString(notificationId), user.id)

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/NotificationRoutes.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/NotificationRoutes.kt
@@ -2,7 +2,6 @@ package io.github.rygel.outerstellar.platform.web
 
 import io.github.rygel.outerstellar.platform.infra.render
 import io.github.rygel.outerstellar.platform.service.NotificationService
-import java.util.UUID
 import org.http4k.contract.ContractRoute
 import org.http4k.contract.bindContract
 import org.http4k.contract.div
@@ -14,6 +13,7 @@ import org.http4k.core.Status
 import org.http4k.lens.Path
 import org.http4k.lens.string
 import org.http4k.template.TemplateRenderer
+import java.util.UUID
 
 class NotificationRoutes(
     private val pageFactory: WebPageFactory,
@@ -59,7 +59,8 @@ class NotificationRoutes(
                 } bindContract
                 POST to
                 { notificationId, _ ->
-                    { request ->
+                    {
+                            request ->
                         val ctx = request.webContext
                         val user = ctx.user
                         if (user == null) {

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PlatformPlugin.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PlatformPlugin.kt
@@ -7,6 +7,7 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.UserRepository
 import io.github.rygel.outerstellar.platform.service.NotificationService
 import org.http4k.contract.ContractRoute
+import org.http4k.core.Filter
 import org.http4k.template.TemplateRenderer
 import org.koin.core.module.Module
 
@@ -68,6 +69,12 @@ interface PlatformPlugin : PluginMigrationSource {
 
     /** HTTP routes contributed to the application. */
     fun routes(context: PluginContext): List<ContractRoute> = emptyList()
+
+    /**
+     * Filters added to the request chain after the platform's own filters (auth, CSRF, state, etc.) but before route
+     * dispatch. Use this to set up plugin-specific request context (e.g. custom session resolution, context keys).
+     */
+    fun filters(context: PluginContext): List<Filter> = emptyList()
 
     /** Koin modules this plugin needs. Register in `startKoin` rather than relying on this. */
     fun koinModules(): List<Module> = emptyList()

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiter.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiter.kt
@@ -1,13 +1,13 @@
 package io.github.rygel.outerstellar.platform.web
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicLong
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 private val logger = LoggerFactory.getLogger("io.github.rygel.outerstellar.platform.web.RateLimiter")
 
@@ -49,26 +49,27 @@ fun rateLimitFilter(
     val buckets = ConcurrentHashMap<String, TokenBucket>()
 
     return Filter { next: HttpHandler ->
-        { request ->
+        {
+                request ->
             val path = request.uri.path
             if (pathPrefixes.any { path.startsWith(it) }) {
-                    val clientIp =
-                        request.header("X-Forwarded-For")?.split(",")?.firstOrNull()?.trim()
-                            ?: request.header("X-Real-IP")
-                            ?: "unknown"
+                val clientIp =
+                    request.header("X-Forwarded-For")?.split(",")?.firstOrNull()?.trim()
+                        ?: request.header("X-Real-IP")
+                        ?: "unknown"
 
-                    val key = "$clientIp:$path"
-                    val bucket = buckets.computeIfAbsent(key) { TokenBucket(maxRequests, windowMs) }
+                val key = "$clientIp:$path"
+                val bucket = buckets.computeIfAbsent(key) { TokenBucket(maxRequests, windowMs) }
 
-                    if (bucket.tryConsume()) {
-                        next(request)
-                    } else {
-                        logger.warn("Rate limit exceeded for {} on {}", clientIp, path)
-                        Response(Status.TOO_MANY_REQUESTS).body("Too many requests. Please try again later.")
-                    }
-                } else {
+                if (bucket.tryConsume()) {
                     next(request)
+                } else {
+                    logger.warn("Rate limit exceeded for {} on {}", clientIp, path)
+                    Response(Status.TOO_MANY_REQUESTS).body("Too many requests. Please try again later.")
                 }
+            } else {
+                next(request)
+            }
                 .also {
                     // Periodic cleanup: evict buckets whose window has already expired
                     if (buckets.size > CLEANUP_THRESHOLD) {

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/SyncWebSocket.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/SyncWebSocket.kt
@@ -1,8 +1,6 @@
 package io.github.rygel.outerstellar.platform.web
 
 import io.github.rygel.outerstellar.platform.security.UserRepository
-import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 import org.http4k.core.Request
 import org.http4k.websocket.Websocket
 import org.http4k.websocket.WsHandler
@@ -10,6 +8,8 @@ import org.http4k.websocket.WsMessage
 import org.http4k.websocket.WsResponse
 import org.http4k.websocket.WsStatus
 import org.slf4j.LoggerFactory
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 private const val WS_AUTH_REQUIRED_STATUS = 4401
 

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminApi.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminApi.kt
@@ -8,7 +8,6 @@ import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.security.SecurityRules
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.UserRole
-import java.util.UUID
 import org.http4k.contract.ContractRoute
 import org.http4k.contract.bindContract
 import org.http4k.contract.div
@@ -22,6 +21,7 @@ import org.http4k.core.with
 import org.http4k.format.Jackson.auto
 import org.http4k.lens.Path
 import org.http4k.lens.string
+import java.util.UUID
 
 class UserAdminApi(private val securityService: SecurityService) : ServerRoutes {
     private val logger = org.slf4j.LoggerFactory.getLogger(UserAdminApi::class.java)
@@ -49,7 +49,8 @@ class UserAdminApi(private val securityService: SecurityService) : ServerRoutes 
                 } bindContract
                 PUT to
                 { userId, _ ->
-                    { request ->
+                    {
+                            request ->
                         val admin = SecurityRules.USER_KEY(request)!!
                         try {
                             val body = setUserEnabledLens(request)
@@ -69,7 +70,8 @@ class UserAdminApi(private val securityService: SecurityService) : ServerRoutes 
                 } bindContract
                 PUT to
                 { userId, _ ->
-                    { request ->
+                    {
+                            request ->
                         val admin = SecurityRules.USER_KEY(request)!!
                         try {
                             val body = setUserRoleLens(request)

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminRoutes.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminRoutes.kt
@@ -6,7 +6,6 @@ import io.github.rygel.outerstellar.platform.model.InsufficientPermissionExcepti
 import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.UserRole
-import java.util.UUID
 import org.http4k.contract.bindContract
 import org.http4k.contract.div
 import org.http4k.contract.meta
@@ -17,6 +16,7 @@ import org.http4k.core.Status
 import org.http4k.lens.Path
 import org.http4k.lens.string
 import org.http4k.template.TemplateRenderer
+import java.util.UUID
 
 private const val DEFAULT_PAGE_LIMIT = 20
 private const val MAX_PAGE_LIMIT = 100
@@ -58,7 +58,8 @@ class UserAdminRoutes(
                 } bindContract
                 POST to
                 { userId, _ ->
-                    { request: org.http4k.core.Request ->
+                    {
+                            request: org.http4k.core.Request ->
                         val ctx = request.webContext
                         val admin = ctx.user ?: throw InsufficientPermissionException("ADMIN role required")
                         val users = securityService.listUsers()
@@ -97,7 +98,8 @@ class UserAdminRoutes(
                 } bindContract
                 POST to
                 { userId, _ ->
-                    { request: org.http4k.core.Request ->
+                    {
+                            request: org.http4k.core.Request ->
                         val ctx = request.webContext
                         val admin = ctx.user ?: throw InsufficientPermissionException("ADMIN role required")
                         val users = securityService.listUsers()

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
@@ -5,13 +5,13 @@ import io.github.rygel.outerstellar.platform.security.JwtService
 import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRepository
 import io.github.rygel.outerstellar.platform.security.UserRole
-import java.util.Locale
-import java.util.UUID
-import java.util.concurrent.ConcurrentHashMap
 import org.http4k.core.Request
 import org.http4k.core.cookie.cookie
 import org.http4k.lens.RequestKey
 import org.slf4j.LoggerFactory
+import java.util.Locale
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 class WebContext(
     val request: Request,

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebPageFactory.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebPageFactory.kt
@@ -53,38 +53,38 @@ open class WebPageFactory(
         return Page(
             shell = shell,
             data =
-                ContactsPage(
-                    title = "Contacts Directory",
-                    description = "A list of all your contacts.",
-                    contacts =
-                        dbContacts.map {
-                            ContactViewModel(
-                                syncId = it.syncId,
-                                name = it.name,
-                                emails = it.emails,
-                                phones = it.phones,
-                                socialMedia = it.socialMedia,
-                                company = it.company,
-                                companyAddress = it.companyAddress,
-                                department = it.department,
-                                deleteUrl = ctx.url("/contacts/${it.syncId}/delete"),
-                                editUrl = ctx.url("/contacts/${it.syncId}/edit"),
-                            )
-                        },
-                    currentPage = currentPage,
-                    hasPrevious = hasPrevious,
-                    hasNext = hasNext,
-                    previousUrl = previousUrl,
-                    nextUrl = nextUrl,
-                    totalCount = totalCount,
-                    createLabel = i18n.translate("web.contacts.create"),
-                    editTitle = i18n.translate("web.contacts.edit"),
-                    deleteTitle = i18n.translate("web.contacts.delete"),
-                    deleteConfirmLabel = i18n.translate("web.contacts.delete.confirm"),
-                    contactsTotalLabel = i18n.translate("web.contacts.total"),
-                    previousPageTitle = i18n.translate("web.contacts.previous.page"),
-                    nextPageTitle = i18n.translate("web.contacts.next.page"),
-                ),
+            ContactsPage(
+                title = "Contacts Directory",
+                description = "A list of all your contacts.",
+                contacts =
+                dbContacts.map {
+                    ContactViewModel(
+                        syncId = it.syncId,
+                        name = it.name,
+                        emails = it.emails,
+                        phones = it.phones,
+                        socialMedia = it.socialMedia,
+                        company = it.company,
+                        companyAddress = it.companyAddress,
+                        department = it.department,
+                        deleteUrl = ctx.url("/contacts/${it.syncId}/delete"),
+                        editUrl = ctx.url("/contacts/${it.syncId}/edit"),
+                    )
+                },
+                currentPage = currentPage,
+                hasPrevious = hasPrevious,
+                hasNext = hasNext,
+                previousUrl = previousUrl,
+                nextUrl = nextUrl,
+                totalCount = totalCount,
+                createLabel = i18n.translate("web.contacts.create"),
+                editTitle = i18n.translate("web.contacts.edit"),
+                deleteTitle = i18n.translate("web.contacts.delete"),
+                deleteConfirmLabel = i18n.translate("web.contacts.delete.confirm"),
+                contactsTotalLabel = i18n.translate("web.contacts.total"),
+                previousPageTitle = i18n.translate("web.contacts.previous.page"),
+                nextPageTitle = i18n.translate("web.contacts.next.page"),
+            ),
         )
     }
 
@@ -104,33 +104,33 @@ open class WebPageFactory(
         return Page(
             shell = shell,
             data =
-                HomePage(
-                    eyebrow = i18n.translate("web.home.eyebrow"),
-                    intro = i18n.translate("web.home.intro"),
-                    features =
-                        listOf(
-                            HomeFeature(
-                                i18n.translate("web.feature.http.label"),
-                                i18n.translate("web.feature.http.value"),
-                            ),
-                            HomeFeature(i18n.translate("web.feature.db.label"), i18n.translate("web.feature.db.value")),
-                            HomeFeature(
-                                i18n.translate("web.feature.sync.label"),
-                                i18n.translate("web.feature.sync.value"),
-                            ),
-                            HomeFeature(
-                                i18n.translate("web.feature.desktop.label"),
-                                i18n.translate("web.feature.desktop.value"),
-                            ),
-                        ),
-                    composerTitle = i18n.translate("web.home.composer.title"),
-                    composerIntro = i18n.translate("web.home.composer.intro"),
-                    authorPlaceholder = i18n.translate("web.home.composer.author"),
-                    contentPlaceholder = i18n.translate("web.home.composer.content"),
-                    submitLabel = i18n.translate("web.home.composer.submit"),
-                    submitUrl = ctx.url("/messages"),
-                    messageList = messageList,
+            HomePage(
+                eyebrow = i18n.translate("web.home.eyebrow"),
+                intro = i18n.translate("web.home.intro"),
+                features =
+                listOf(
+                    HomeFeature(
+                        i18n.translate("web.feature.http.label"),
+                        i18n.translate("web.feature.http.value"),
+                    ),
+                    HomeFeature(i18n.translate("web.feature.db.label"), i18n.translate("web.feature.db.value")),
+                    HomeFeature(
+                        i18n.translate("web.feature.sync.label"),
+                        i18n.translate("web.feature.sync.value"),
+                    ),
+                    HomeFeature(
+                        i18n.translate("web.feature.desktop.label"),
+                        i18n.translate("web.feature.desktop.value"),
+                    ),
                 ),
+                composerTitle = i18n.translate("web.home.composer.title"),
+                composerIntro = i18n.translate("web.home.composer.intro"),
+                authorPlaceholder = i18n.translate("web.home.composer.author"),
+                contentPlaceholder = i18n.translate("web.home.composer.content"),
+                submitLabel = i18n.translate("web.home.composer.submit"),
+                submitUrl = ctx.url("/messages"),
+                messageList = messageList,
+            ),
         )
     }
 
@@ -143,30 +143,30 @@ open class WebPageFactory(
         return Page(
             shell = shell,
             data =
-                AuthViewModel(
-                    heading = i18n.translate("web.auth.heading"),
-                    intro = i18n.translate("web.auth.intro"),
-                    helperText = i18n.translate("web.auth.helper"),
-                    tabs =
-                        listOf(
-                            AuthModeTab(
-                                "sign-in",
-                                i18n.translate("web.auth.signin"),
-                                ctx.url("$formsUrl/sign-in?returnTo=$returnTo"),
-                            ),
-                            AuthModeTab(
-                                "register",
-                                i18n.translate("web.auth.register"),
-                                ctx.url("$formsUrl/register?returnTo=$returnTo"),
-                            ),
-                            AuthModeTab(
-                                "recover",
-                                i18n.translate("web.auth.recover"),
-                                ctx.url("$formsUrl/recover?returnTo=$returnTo"),
-                            ),
-                        ),
-                    defaultFormUrl = ctx.url("$formsUrl/sign-in?returnTo=$returnTo"),
+            AuthViewModel(
+                heading = i18n.translate("web.auth.heading"),
+                intro = i18n.translate("web.auth.intro"),
+                helperText = i18n.translate("web.auth.helper"),
+                tabs =
+                listOf(
+                    AuthModeTab(
+                        "sign-in",
+                        i18n.translate("web.auth.signin"),
+                        ctx.url("$formsUrl/sign-in?returnTo=$returnTo"),
+                    ),
+                    AuthModeTab(
+                        "register",
+                        i18n.translate("web.auth.register"),
+                        ctx.url("$formsUrl/register?returnTo=$returnTo"),
+                    ),
+                    AuthModeTab(
+                        "recover",
+                        i18n.translate("web.auth.recover"),
+                        ctx.url("$formsUrl/recover?returnTo=$returnTo"),
+                    ),
                 ),
+                defaultFormUrl = ctx.url("$formsUrl/sign-in?returnTo=$returnTo"),
+            ),
         )
     }
 
@@ -246,17 +246,17 @@ open class WebPageFactory(
         return Page(
             shell = shell,
             data =
-                ErrorPage(
-                    statusCode = statusCode,
-                    heading = i18n.translate("web.error.$normalizedKind.title"),
-                    message = i18n.translate("web.error.$normalizedKind.message"),
-                    primaryActionLabel = i18n.translate("web.error.primary"),
-                    primaryActionUrl = ctx.url("/"),
-                    secondaryActionLabel = i18n.translate("web.error.secondary"),
-                    secondaryActionUrl = ctx.url("/auth"),
-                    helpButtonLabel = i18n.translate("web.error.help"),
-                    helpUrl = ctx.url("/errors/components/help/$normalizedKind"),
-                ),
+            ErrorPage(
+                statusCode = statusCode,
+                heading = i18n.translate("web.error.$normalizedKind.title"),
+                message = i18n.translate("web.error.$normalizedKind.message"),
+                primaryActionLabel = i18n.translate("web.error.primary"),
+                primaryActionUrl = ctx.url("/"),
+                secondaryActionLabel = i18n.translate("web.error.secondary"),
+                secondaryActionUrl = ctx.url("/auth"),
+                helpButtonLabel = i18n.translate("web.error.help"),
+                helpUrl = ctx.url("/errors/components/help/$normalizedKind"),
+            ),
         )
     }
 
@@ -267,11 +267,11 @@ open class WebPageFactory(
         return ErrorHelpFragment(
             title = i18n.translate("web.error.$normalizedKind.help.title"),
             items =
-                listOf(
-                    i18n.translate("web.error.$normalizedKind.help.item1"),
-                    i18n.translate("web.error.$normalizedKind.help.item2"),
-                    i18n.translate("web.error.$normalizedKind.help.item3"),
-                ),
+            listOf(
+                i18n.translate("web.error.$normalizedKind.help.item1"),
+                i18n.translate("web.error.$normalizedKind.help.item2"),
+                i18n.translate("web.error.$normalizedKind.help.item3"),
+            ),
         )
     }
 
@@ -296,11 +296,11 @@ open class WebPageFactory(
         return Page(
             shell = shell,
             data =
-                TrashPage(
-                    title = i18n.translate("web.trash.title"),
-                    description = i18n.translate("web.trash.description"),
-                    messageList = messageList,
-                ),
+            TrashPage(
+                title = i18n.translate("web.trash.title"),
+                description = i18n.translate("web.trash.description"),
+                messageList = messageList,
+            ),
         )
     }
 
@@ -324,24 +324,24 @@ open class WebPageFactory(
         return Page(
             shell = shell,
             data =
-                DevDashboardPage(
-                    metrics = metrics,
-                    cacheStats = cacheStats,
-                    outboxStats = outboxStats,
-                    telemetryStatus = telemetryStatus,
-                    badge = i18n.translate("web.dev.badge"),
-                    heading = i18n.translate("web.dev.heading"),
-                    description = i18n.translate("web.dev.description"),
-                    outboxLabel = i18n.translate("web.dev.outbox"),
-                    pendingLabel = i18n.translate("web.dev.outbox.pending"),
-                    processedLabel = i18n.translate("web.dev.outbox.processed"),
-                    failedLabel = i18n.translate("web.dev.outbox.failed"),
-                    cacheLabel = i18n.translate("web.dev.cache"),
-                    protocolLabel = i18n.translate("web.dev.protocol"),
-                    telemetryLabel = i18n.translate("web.dev.telemetry"),
-                    metricsLabel = i18n.translate("web.dev.metrics"),
-                    triggerSyncLabel = i18n.translate("web.dev.trigger.sync"),
-                ),
+            DevDashboardPage(
+                metrics = metrics,
+                cacheStats = cacheStats,
+                outboxStats = outboxStats,
+                telemetryStatus = telemetryStatus,
+                badge = i18n.translate("web.dev.badge"),
+                heading = i18n.translate("web.dev.heading"),
+                description = i18n.translate("web.dev.description"),
+                outboxLabel = i18n.translate("web.dev.outbox"),
+                pendingLabel = i18n.translate("web.dev.outbox.pending"),
+                processedLabel = i18n.translate("web.dev.outbox.processed"),
+                failedLabel = i18n.translate("web.dev.outbox.failed"),
+                cacheLabel = i18n.translate("web.dev.cache"),
+                protocolLabel = i18n.translate("web.dev.protocol"),
+                telemetryLabel = i18n.translate("web.dev.telemetry"),
+                metricsLabel = i18n.translate("web.dev.metrics"),
+                triggerSyncLabel = i18n.translate("web.dev.trigger.sync"),
+            ),
         )
     }
 
@@ -380,27 +380,27 @@ open class WebPageFactory(
             selectId = "theme-selector",
             selectName = "theme",
             options =
-                ThemeCatalog.allThemes().map { theme ->
-                    ShellOption(
-                        id = theme.id,
-                        label = theme.name,
-                        url = theme.id,
-                        active = theme.id == ctx.theme,
-                        previewColors =
-                            ThemePreviewColors(
-                                background = theme.colors["background"] ?: "#1e1e1e",
-                                foreground = theme.colors["foreground"] ?: "#d4d4d4",
-                                accent = theme.colors["accent"] ?: "#007acc",
-                                componentBackground = theme.colors["componentBackground"] ?: "#252526",
-                            ),
-                    )
-                },
+            ThemeCatalog.allThemes().map { theme ->
+                ShellOption(
+                    id = theme.id,
+                    label = theme.name,
+                    url = theme.id,
+                    active = theme.id == ctx.theme,
+                    previewColors =
+                    ThemePreviewColors(
+                        background = theme.colors["background"] ?: "#1e1e1e",
+                        foreground = theme.colors["foreground"] ?: "#d4d4d4",
+                        accent = theme.colors["accent"] ?: "#007acc",
+                        componentBackground = theme.colors["componentBackground"] ?: "#252526",
+                    ),
+                )
+            },
             hiddenFields =
-                listOf(
-                    HiddenField("pagePath", pagePath),
-                    HiddenField("lang", ctx.lang),
-                    HiddenField("layout", ctx.layout),
-                ),
+            listOf(
+                HiddenField("pagePath", pagePath),
+                HiddenField("lang", ctx.lang),
+                HiddenField("layout", ctx.layout),
+            ),
             refreshUrl = "/components/navigation/page",
         )
     }
@@ -415,15 +415,15 @@ open class WebPageFactory(
             selectId = "language-selector",
             selectName = "lang",
             options =
-                listOf("en" to "web.language.english", "fr" to "web.language.french").map { (id, key) ->
-                    ShellOption(id, i18n.translate(key), id, id == ctx.lang)
-                },
+            listOf("en" to "web.language.english", "fr" to "web.language.french").map { (id, key) ->
+                ShellOption(id, i18n.translate(key), id, id == ctx.lang)
+            },
             hiddenFields =
-                listOf(
-                    HiddenField("pagePath", pagePath),
-                    HiddenField("theme", ctx.theme),
-                    HiddenField("layout", ctx.layout),
-                ),
+            listOf(
+                HiddenField("pagePath", pagePath),
+                HiddenField("theme", ctx.theme),
+                HiddenField("layout", ctx.layout),
+            ),
             refreshUrl = "/components/navigation/page",
         )
     }
@@ -438,14 +438,14 @@ open class WebPageFactory(
             selectId = "layout-selector",
             selectName = "layout",
             options =
-                listOf("nice" to "web.layout.nice", "cozy" to "web.layout.cozy", "compact" to "web.layout.compact")
-                    .map { (id, key) -> ShellOption(id, i18n.translate(key), id, id == ctx.layout) },
+            listOf("nice" to "web.layout.nice", "cozy" to "web.layout.cozy", "compact" to "web.layout.compact")
+                .map { (id, key) -> ShellOption(id, i18n.translate(key), id, id == ctx.layout) },
             hiddenFields =
-                listOf(
-                    HiddenField("pagePath", pagePath),
-                    HiddenField("theme", ctx.theme),
-                    HiddenField("lang", ctx.lang),
-                ),
+            listOf(
+                HiddenField("pagePath", pagePath),
+                HiddenField("theme", ctx.theme),
+                HiddenField("lang", ctx.lang),
+            ),
             refreshUrl = "/components/navigation/page",
         )
     }
@@ -477,15 +477,15 @@ open class WebPageFactory(
         return Page(
             shell = shell,
             data =
-                ResetPasswordPage(
-                    token = token,
-                    newPasswordLabel = i18n.translate("web.reset.newPassword"),
-                    confirmPasswordLabel = i18n.translate("web.reset.confirmPassword"),
-                    submitLabel = i18n.translate("web.reset.submit"),
-                    submitUrl = ctx.url("/auth/components/reset-confirm"),
-                    newPasswordPlaceholder = i18n.translate("web.auth.placeholder.password"),
-                    confirmPasswordPlaceholder = i18n.translate("web.password.confirm.placeholder"),
-                ),
+            ResetPasswordPage(
+                token = token,
+                newPasswordLabel = i18n.translate("web.reset.newPassword"),
+                confirmPasswordLabel = i18n.translate("web.reset.confirmPassword"),
+                submitLabel = i18n.translate("web.reset.submit"),
+                submitUrl = ctx.url("/auth/components/reset-confirm"),
+                newPasswordPlaceholder = i18n.translate("web.auth.placeholder.password"),
+                confirmPasswordPlaceholder = i18n.translate("web.password.confirm.placeholder"),
+            ),
         )
     }
 
@@ -536,14 +536,14 @@ open class WebPageFactory(
         return Page(
             shell = shell,
             data =
-                SearchPage(
-                    title = i18n.translate("web.search.title"),
-                    query = query,
-                    results = results,
-                    emptyLabel = i18n.translate("web.search.empty"),
-                    searchPlaceholder = i18n.translate("web.search.placeholder"),
-                    searchLabel = i18n.translate("web.search.label"),
-                ),
+            SearchPage(
+                title = i18n.translate("web.search.title"),
+                query = query,
+                results = results,
+                emptyLabel = i18n.translate("web.search.empty"),
+                searchPlaceholder = i18n.translate("web.search.placeholder"),
+                searchLabel = i18n.translate("web.search.label"),
+            ),
         )
     }
 
@@ -606,11 +606,11 @@ open class WebPageFactory(
             submitUrl = ctx.url(if (syncId != null) "/contacts/$syncId/update" else "/contacts"),
             isEdit = syncId != null,
             titleLabel =
-                if (syncId != null) {
-                    i18n.translate("web.contacts.edit")
-                } else {
-                    i18n.translate("web.contacts.create")
-                },
+            if (syncId != null) {
+                i18n.translate("web.contacts.edit")
+            } else {
+                i18n.translate("web.contacts.create")
+            },
             nameLabel = i18n.translate("web.contacts.form.name"),
             emailsLabel = i18n.translate("web.contacts.form.emails"),
             phonesLabel = i18n.translate("web.contacts.form.phones"),

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/HomePageEndToEndTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/HomePageEndToEndTest.kt
@@ -11,12 +11,12 @@ import io.github.rygel.outerstellar.platform.web.StubMessageCache
 import io.github.rygel.outerstellar.platform.web.StubOutboxRepository
 import io.github.rygel.outerstellar.platform.web.StubTransactionManager
 import io.github.rygel.outerstellar.platform.web.WebPageFactory
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class HomePageEndToEndTest : H2WebTest() {
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/ReproductionTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/ReproductionTest.kt
@@ -11,12 +11,12 @@ import io.github.rygel.outerstellar.platform.web.StubMessageCache
 import io.github.rygel.outerstellar.platform.web.StubOutboxRepository
 import io.github.rygel.outerstellar.platform.web.StubTransactionManager
 import io.github.rygel.outerstellar.platform.web.WebPageFactory
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ReproductionTest : H2WebTest() {
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/di/KoinModuleTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/di/KoinModuleTest.kt
@@ -1,10 +1,10 @@
 package io.github.rygel.outerstellar.platform.di
 
 import io.github.rygel.outerstellar.platform.security.securityModule
-import kotlin.test.Test
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.KoinTest
 import org.koin.test.check.checkModules
+import kotlin.test.Test
 
 @OptIn(KoinExperimentalAPI::class)
 class KoinModuleTest : KoinTest {

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/PlaywrightE2ETest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/PlaywrightE2ETest.kt
@@ -10,7 +10,6 @@ import io.github.rygel.outerstellar.platform.di.webModule
 import io.github.rygel.outerstellar.platform.persistence.ContactRepository
 import io.github.rygel.outerstellar.platform.persistence.MessageRepository
 import io.github.rygel.outerstellar.platform.security.securityModule
-import kotlin.test.assertTrue
 import org.http4k.server.Http4kServer
 import org.http4k.server.Jetty
 import org.http4k.server.PolyHandler
@@ -27,6 +26,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.test.KoinTest
 import org.koin.test.inject
+import kotlin.test.assertTrue
 
 @Tag("e2e")
 class PlaywrightE2ETest : KoinTest {
@@ -67,8 +67,8 @@ class PlaywrightE2ETest : KoinTest {
                     single {
                         AppConfig(
                             jdbcUrl =
-                                "jdbc:h2:mem:playwright_test_${System.currentTimeMillis()}" +
-                                    ";MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+                            "jdbc:h2:mem:playwright_test_${System.currentTimeMillis()}" +
+                                ";MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
                             devMode = true,
                         )
                     }

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/ResponsiveLayoutE2ETest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/ResponsiveLayoutE2ETest.kt
@@ -9,8 +9,6 @@ import io.github.rygel.outerstellar.platform.di.coreModule
 import io.github.rygel.outerstellar.platform.di.persistenceModule
 import io.github.rygel.outerstellar.platform.di.webModule
 import io.github.rygel.outerstellar.platform.security.securityModule
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.http4k.server.Http4kServer
 import org.http4k.server.Jetty
 import org.http4k.server.PolyHandler
@@ -27,6 +25,8 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.test.KoinTest
 import org.koin.test.inject
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @Tag("e2e")
 class ResponsiveLayoutE2ETest : KoinTest {
@@ -72,8 +72,8 @@ class ResponsiveLayoutE2ETest : KoinTest {
                     single {
                         AppConfig(
                             jdbcUrl =
-                                "jdbc:h2:mem:responsive_test_${System.currentTimeMillis()}" +
-                                    ";MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+                            "jdbc:h2:mem:responsive_test_${System.currentTimeMillis()}" +
+                                ";MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
                             devMode = true,
                         )
                     }

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityIntegrationTest.kt
@@ -2,13 +2,13 @@ package io.github.rygel.outerstellar.platform.security
 
 import io.github.rygel.outerstellar.platform.persistence.JooqUserRepository
 import io.github.rygel.outerstellar.platform.web.H2WebTest
-import java.util.UUID
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.UUID
 
 class SecurityIntegrationTest : H2WebTest() {
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AdminExportIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AdminExportIntegrationTest.kt
@@ -13,10 +13,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
@@ -25,6 +21,10 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for admin CSV export endpoints and audit log page (Feature 5 — admin routes).
@@ -85,16 +85,16 @@ class AdminExportIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AdminHtmlRoutesIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AdminHtmlRoutesIntegrationTest.kt
@@ -12,11 +12,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -26,6 +21,11 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for admin HTML routes.
@@ -82,16 +82,16 @@ class AdminHtmlRoutesIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyAuthIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyAuthIntegrationTest.kt
@@ -14,10 +14,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.DELETE
 import org.http4k.core.Method.GET
@@ -27,6 +23,10 @@ import org.http4k.core.Status
 import org.http4k.format.Jackson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for API key authentication (named API keys as Bearer tokens).
@@ -79,16 +79,16 @@ class ApiKeyAuthIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyLifecycleIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyLifecycleIntegrationTest.kt
@@ -15,10 +15,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.Body
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.DELETE
@@ -30,6 +26,10 @@ import org.http4k.core.Status
 import org.http4k.format.Jackson.auto
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for the API key lifecycle (Feature 6).
@@ -100,16 +100,16 @@ class ApiKeyLifecycleIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuditLogIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuditLogIntegrationTest.kt
@@ -13,10 +13,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.PUT
 import org.http4k.core.Request
@@ -24,6 +20,10 @@ import org.http4k.core.Status
 import org.jooq.impl.DSL
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for audit log generation (admin action tracking).
@@ -114,16 +114,16 @@ class AuditLogIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthApiIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthApiIntegrationTest.kt
@@ -7,9 +7,6 @@ import io.github.rygel.outerstellar.platform.persistence.JooqSessionRepository
 import io.github.rygel.outerstellar.platform.persistence.JooqUserRepository
 import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.SecurityService
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
@@ -18,6 +15,9 @@ import org.http4k.core.with
 import org.http4k.format.Jackson.auto
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class AuthApiIntegrationTest : H2WebTest() {
 
@@ -41,16 +41,16 @@ class AuthApiIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthHtmlFlowIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthHtmlFlowIntegrationTest.kt
@@ -13,11 +13,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -27,6 +22,11 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for HTML-form auth flows (Feature 2 — auth routes).
@@ -96,16 +96,16 @@ class AuthHtmlFlowIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthProfileApiKeysIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthProfileApiKeysIntegrationTest.kt
@@ -13,13 +13,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -29,6 +22,13 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for profile, notification preferences, account deletion, API keys page, and password reset HTML
@@ -76,16 +76,16 @@ class AuthProfileApiKeysIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthenticationWorkflowTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthenticationWorkflowTest.kt
@@ -8,10 +8,6 @@ import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.MessageService
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -22,6 +18,10 @@ import org.http4k.core.cookie.cookie
 import org.http4k.core.cookie.cookies
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class AuthenticationWorkflowTest : H2WebTest() {
 
@@ -44,16 +44,16 @@ class AuthenticationWorkflowTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ChangePasswordWebIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ChangePasswordWebIntegrationTest.kt
@@ -11,11 +11,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -25,6 +20,11 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for the change-password web form endpoints.
@@ -72,16 +72,16 @@ class ChangePasswordWebIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ComponentFragmentIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ComponentFragmentIntegrationTest.kt
@@ -11,10 +11,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
@@ -23,6 +19,10 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for HTMX component fragment endpoints (Feature 7).
@@ -75,16 +75,16 @@ class ComponentFragmentIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ComprehensiveWebE2ETest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ComprehensiveWebE2ETest.kt
@@ -7,11 +7,6 @@ import io.github.rygel.outerstellar.platform.di.webModule
 import io.github.rygel.outerstellar.platform.persistence.ContactRepository
 import io.github.rygel.outerstellar.platform.persistence.MessageRepository
 import io.github.rygel.outerstellar.platform.security.securityModule
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Status
@@ -22,6 +17,11 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.test.KoinTest
 import org.koin.test.inject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class ComprehensiveWebE2ETest : KoinTest {
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ConcurrentSyncIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ConcurrentSyncIntegrationTest.kt
@@ -13,14 +13,6 @@ import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.sync.SyncPullResponse
 import io.mockk.mockk
-import java.util.UUID
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -29,6 +21,14 @@ import org.http4k.core.Status
 import org.http4k.format.Jackson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for concurrent sync operations.
@@ -85,16 +85,16 @@ class ConcurrentSyncIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ContactDetailsSyncIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ContactDetailsSyncIntegrationTest.kt
@@ -14,11 +14,6 @@ import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.sync.SyncPullContactResponse
 import io.github.rygel.outerstellar.platform.sync.SyncPushContactResponse
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -27,6 +22,11 @@ import org.http4k.core.Status
 import org.http4k.format.Jackson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for contact detail fields round-trip through sync.
@@ -74,16 +74,16 @@ class ContactDetailsSyncIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ContactsPaginationIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ContactsPaginationIntegrationTest.kt
@@ -11,16 +11,16 @@ import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.every
 import io.mockk.mockk
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for contacts page pagination (Feature 3).
@@ -71,16 +71,16 @@ class ContactsPaginationIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ContactsSyncCrudIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ContactsSyncCrudIntegrationTest.kt
@@ -14,10 +14,6 @@ import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.sync.SyncPullContactResponse
 import io.github.rygel.outerstellar.platform.sync.SyncPushContactResponse
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -26,6 +22,10 @@ import org.http4k.core.Status
 import org.http4k.format.Jackson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for contact sync CRUD — push contacts and pull them back via real DB.
@@ -73,16 +73,16 @@ class ContactsSyncCrudIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/CsrfProtectionIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/CsrfProtectionIntegrationTest.kt
@@ -9,9 +9,6 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -22,6 +19,9 @@ import org.http4k.core.cookie.cookie
 import org.http4k.core.cookie.cookies
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 /**
  * Integration tests for CSRF protection.
@@ -58,16 +58,16 @@ class CsrfProtectionIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    csrfConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                csrfConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DarkModeToggleIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DarkModeToggleIntegrationTest.kt
@@ -10,11 +10,6 @@ import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
@@ -23,6 +18,11 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for the dark mode toggle button (Feature 2).
@@ -57,16 +57,16 @@ class DarkModeToggleIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DevDashboardAccessIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DevDashboardAccessIntegrationTest.kt
@@ -12,10 +12,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
@@ -24,6 +20,10 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for the developer dashboard at GET /admin/dev.
@@ -80,31 +80,31 @@ class DevDashboardAccessIntegrationTest : H2WebTest() {
         // testConfig already has devDashboardEnabled=true
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    renderer,
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                renderer,
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
 
         // A second app instance with the dashboard disabled
         appWithDashboardDisabled =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    renderer,
-                    pageFactory,
-                    testConfig.copy(devDashboardEnabled = false),
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                renderer,
+                pageFactory,
+                testConfig.copy(devDashboardEnabled = false),
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DeviceRegistrationApiIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DeviceRegistrationApiIntegrationTest.kt
@@ -12,11 +12,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.DELETE
 import org.http4k.core.Method.POST
@@ -24,6 +19,11 @@ import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for device push-notification token registration API.
@@ -74,17 +74,17 @@ class DeviceRegistrationApiIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                    deviceTokenRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+                deviceTokenRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ErrorPagesIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ErrorPagesIntegrationTest.kt
@@ -9,10 +9,6 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -20,6 +16,10 @@ import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for error pages and the global error handler (Feature 8).
@@ -58,16 +58,16 @@ class ErrorPagesIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/H2WebTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/H2WebTest.kt
@@ -2,10 +2,10 @@ package io.github.rygel.outerstellar.platform.web
 
 import io.github.rygel.outerstellar.platform.infra.createDataSource
 import io.github.rygel.outerstellar.platform.infra.migrate
-import javax.sql.DataSource
 import org.jooq.DSLContext
 import org.jooq.SQLDialect
 import org.jooq.impl.DSL
+import javax.sql.DataSource
 
 @Suppress("UtilityClassWithPublicConstructor")
 abstract class H2WebTest {

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/HealthCheckIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/HealthCheckIntegrationTest.kt
@@ -11,16 +11,16 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for the /health endpoint.
@@ -55,16 +55,16 @@ class HealthCheckIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/LoginReturnToIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/LoginReturnToIntegrationTest.kt
@@ -11,16 +11,16 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for login returnTo redirect handling and external URL sanitisation.
@@ -63,16 +63,16 @@ class LoginReturnToIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/LogoutIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/LogoutIntegrationTest.kt
@@ -11,12 +11,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -27,6 +21,12 @@ import org.http4k.core.cookie.cookie
 import org.http4k.core.cookie.cookies
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for the logout flow.
@@ -70,16 +70,16 @@ class LogoutIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MdcLoggingIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MdcLoggingIntegrationTest.kt
@@ -10,10 +10,6 @@ import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -22,6 +18,10 @@ import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.slf4j.LoggerFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for structured logging with MDC correlation IDs (Feature 1).
@@ -66,16 +66,16 @@ class MdcLoggingIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MessageActionE2ETest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MessageActionE2ETest.kt
@@ -7,15 +7,15 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.UserRepository
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.http4k.core.body.form
 import org.junit.jupiter.api.AfterEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class MessageActionE2ETest : H2WebTest() {
     @AfterEach

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MessageRestoreIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MessageRestoreIntegrationTest.kt
@@ -6,10 +6,6 @@ import io.github.rygel.outerstellar.platform.persistence.JooqMessageRepository
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
@@ -17,6 +13,10 @@ import org.http4k.core.Status
 import org.http4k.core.body.form
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for the message restore flow.
@@ -46,16 +46,16 @@ class MessageRestoreIntegrationTest : H2WebTest() {
 
     private fun buildApp() =
         app(
-                messageService,
-                mockk<ContactService>(relaxed = true),
-                StubOutboxRepository(),
-                StubMessageCache(),
-                createRenderer(),
-                WebPageFactory(repository, messageService),
-                testConfig,
-                mockk(relaxed = true),
-                mockk(relaxed = true),
-            )
+            messageService,
+            mockk<ContactService>(relaxed = true),
+            StubOutboxRepository(),
+            StubMessageCache(),
+            createRenderer(),
+            WebPageFactory(repository, messageService),
+            testConfig,
+            mockk(relaxed = true),
+            mockk(relaxed = true),
+        )
             .http!!
 
     /** Creates a server message and returns its syncId. */

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MessageSearchIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MessageSearchIntegrationTest.kt
@@ -14,11 +14,6 @@ import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.sync.SyncPullResponse
 import io.github.rygel.outerstellar.platform.sync.SyncPushResponse
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -27,6 +22,11 @@ import org.http4k.core.Status
 import org.http4k.format.Jackson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for message search via the sync API.
@@ -72,16 +72,16 @@ class MessageSearchIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/NotificationsIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/NotificationsIntegrationTest.kt
@@ -15,11 +15,6 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.NotificationService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.http4k.core.Body
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
@@ -31,6 +26,11 @@ import org.http4k.core.with
 import org.http4k.format.Jackson.auto
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class NotificationsIntegrationTest : H2WebTest() {
 
@@ -76,17 +76,17 @@ class NotificationsIntegrationTest : H2WebTest() {
             )
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                    notificationService = notificationService,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+                notificationService = notificationService,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
@@ -9,11 +9,6 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -23,6 +18,11 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for OAuth sign-in routes (Feature 4).
@@ -70,16 +70,16 @@ class OAuthIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PasswordResetFlowIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PasswordResetFlowIntegrationTest.kt
@@ -13,17 +13,17 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for the full API password reset flow.
@@ -79,16 +79,16 @@ class PasswordResetFlowIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PerformanceBenchmarkTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PerformanceBenchmarkTest.kt
@@ -17,10 +17,6 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.nio.file.Path
-import java.time.LocalDateTime
-import kotlin.test.Test
-import kotlin.test.assertTrue
 import org.http4k.core.Body
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
@@ -34,6 +30,10 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.slf4j.LoggerFactory
+import java.nio.file.Path
+import java.time.LocalDateTime
+import kotlin.test.Test
+import kotlin.test.assertTrue
 
 // ---------------------------------------------------------------------------
 // Baseline persistence model
@@ -161,18 +161,18 @@ class PerformanceBenchmarkTest : H2WebTest() {
                     recordedAt = LocalDateTime.now().toString(),
                     javaVersion = System.getProperty("java.version"),
                     benchmarks =
-                        collectedReports.values
-                            .sortedBy { it.name }
-                            .map { r ->
-                                BenchmarkEntry(
-                                    name = r.name,
-                                    iterations = r.count,
-                                    p50Ms = r.p50Ms(),
-                                    p95Ms = r.p95Ms(),
-                                    p99Ms = r.p99Ms(),
-                                    maxMs = r.maxMs(),
-                                )
-                            },
+                    collectedReports.values
+                        .sortedBy { it.name }
+                        .map { r ->
+                            BenchmarkEntry(
+                                name = r.name,
+                                iterations = r.count,
+                                p50Ms = r.p50Ms(),
+                                p95Ms = r.p95Ms(),
+                                p99Ms = r.p99Ms(),
+                                maxMs = r.maxMs(),
+                            )
+                        },
                 )
             mapper.writeValue(baselineFile, baseline)
             logger.info("Baseline written to {}", baselineFile.canonicalPath)
@@ -205,16 +205,16 @@ class PerformanceBenchmarkTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
 
         val registerLens = Body.auto<RegisterRequest>().toLens()
@@ -365,16 +365,16 @@ class PerformanceBenchmarkTest : H2WebTest() {
 
         val prodApp =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    prodSecurityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                prodSecurityService,
+                userRepository,
+            )
                 .http!!
 
         val req = Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("prodperfuser", "prodpass123!"))

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ProfileApiIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ProfileApiIntegrationTest.kt
@@ -16,13 +16,6 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRole
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.http4k.core.Body
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.DELETE
@@ -35,6 +28,13 @@ import org.http4k.core.with
 import org.http4k.format.Jackson.auto
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ProfileApiIntegrationTest : H2WebTest() {
 
@@ -66,16 +66,16 @@ class ProfileApiIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PushNotificationsIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PushNotificationsIntegrationTest.kt
@@ -16,11 +16,6 @@ import io.github.rygel.outerstellar.platform.service.FcmPushNotificationService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.service.PushNotification
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.DELETE
 import org.http4k.core.Method.POST
@@ -28,6 +23,11 @@ import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for push notification device registration API (Feature 5).
@@ -86,17 +86,17 @@ class PushNotificationsIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                    deviceTokenRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+                deviceTokenRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiterIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiterIntegrationTest.kt
@@ -9,16 +9,16 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for the rate limiter (brute-force protection on auth endpoints).
@@ -49,16 +49,16 @@ class RateLimiterIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SecurityHeadersIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SecurityHeadersIntegrationTest.kt
@@ -12,12 +12,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.OPTIONS
@@ -25,6 +19,12 @@ import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for HTTP security headers applied by Filters.securityHeaders and Filters.cors.
@@ -73,16 +73,16 @@ class SecurityHeadersIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SessionSecurityIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SessionSecurityIntegrationTest.kt
@@ -11,12 +11,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -26,6 +20,12 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for session-based security (Feature 3 — filters and security rules).
@@ -100,16 +100,16 @@ class SessionSecurityIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SessionTimeoutIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SessionTimeoutIntegrationTest.kt
@@ -13,12 +13,6 @@ import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import java.time.LocalDateTime
-import java.time.ZoneOffset
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
@@ -27,6 +21,12 @@ import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for session timeout enforcement.
@@ -112,16 +112,16 @@ class SessionTimeoutIntegrationTest : H2WebTest() {
         val contactService = mockk<ContactService>(relaxed = true)
         val pageFactory = WebPageFactory(repository, messageService, contactService, securityService)
         return app(
-                messageService,
-                contactService,
-                outbox,
-                cache,
-                createRenderer(),
-                pageFactory,
-                testConfig,
-                securityService,
-                userRepository,
-            )
+            messageService,
+            contactService,
+            outbox,
+            cache,
+            createRenderer(),
+            pageFactory,
+            testConfig,
+            securityService,
+            userRepository,
+        )
             .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SmokeE2ETest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SmokeE2ETest.kt
@@ -4,11 +4,6 @@ import io.github.rygel.outerstellar.platform.di.coreModule
 import io.github.rygel.outerstellar.platform.di.persistenceModule
 import io.github.rygel.outerstellar.platform.di.webModule
 import io.github.rygel.outerstellar.platform.security.securityModule
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.server.PolyHandler
@@ -17,6 +12,11 @@ import org.koin.core.context.stopKoin
 import org.koin.core.qualifier.named
 import org.koin.test.KoinTest
 import org.koin.test.inject
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class SmokeE2ETest : KoinTest {
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/StatePersistenceE2ETest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/StatePersistenceE2ETest.kt
@@ -7,13 +7,13 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.UserRepository
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import kotlin.test.Test
-import kotlin.test.assertEquals
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.http4k.core.cookie.cookies
 import org.junit.jupiter.api.AfterEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class StatePersistenceE2ETest : H2WebTest() {
     @AfterEach

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/StaticAssetIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/StaticAssetIntegrationTest.kt
@@ -9,15 +9,15 @@ import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.mockk.mockk
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for static asset serving (classpath static/ directory).
@@ -50,16 +50,16 @@ class StaticAssetIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncApiIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncApiIntegrationTest.kt
@@ -18,11 +18,6 @@ import io.github.rygel.outerstellar.platform.sync.SyncPushResponse
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -31,6 +26,11 @@ import org.http4k.core.Status
 import org.http4k.format.Jackson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for the sync API (Feature 4 — bearer-authenticated sync endpoints).
@@ -89,16 +89,16 @@ class SyncApiIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncConflictResolutionIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncConflictResolutionIntegrationTest.kt
@@ -13,10 +13,6 @@ import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.sync.SyncPushResponse
 import io.mockk.mockk
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
@@ -24,6 +20,10 @@ import org.http4k.core.Status
 import org.http4k.format.Jackson
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for sync push conflict detection.
@@ -70,16 +70,16 @@ class SyncConflictResolutionIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncIntegrationTest.kt
@@ -11,14 +11,14 @@ import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.sync.SyncPullResponse
-import java.util.*
-import kotlin.test.Test
-import kotlin.test.assertEquals
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Status
 import org.http4k.format.Jackson.asA
 import org.junit.jupiter.api.AfterEach
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class SyncIntegrationTest : H2WebTest() {
 
@@ -57,16 +57,16 @@ class SyncIntegrationTest : H2WebTest() {
 
         val app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
 
         // Add some data

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementIntegrationTest.kt
@@ -19,11 +19,6 @@ import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRole
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.Body
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
@@ -35,6 +30,11 @@ import org.http4k.core.with
 import org.http4k.format.Jackson.auto
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class UserManagementIntegrationTest : H2WebTest() {
 
@@ -79,16 +79,16 @@ class UserManagementIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementWebUiIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementWebUiIntegrationTest.kt
@@ -15,12 +15,6 @@ import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRole
-import java.util.UUID
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 import org.http4k.core.Body
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
@@ -33,6 +27,12 @@ import org.http4k.core.with
 import org.http4k.format.Jackson.auto
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Integration tests for web UI rendering, navigation, CORS, security headers, correlation IDs, health check, rate
@@ -77,16 +77,16 @@ class UserManagementWebUiIntegrationTest : H2WebTest() {
 
         app =
             app(
-                    messageService,
-                    contactService,
-                    outbox,
-                    cache,
-                    createRenderer(),
-                    pageFactory,
-                    testConfig,
-                    securityService,
-                    userRepository,
-                )
+                messageService,
+                contactService,
+                outbox,
+                cache,
+                createRenderer(),
+                pageFactory,
+                testConfig,
+                securityService,
+                userRepository,
+            )
                 .http!!
     }
 

--- a/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/WebSocketSyncIntegrationTest.kt
+++ b/web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/WebSocketSyncIntegrationTest.kt
@@ -6,8 +6,6 @@ import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRole
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.UUID
-import kotlin.test.Test
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.websocket.Websocket
@@ -15,6 +13,8 @@ import org.http4k.websocket.WsMessage
 import org.http4k.websocket.WsStatus
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import java.util.UUID
+import kotlin.test.Test
 
 class WebSocketSyncIntegrationTest : H2WebTest() {
 


### PR DESCRIPTION
## Summary
Platform release v1.2.5.

### Changes since v1.2.4
- **Plugin filter hook** — `PlatformPlugin.filters(context)` allows plugins to inject filters into the request chain (e.g. custom session resolution for MirrorlessDB)
- **Parallel test execution** — Surefire runs test classes in parallel (4 threads) for core, security, persistence, api-client modules. Web module stays sequential (shared H2 DB).
- **CodeQL Maven auth fix** — switched to `s4u/maven-settings-action` for consistent GitHub Packages auth

## Test plan
- [x] `mvn verify -T 4` passes locally
- [x] No merge conflicts
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)