### PR TITLE
fix: use GH_PACKAGES_TOKEN in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions: {}
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: ci
     permissions:
       contents: write
       packages: write
@@ -61,9 +62,9 @@ jobs:
           cache: 'maven'
           server-id: github-rygel
           server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
+          server-password: GH_PACKAGES_TOKEN
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
 
       - name: Set up Node.js 20
         if: steps.check.outputs.exists == 'false'
@@ -84,4 +85,4 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         run: mvn deploy -DskipTests -Denforcer.skip=true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}


### PR DESCRIPTION
## Problem
The publish workflow used `GITHUB_TOKEN` for Maven auth, which returns 401 when resolving framework artifacts from `outerstellar-framework`'s GitHub Packages (cross-repo).

## Fix
Use `GH_PACKAGES_TOKEN` PAT for Maven server auth and deploy. Add `environment: ci` to access the secret.

This caused the v1.2.8 publish to fail — the GitHub release was created but artifacts weren't published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)