### PR TITLE
hotfix: use GITHUB_TOKEN for sync workflow push

### DIFF
--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -4,15 +4,16 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest
-    environment: ci
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_PACKAGES_TOKEN }}
 
       - name: Merge main into develop
         run: |


### PR DESCRIPTION
## Summary
The `GH_PACKAGES_TOKEN` PAT lacks `repo` scope — it only has packages permissions. Switch to the default `GITHUB_TOKEN` with explicit `contents: write`, which can push to the repo.

## Changes
- Replace `token: GH_PACKAGES_TOKEN` with default `GITHUB_TOKEN`
- Add `permissions: contents: write` at workflow level
- Remove `environment: ci` (no secrets needed)

## Test plan
- [ ] Merging this to main will trigger the sync workflow — it should push to develop successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)