### PR TITLE
fix: add baselineOnMigrate(true) to migratePlugin()

### DIFF
--- a/persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/DatabaseInfra.kt
+++ b/persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/DatabaseInfra.kt
@@ -24,5 +24,11 @@ fun migrate(dataSource: DataSource) {
 }
 
 fun migratePlugin(dataSource: DataSource, location: String, historyTable: String) {
-    Flyway.configure().dataSource(dataSource).locations(location).table(historyTable).load().migrate()
+    Flyway.configure()
+        .dataSource(dataSource)
+        .locations(location)
+        .table(historyTable)
+        .baselineOnMigrate(true)
+        .load()
+        .migrate()
 }

--- a/persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/DatabaseInfra.kt
+++ b/persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/DatabaseInfra.kt
@@ -24,5 +24,11 @@ fun migrate(dataSource: DataSource) {
 }
 
 fun migratePlugin(dataSource: DataSource, location: String, historyTable: String) {
-    Flyway.configure().dataSource(dataSource).locations(location).table(historyTable).load().migrate()
+    Flyway.configure()
+        .dataSource(dataSource)
+        .locations(location)
+        .table(historyTable)
+        .baselineOnMigrate(true)
+        .load()
+        .migrate()
 }


### PR DESCRIPTION
## Summary
Add `baselineOnMigrate(true)` to `migratePlugin()` in both persistence modules. Without it, plugin migrations fail when the schema already contains platform tables.

Fixes #54

## Test plan
- [x] `mvn verify -T 4` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)