### PR TITLE
feat: add Maven Central publishing support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,20 @@
         </license>
     </licenses>
 
+    <developers>
+        <developer>
+            <name>Alexander Brandt</name>
+            <email>github@a13x.de</email>
+            <url>https://github.com/rygel</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/rygel/outerstellar-platform.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/rygel/outerstellar-platform.git</developerConnection>
+        <url>https://github.com/rygel/outerstellar-platform</url>
+    </scm>
+
     <modules>
         <module>platform-core</module>
         <module>platform-persistence-jooq</module>
@@ -529,6 +543,19 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${maven.jar.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.4.0</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar-no-fork</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -1098,6 +1125,59 @@
                 <spotbugs.skip>true</spotbugs.skip>
                 <spotless.check.skip>true</spotless.check.skip>
             </properties>
+        </profile>
+        <!-- mvn deploy -Prelease — sign, attach sources/javadoc, publish to Maven Central -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.8</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>${maven.jar.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>empty-javadoc-jar</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.basedir}/src</classesDirectory>
+                                    <includes>
+                                        <include>**/*.kt</include>
+                                        <include>**/*.java</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## Summary
- Adds `<developers>` and `<scm>` metadata required by Maven Central
- Adds `maven-source-plugin` to attach source JARs
- Adds `release` profile with:
  - `maven-gpg-plugin` for artifact signing
  - `central-publishing-maven-plugin` (0.7.0) for Central Portal publishing
  - Javadoc JAR (Kotlin sources as javadoc, matching framework approach)

## Usage
```bash
mvn deploy -Prelease
```

Requires `central` server credentials in `~/.m2/settings.xml` and GPG key configured.

## Test plan
- [ ] `mvn verify` passes (no impact on normal builds)
- [ ] `mvn deploy -Prelease -DskipTests` publishes to Central staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)