### PR TITLE
fix: sync workflow push denied (persist-credentials)

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -13,13 +13,11 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PACKAGES_TOKEN }}
-          persist-credentials: false
 
       - name: Merge main into develop
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${{ secrets.GH_PACKAGES_TOKEN }}@github.com/${{ github.repository }}.git"
           git checkout develop
           git merge main --no-edit
           git push origin develop


### PR DESCRIPTION
## Summary
- Remove `persist-credentials: false` from the sync-main-to-develop workflow
- Remove redundant `git remote set-url` (checkout action already configures the remote with the token)

## Problem
The sync workflow failed with `403 Permission denied` when pushing to develop after merging main. The `persist-credentials: false` flag caused the checkout action to discard the `GH_PACKAGES_TOKEN` after cloning. The manual `git remote set-url` attempted to re-set it, but the token was rejected.

## Fix
Let the checkout action persist its credentials (the default behavior). This means the token used for checkout is also used for push — no manual URL manipulation needed.

## Test plan
- [ ] Merge this to develop, then merge a release to main — sync workflow should push to develop successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)