### PR TITLE
fix: performance and security hardening

### DIFF
--- a/core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/ContactService.kt
+++ b/core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/ContactService.kt
@@ -16,7 +16,12 @@ class ContactService(
 ) {
     private val logger = LoggerFactory.getLogger(ContactService::class.java)
 
+    companion object {
+        private const val MAX_PAGE_LIMIT = 1000
+    }
+
     fun listContacts(query: String? = null, limit: Int = 100, offset: Int = 0): List<ContactSummary> {
+        val limit = limit.coerceIn(1, MAX_PAGE_LIMIT)
         logger.debug("Listing contacts query='{}' limit={} offset={}", query, limit, offset)
         return repository.listContacts(query, limit, offset)
     }

--- a/core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
+++ b/core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
@@ -37,12 +37,17 @@ class MessageService(
 ) {
     private val logger = LoggerFactory.getLogger(MessageService::class.java)
 
+    companion object {
+        private const val MAX_PAGE_LIMIT = 1000
+    }
+
     fun listMessages(
         query: String? = null,
         year: Int? = null,
         limit: Int = 100,
         offset: Int = 0,
     ): PagedResult<MessageSummary> {
+        val limit = limit.coerceIn(1, MAX_PAGE_LIMIT)
         val cacheKey = "list:$query:$year:$limit:$offset"
 
         @Suppress("UNCHECKED_CAST")

--- a/persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepository.kt
+++ b/persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepository.kt
@@ -101,6 +101,15 @@ class JdbiUserRepository(private val jdbi: Jdbi) : UserRepository {
             handle.createQuery("SELECT COUNT(*) FROM plt_users").mapTo(Long::class.java).one()
         }
 
+    override fun countByRole(role: UserRole): Long =
+        jdbi.withHandle<Long, Exception> { handle ->
+            handle
+                .createQuery("SELECT COUNT(*) FROM plt_users WHERE role = :role")
+                .bind("role", role.name)
+                .mapTo(Long::class.java)
+                .one()
+        }
+
     override fun updateRole(userId: UUID, role: UserRole) {
         jdbi.useHandle<Exception> { handle ->
             handle

--- a/persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/DatabaseInfra.kt
+++ b/persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/DatabaseInfra.kt
@@ -11,10 +11,12 @@ fun createDataSource(jdbcUrl: String, jdbcUser: String, jdbcPassword: String): H
             this.jdbcUrl = jdbcUrl
             username = jdbcUser
             password = jdbcPassword
-            maximumPoolSize = 10
-            minimumIdle = 1
+            maximumPoolSize = 20
+            minimumIdle = 2
             idleTimeout = 300_000
+            maxLifetime = 1_800_000 // 30 minutes — prevents stale connections
             connectionTimeout = 10_000
+            leakDetectionThreshold = 60_000 // warn if connection held > 60s
             poolName = "outerstellar-pool"
         }
     )

--- a/persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepository.kt
+++ b/persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepository.kt
@@ -83,6 +83,9 @@ class JooqUserRepository(private val dsl: DSLContext) : UserRepository {
 
     override fun countAll(): Long = dsl.selectCount().from(PLT_USERS).fetchOne(0, Long::class.java) ?: 0L
 
+    override fun countByRole(role: UserRole): Long =
+        dsl.selectCount().from(PLT_USERS).where(PLT_USERS.ROLE.eq(role.name)).fetchOne(0, Long::class.java) ?: 0L
+
     override fun updateRole(userId: UUID, role: UserRole) {
         dsl.update(PLT_USERS).set(PLT_USERS.ROLE, role.name).where(PLT_USERS.ID.eq(userId)).execute()
     }

--- a/security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AsyncActivityUpdater.kt
+++ b/security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AsyncActivityUpdater.kt
@@ -21,6 +21,10 @@ class AsyncActivityUpdater(private val userRepository: UserRepository) {
     private val logger = LoggerFactory.getLogger(AsyncActivityUpdater::class.java)
     private val pending = ConcurrentHashMap<UUID, Unit>()
 
+    init {
+        Runtime.getRuntime().addShutdownHook(Thread({ flush() }, "activity-flush-shutdown"))
+    }
+
     /** Record that [userId] was active. Safe to call from any thread; never blocks. */
     fun record(userId: UUID) {
         pending[userId] = Unit

--- a/security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/JwtService.kt
+++ b/security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/JwtService.kt
@@ -61,4 +61,9 @@ class JwtService(private val config: JwtConfig) {
             null
         }
     }
+
+    /** Evict a token from the claims cache (e.g. on logout). */
+    fun invalidate(token: String) {
+        claimsCache.invalidate(token)
+    }
 }

--- a/security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/Models.kt
+++ b/security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/Models.kt
@@ -41,6 +41,8 @@ interface UserRepository {
 
     fun countAll(): Long
 
+    fun countByRole(role: UserRole): Long
+
     fun updateRole(userId: UUID, role: UserRole)
 
     fun updateEnabled(userId: UUID, enabled: Boolean)

--- a/security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityService.kt
+++ b/security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityService.kt
@@ -117,7 +117,7 @@ class SecurityService(
     }
 
     fun listUsers(limit: Int, offset: Int): List<UserSummary> =
-        userRepository.findPage(limit, offset).map { it.toSummary() }
+        userRepository.findPage(limit.coerceIn(1, MAX_PAGE_LIMIT), offset).map { it.toSummary() }
 
     fun countUsers(): Long = userRepository.countAll()
 
@@ -198,8 +198,22 @@ class SecurityService(
         }
         if (newAvatarUrl != user.avatarUrl) {
             val sanitizedUrl = newAvatarUrl?.takeIf { it.isNotBlank() }
-            if (sanitizedUrl != null && !sanitizedUrl.startsWith("https://") && !sanitizedUrl.startsWith("http://")) {
-                throw IllegalArgumentException("Avatar URL must use http or https scheme")
+            if (sanitizedUrl != null) {
+                if (!sanitizedUrl.startsWith("https://") && !sanitizedUrl.startsWith("http://")) {
+                    throw IllegalArgumentException("Avatar URL must use http or https scheme")
+                }
+                if (sanitizedUrl.length > MAX_URL_LENGTH) {
+                    throw IllegalArgumentException("Avatar URL exceeds maximum length of $MAX_URL_LENGTH characters")
+                }
+                val host =
+                    try {
+                        java.net.URI(sanitizedUrl).host?.lowercase()
+                    } catch (_: Exception) {
+                        null
+                    }
+                if (host != null && PRIVATE_HOST_PATTERNS.any { it.matches(host) }) {
+                    throw IllegalArgumentException("Avatar URL must not point to private or internal addresses")
+                }
             }
             userRepository.updateAvatarUrl(userId, sanitizedUrl)
         }
@@ -210,7 +224,7 @@ class SecurityService(
     fun deleteAccount(userId: UUID) {
         val user = userRepository.findById(userId) ?: throw UserNotFoundException(userId.toString())
         if (user.role == UserRole.ADMIN) {
-            val adminCount = userRepository.findAll().count { it.role == UserRole.ADMIN }
+            val adminCount = userRepository.countByRole(UserRole.ADMIN)
             if (adminCount <= 1) {
                 throw InsufficientPermissionException("Cannot delete the only remaining admin account")
             }
@@ -300,7 +314,20 @@ class SecurityService(
         private const val MIN_PASSWORD_LENGTH = 8
         private const val MAX_USERNAME_LENGTH = 50
         private const val SESSION_TOKEN_HEX_LENGTH = 48
+        private const val MAX_PAGE_LIMIT = 1000
+        private const val MAX_URL_LENGTH = 2048
         private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
+        private val PRIVATE_HOST_PATTERNS =
+            listOf(
+                Regex("^localhost$"),
+                Regex("^127\\..*"),
+                Regex("^10\\..*"),
+                Regex("^172\\.(1[6-9]|2\\d|3[01])\\..*"),
+                Regex("^192\\.168\\..*"),
+                Regex("^0\\..*"),
+                Regex(".*\\.local$"),
+                Regex(".*\\.internal$"),
+            )
     }
 }
 

--- a/security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityServiceTest.kt
+++ b/security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityServiceTest.kt
@@ -360,7 +360,6 @@ class SecurityServiceTest {
     @Test
     fun `deleteAccount removes the user`() {
         every { userRepository.findById(testUser.id) } returns testUser
-        every { userRepository.findAll() } returns listOf(testUser, adminUser)
 
         service.deleteAccount(testUser.id)
 
@@ -370,7 +369,7 @@ class SecurityServiceTest {
     @Test
     fun `deleteAccount blocks deleting the only admin`() {
         every { userRepository.findById(adminUser.id) } returns adminUser
-        every { userRepository.findAll() } returns listOf(adminUser)
+        every { userRepository.countByRole(UserRole.ADMIN) } returns 1L
 
         assertThrows<io.github.rygel.outerstellar.platform.model.InsufficientPermissionException> {
             service.deleteAccount(adminUser.id)
@@ -380,9 +379,8 @@ class SecurityServiceTest {
 
     @Test
     fun `deleteAccount allows admin deletion when another admin exists`() {
-        val secondAdmin = adminUser.copy(id = UUID.randomUUID(), username = "admin2")
         every { userRepository.findById(adminUser.id) } returns adminUser
-        every { userRepository.findAll() } returns listOf(adminUser, secondAdmin)
+        every { userRepository.countByRole(UserRole.ADMIN) } returns 2L
 
         service.deleteAccount(adminUser.id)
 

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
@@ -393,7 +393,7 @@ private fun buildBaseApp(
 private fun buildHealthResponse(userRepository: UserRepository): Response {
     val checks = mutableMapOf<String, Any>("status" to "UP")
     try {
-        val userCount = userRepository.findAll().size
+        val userCount = userRepository.countAll()
         checks["database"] = mapOf("status" to "UP", "users" to userCount)
     } catch (e: Exception) {
         checks["status"] = "DOWN"

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -364,7 +364,11 @@ object Filters {
                 val headerToken = request.header("X-CSRF-Token")
                 val submitted = formToken ?: headerToken
 
-                if (cookieToken == null || submitted == null || cookieToken != submitted) {
+                if (
+                    cookieToken == null ||
+                    submitted == null ||
+                    !java.security.MessageDigest.isEqual(cookieToken.toByteArray(), submitted.toByteArray())
+                ) {
                     logger.warn("CSRF check failed for {} {}", request.method, path)
                     Response(Status.FORBIDDEN).body("Invalid or missing CSRF token")
                 } else {

--- a/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiter.kt
+++ b/web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiter.kt
@@ -1,11 +1,12 @@
 package io.github.rygel.outerstellar.platform.web
 
+import com.github.benmanes.caffeine.cache.Caffeine
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.slf4j.LoggerFactory
-import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
@@ -13,7 +14,9 @@ private val logger = LoggerFactory.getLogger("io.github.rygel.outerstellar.platf
 
 private const val DEFAULT_MAX_REQUESTS = 10
 private const val DEFAULT_WINDOW_MS = 60_000L
-private const val CLEANUP_THRESHOLD = 1000
+private const val RESET_MAX_REQUESTS = 5
+private const val RESET_WINDOW_MS = 900_000L // 15 minutes
+private const val MAX_BUCKETS = 10_000L
 
 class TokenBucket(private val maxRequests: Int, private val windowMs: Long) {
     private val count = AtomicInteger(0)
@@ -28,9 +31,17 @@ class TokenBucket(private val maxRequests: Int, private val windowMs: Long) {
         }
         return count.incrementAndGet() <= maxRequests
     }
-
-    fun isExpired(): Boolean = System.currentTimeMillis() - windowStart.get() > windowMs
 }
+
+/** Per-path rate limit configuration. */
+data class RateLimit(val maxRequests: Int, val windowMs: Long)
+
+private val SENSITIVE_PATHS =
+    mapOf(
+        "/api/v1/auth/reset-request" to RateLimit(RESET_MAX_REQUESTS, RESET_WINDOW_MS),
+        "/api/v1/auth/reset-confirm" to RateLimit(RESET_MAX_REQUESTS, RESET_WINDOW_MS),
+        "/auth/components/reset-confirm" to RateLimit(RESET_MAX_REQUESTS, RESET_WINDOW_MS),
+    )
 
 fun rateLimitFilter(
     maxRequests: Int = DEFAULT_MAX_REQUESTS,
@@ -46,7 +57,11 @@ fun rateLimitFilter(
             "/auth/components/reset-confirm",
         ),
 ): Filter {
-    val buckets = ConcurrentHashMap<String, TokenBucket>()
+    val buckets =
+        Caffeine.newBuilder()
+            .maximumSize(MAX_BUCKETS)
+            .expireAfterWrite(RESET_WINDOW_MS * 2, TimeUnit.MILLISECONDS)
+            .build<String, TokenBucket>()
 
     return Filter { next: HttpHandler ->
         {
@@ -58,8 +73,12 @@ fun rateLimitFilter(
                         ?: request.header("X-Real-IP")
                         ?: "unknown"
 
+                val override = SENSITIVE_PATHS.entries.find { path.startsWith(it.key) }?.value
+                val effectiveMax = override?.maxRequests ?: maxRequests
+                val effectiveWindow = override?.windowMs ?: windowMs
+
                 val key = "$clientIp:$path"
-                val bucket = buckets.computeIfAbsent(key) { TokenBucket(maxRequests, windowMs) }
+                val bucket = buckets.get(key) { TokenBucket(effectiveMax, effectiveWindow) }
 
                 if (bucket.tryConsume()) {
                     next(request)
@@ -70,12 +89,6 @@ fun rateLimitFilter(
             } else {
                 next(request)
             }
-                .also {
-                    // Periodic cleanup: evict buckets whose window has already expired
-                    if (buckets.size > CLEANUP_THRESHOLD) {
-                        buckets.entries.removeIf { (_, bucket) -> bucket.isExpired() }
-                    }
-                }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace N+1 queries: health check findAll().size → countAll(), admin count findAll().count{} → countByRole()
- Replace unbounded rate limiter map with Caffeine (TTL + max 10K entries)
- Harden HikariCP: maxLifetime, leakDetectionThreshold, pool size 20
- CSRF constant-time token comparison via MessageDigest.isEqual
- Avatar URL: block private/internal IPs, enforce 2048 char limit
- Password reset rate limit: 5 req / 15 min (was 10 / 60s)
- AsyncActivityUpdater shutdown hook to flush pending writes
- JwtService.invalidate() for cache eviction on logout
- Enforce MAX_PAGE_LIMIT = 1000 on all pagination endpoints

## Test plan
- [x] mvn verify -T 4 -pl !desktop passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)