### PR TITLE
hotfix: fix sync workflow credentials on main

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -13,13 +13,11 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PACKAGES_TOKEN }}
-          persist-credentials: false
 
       - name: Merge main into develop
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${{ secrets.GH_PACKAGES_TOKEN }}@github.com/${{ github.repository }}.git"
           git checkout develop
           git merge main --no-edit
           git push origin develop


### PR DESCRIPTION
## Summary
Hotfix to main — remove `persist-credentials: false` from sync workflow so the main→develop sync can push.

Same fix as #60 (which targeted develop). This lands it on main so the sync workflow actually uses the fixed version.

Merging this PR will re-trigger the sync workflow, which should now succeed and sync main→develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)