### PR TITLE
ci: auto-create GitHub release on version bump to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,28 +1,57 @@
-name: Publish to GitHub Packages
+name: Release and Publish
 
 on:
-  release:
-    types: [created]
+  push:
+    branches: [main]
+    paths:
+      - 'pom.xml'
   workflow_dispatch:
 
 permissions: {}
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          persist-credentials: false
+          fetch-depth: 2
+
+      - name: Extract version from pom.xml
+        id: version
+        run: |
+          VERSION=$(grep -m1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: check
+        run: |
+          if gh release view "v${{ steps.version.outputs.version }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --target main \
+            --title "${{ steps.version.outputs.tag }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 21
+        if: steps.check.outputs.exists == 'false'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: '21'
@@ -31,20 +60,26 @@ jobs:
           server-id: github-rygel
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js 20
+        if: steps.check.outputs.exists == 'false'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Install Node dependencies
+        if: steps.check.outputs.exists == 'false'
         run: npm ci --no-audit --no-fund
 
       - name: Build and test
+        if: steps.check.outputs.exists == 'false'
         run: mvn clean verify -Pfast
 
       - name: Publish to GitHub Packages
+        if: steps.check.outputs.exists == 'false'
         run: mvn deploy -DskipTests -Denforcer.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,23 +32,25 @@ jobs:
       - name: Check if release already exists
         id: check
         run: |
-          if gh release view "v${{ steps.version.outputs.version }}" > /dev/null 2>&1; then
+          if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
 
       - name: Create GitHub release
         if: steps.check.outputs.exists == 'false'
         run: |
-          gh release create "${{ steps.version.outputs.tag }}" \
+          gh release create "$RELEASE_TAG" \
             --target main \
-            --title "${{ steps.version.outputs.tag }}" \
+            --title "$RELEASE_TAG" \
             --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
 
       - name: Set up JDK 21
         if: steps.check.outputs.exists == 'false'


### PR DESCRIPTION
## Problem
The publish workflow only triggered on `release: created`, but nothing auto-created the release. Every release had to be tagged manually.

## Fix
Trigger on `push: branches: [main]` when `pom.xml` changes. The workflow:
1. Extracts version from pom.xml
2. Checks if release already exists (idempotent)
3. Creates GitHub release + tag with auto-generated notes
4. Builds, tests, and publishes to GitHub Packages

Same fix as outerstellar-framework PR #30, adapted for the platform (includes Node.js setup for Tailwind CSS).

## Test plan
- [ ] Merge to develop, then merge a release branch to main — release should be created automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)