### PR TITLE
chore: bump http4k, JDBI, ByteBuddy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,11 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <kotlin.version>2.3.10</kotlin.version>
         <outerstellar.version>1.0.4</outerstellar.version>
-        <http4k.version>6.36.0.0</http4k.version>
+        <http4k.version>6.37.0.0</http4k.version>
         <flyway.version>12.1.1</flyway.version>
         <postgresql.version>42.7.10</postgresql.version>
         <jooq.version>3.20.11</jooq.version>
-        <jdbi.version>3.51.0</jdbi.version>
+        <jdbi.version>3.52.0</jdbi.version>
         <h2.version>2.4.240</h2.version>
         <jte.version>3.2.3</jte.version>
         <flatlaf.version>3.7.1</flatlaf.version>
@@ -60,7 +60,7 @@
         <maven.install.plugin.version>3.1.4</maven.install.plugin.version>
         <maven.site.plugin.version>3.21.0</maven.site.plugin.version>
         <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
-        <bytebuddy.version>1.18.5</bytebuddy.version>
+        <bytebuddy.version>1.18.7</bytebuddy.version>
         <koin.version>4.2.0</koin.version>
         <hoplite.version>2.9.0</hoplite.version>
         <http4k-connect.version>6.1.0.0</http4k-connect.version>


### PR DESCRIPTION
## Summary
- http4k 6.36.0.0 → 6.37.0.0
- JDBI 3.51.0 → 3.52.0
- ByteBuddy 1.18.5 → 1.18.7

## Test plan
- [x] `mvn verify -T 4` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)