### PR TITLE
feat: improve plugin API ergonomics

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AdminPageFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AdminPageFactory.kt
@@ -27,40 +27,40 @@ class AdminPageFactory(
         return Page(
             shell = shell,
             data =
-            UserAdminPage(
-                title = i18n.translate("web.admin.users.title"),
-                description = i18n.translate("web.admin.users.description"),
-                users =
-                pageUsers.map { u ->
-                    UserAdminRow(
-                        id = u.id,
-                        username = u.username,
-                        email = u.email,
-                        role = u.role,
-                        enabled = u.enabled,
-                        toggleEnabledUrl = ctx.url("/admin/users/${u.id}/toggle-enabled"),
-                        toggleRoleUrl = ctx.url("/admin/users/${u.id}/toggle-role"),
-                        isSelf = u.id == currentUserId,
-                    )
-                },
-                currentPage = currentPage,
-                hasPrevious = hasPrevious,
-                hasNext = hasNext,
-                previousUrl = previousUrl,
-                nextUrl = nextUrl,
-                headerUsername = i18n.translate("web.admin.users.header.username"),
-                headerEmail = i18n.translate("web.admin.users.header.email"),
-                headerRole = i18n.translate("web.admin.users.header.role"),
-                headerEnabled = i18n.translate("web.admin.users.header.enabled"),
-                headerActions = i18n.translate("web.admin.users.header.actions"),
-                actionDisable = i18n.translate("web.admin.users.action.disable"),
-                actionEnable = i18n.translate("web.admin.users.action.enable"),
-                actionDemote = i18n.translate("web.admin.users.action.demote"),
-                actionPromote = i18n.translate("web.admin.users.action.promote"),
-                selfLabel = i18n.translate("web.admin.users.self"),
-                previousLabel = i18n.translate("web.admin.pagination.previous"),
-                nextLabel = i18n.translate("web.admin.pagination.next"),
-            ),
+                UserAdminPage(
+                    title = i18n.translate("web.admin.users.title"),
+                    description = i18n.translate("web.admin.users.description"),
+                    users =
+                        pageUsers.map { u ->
+                            UserAdminRow(
+                                id = u.id,
+                                username = u.username,
+                                email = u.email,
+                                role = u.role,
+                                enabled = u.enabled,
+                                toggleEnabledUrl = ctx.url("/admin/users/${u.id}/toggle-enabled"),
+                                toggleRoleUrl = ctx.url("/admin/users/${u.id}/toggle-role"),
+                                isSelf = u.id == currentUserId,
+                            )
+                        },
+                    currentPage = currentPage,
+                    hasPrevious = hasPrevious,
+                    hasNext = hasNext,
+                    previousUrl = previousUrl,
+                    nextUrl = nextUrl,
+                    headerUsername = i18n.translate("web.admin.users.header.username"),
+                    headerEmail = i18n.translate("web.admin.users.header.email"),
+                    headerRole = i18n.translate("web.admin.users.header.role"),
+                    headerEnabled = i18n.translate("web.admin.users.header.enabled"),
+                    headerActions = i18n.translate("web.admin.users.header.actions"),
+                    actionDisable = i18n.translate("web.admin.users.action.disable"),
+                    actionEnable = i18n.translate("web.admin.users.action.enable"),
+                    actionDemote = i18n.translate("web.admin.users.action.demote"),
+                    actionPromote = i18n.translate("web.admin.users.action.promote"),
+                    selfLabel = i18n.translate("web.admin.users.self"),
+                    previousLabel = i18n.translate("web.admin.pagination.previous"),
+                    nextLabel = i18n.translate("web.admin.pagination.next"),
+                ),
         )
     }
 
@@ -79,31 +79,31 @@ class AdminPageFactory(
         return Page(
             shell = shell,
             data =
-            AuditLogPage(
-                title = i18n.translate("web.admin.audit.title"),
-                entries =
-                pageEntries.map { e ->
-                    AuditEntryViewModel(
-                        actorUsername = e.actorUsername ?: "",
-                        targetUsername = e.targetUsername ?: "",
-                        action = e.action,
-                        detail = e.detail ?: "",
-                        timestamp = e.createdAt.toString(),
-                    )
-                },
-                currentPage = currentPage,
-                hasPrevious = hasPrevious,
-                hasNext = hasNext,
-                previousUrl = previousUrl,
-                nextUrl = nextUrl,
-                headerWhen = i18n.translate("web.admin.audit.header.when"),
-                headerActor = i18n.translate("web.admin.audit.header.actor"),
-                headerAction = i18n.translate("web.admin.audit.header.action"),
-                headerTarget = i18n.translate("web.admin.audit.header.target"),
-                headerDetail = i18n.translate("web.admin.audit.header.detail"),
-                previousLabel = i18n.translate("web.admin.pagination.previous"),
-                nextLabel = i18n.translate("web.admin.pagination.next"),
-            ),
+                AuditLogPage(
+                    title = i18n.translate("web.admin.audit.title"),
+                    entries =
+                        pageEntries.map { e ->
+                            AuditEntryViewModel(
+                                actorUsername = e.actorUsername ?: "",
+                                targetUsername = e.targetUsername ?: "",
+                                action = e.action,
+                                detail = e.detail ?: "",
+                                timestamp = e.createdAt.toString(),
+                            )
+                        },
+                    currentPage = currentPage,
+                    hasPrevious = hasPrevious,
+                    hasNext = hasNext,
+                    previousUrl = previousUrl,
+                    nextUrl = nextUrl,
+                    headerWhen = i18n.translate("web.admin.audit.header.when"),
+                    headerActor = i18n.translate("web.admin.audit.header.actor"),
+                    headerAction = i18n.translate("web.admin.audit.header.action"),
+                    headerTarget = i18n.translate("web.admin.audit.header.target"),
+                    headerDetail = i18n.translate("web.admin.audit.header.detail"),
+                    previousLabel = i18n.translate("web.admin.pagination.previous"),
+                    nextLabel = i18n.translate("web.admin.pagination.next"),
+                ),
         )
     }
 
@@ -116,28 +116,28 @@ class AdminPageFactory(
         return Page(
             shell = shell,
             data =
-            ApiKeysPage(
-                title = i18n.translate("web.apikeys.title"),
-                keys = keys,
-                createUrl = ctx.url("/auth/api-keys/create"),
-                newKey = newKey,
-                newKeyName = newKeyName,
-                description = i18n.translate("web.apikeys.description"),
-                newKeyBanner = i18n.translate("web.apikeys.created"),
-                createLabel = i18n.translate("web.apikeys.create"),
-                keyNameLabel = i18n.translate("web.apikeys.name"),
-                keyNamePlaceholder = i18n.translate("web.apikeys.name.placeholder"),
-                yourKeysHeading = i18n.translate("web.apikeys.your.keys"),
-                emptyLabel = i18n.translate("web.apikeys.empty"),
-                headerPrefix = i18n.translate("web.apikeys.table.prefix"),
-                headerName = i18n.translate("web.apikeys.table.name"),
-                headerCreated = i18n.translate("web.apikeys.table.created"),
-                headerLastUsed = i18n.translate("web.apikeys.table.last.used"),
-                headerActions = i18n.translate("web.apikeys.table.actions"),
-                neverLabel = i18n.translate("web.apikeys.table.never"),
-                deleteConfirm = i18n.translate("web.apikeys.delete.confirm"),
-                deleteLabel = i18n.translate("web.apikeys.delete"),
-            ),
+                ApiKeysPage(
+                    title = i18n.translate("web.apikeys.title"),
+                    keys = keys,
+                    createUrl = ctx.url("/auth/api-keys/create"),
+                    newKey = newKey,
+                    newKeyName = newKeyName,
+                    description = i18n.translate("web.apikeys.description"),
+                    newKeyBanner = i18n.translate("web.apikeys.created"),
+                    createLabel = i18n.translate("web.apikeys.create"),
+                    keyNameLabel = i18n.translate("web.apikeys.name"),
+                    keyNamePlaceholder = i18n.translate("web.apikeys.name.placeholder"),
+                    yourKeysHeading = i18n.translate("web.apikeys.your.keys"),
+                    emptyLabel = i18n.translate("web.apikeys.empty"),
+                    headerPrefix = i18n.translate("web.apikeys.table.prefix"),
+                    headerName = i18n.translate("web.apikeys.table.name"),
+                    headerCreated = i18n.translate("web.apikeys.table.created"),
+                    headerLastUsed = i18n.translate("web.apikeys.table.last.used"),
+                    headerActions = i18n.translate("web.apikeys.table.actions"),
+                    neverLabel = i18n.translate("web.apikeys.table.never"),
+                    deleteConfirm = i18n.translate("web.apikeys.delete.confirm"),
+                    deleteLabel = i18n.translate("web.apikeys.delete"),
+                ),
         )
     }
 
@@ -150,34 +150,34 @@ class AdminPageFactory(
         return Page(
             shell = shell,
             data =
-            ProfilePage(
-                title = i18n.translate("web.profile.title"),
-                username = user.username,
-                email = user.email,
-                role = user.role.name,
-                avatarUrl = avatarUrl,
-                submitUrl = ctx.url("/auth/components/profile-update"),
-                usernameLabel = i18n.translate("web.profile.username"),
-                usernamePlaceholder = i18n.translate("web.profile.username.placeholder"),
-                emailLabel = i18n.translate("web.profile.email"),
-                emailPlaceholder = i18n.translate("web.profile.email.placeholder"),
-                avatarLabel = i18n.translate("web.profile.avatar"),
-                avatarPlaceholder = i18n.translate("web.profile.avatar.placeholder"),
-                submitLabel = i18n.translate("web.profile.submit"),
-                emailNotificationsEnabled = user.emailNotificationsEnabled,
-                pushNotificationsEnabled = user.pushNotificationsEnabled,
-                notificationPrefsUrl = ctx.url("/auth/notification-preferences"),
-                notificationPrefsLabel = i18n.translate("web.profile.notif.prefs"),
-                emailNotifLabel = i18n.translate("web.profile.notif.email"),
-                pushNotifLabel = i18n.translate("web.profile.notif.push"),
-                savePrefsLabel = i18n.translate("web.profile.notif.save"),
-                deleteAccountUrl = ctx.url("/auth/account/delete"),
-                dangerZoneLabel = i18n.translate("web.profile.danger.zone"),
-                deleteAccountLabel = i18n.translate("web.profile.delete.account"),
-                deleteAccountDescription = i18n.translate("web.profile.delete.account.description"),
-                deleteAccountConfirmLabel = i18n.translate("web.profile.delete.confirm"),
-                deleteAccountCancelLabel = i18n.translate("web.profile.delete.cancel"),
-            ),
+                ProfilePage(
+                    title = i18n.translate("web.profile.title"),
+                    username = user.username,
+                    email = user.email,
+                    role = user.role.name,
+                    avatarUrl = avatarUrl,
+                    submitUrl = ctx.url("/auth/components/profile-update"),
+                    usernameLabel = i18n.translate("web.profile.username"),
+                    usernamePlaceholder = i18n.translate("web.profile.username.placeholder"),
+                    emailLabel = i18n.translate("web.profile.email"),
+                    emailPlaceholder = i18n.translate("web.profile.email.placeholder"),
+                    avatarLabel = i18n.translate("web.profile.avatar"),
+                    avatarPlaceholder = i18n.translate("web.profile.avatar.placeholder"),
+                    submitLabel = i18n.translate("web.profile.submit"),
+                    emailNotificationsEnabled = user.emailNotificationsEnabled,
+                    pushNotificationsEnabled = user.pushNotificationsEnabled,
+                    notificationPrefsUrl = ctx.url("/auth/notification-preferences"),
+                    notificationPrefsLabel = i18n.translate("web.profile.notif.prefs"),
+                    emailNotifLabel = i18n.translate("web.profile.notif.email"),
+                    pushNotifLabel = i18n.translate("web.profile.notif.push"),
+                    savePrefsLabel = i18n.translate("web.profile.notif.save"),
+                    deleteAccountUrl = ctx.url("/auth/account/delete"),
+                    dangerZoneLabel = i18n.translate("web.profile.danger.zone"),
+                    deleteAccountLabel = i18n.translate("web.profile.delete.account"),
+                    deleteAccountDescription = i18n.translate("web.profile.delete.account.description"),
+                    deleteAccountConfirmLabel = i18n.translate("web.profile.delete.confirm"),
+                    deleteAccountCancelLabel = i18n.translate("web.profile.delete.cancel"),
+                ),
         )
     }
 
@@ -192,28 +192,28 @@ class AdminPageFactory(
         return Page(
             shell = shell,
             data =
-            NotificationsPage(
-                title = i18n.translate("web.notifications.title"),
-                description = i18n.translate("web.notifications.description"),
-                notifications =
-                notifications.map { n ->
-                    NotificationViewModel(
-                        id = n.id.toString(),
-                        title = n.title,
-                        body = n.body,
-                        type = n.type,
-                        read = n.isRead,
-                        timeAgo = formatTimeAgo(n.createdAt),
-                        markReadUrl = ctx.url("/notifications/${n.id}/read"),
-                    )
-                },
-                unreadCount = unreadCount,
-                markAllReadUrl = ctx.url("/notifications/read-all"),
-                emptyLabel = i18n.translate("web.notifications.empty"),
-                markAllReadLabel = i18n.translate("web.notifications.mark.all.read"),
-                markReadLabel = i18n.translate("web.notifications.mark.read"),
-                readLabel = i18n.translate("web.notifications.read"),
-            ),
+                NotificationsPage(
+                    title = i18n.translate("web.notifications.title"),
+                    description = i18n.translate("web.notifications.description"),
+                    notifications =
+                        notifications.map { n ->
+                            NotificationViewModel(
+                                id = n.id.toString(),
+                                title = n.title,
+                                body = n.body,
+                                type = n.type,
+                                read = n.isRead,
+                                timeAgo = formatTimeAgo(n.createdAt),
+                                markReadUrl = ctx.url("/notifications/${n.id}/read"),
+                            )
+                        },
+                    unreadCount = unreadCount,
+                    markAllReadUrl = ctx.url("/notifications/read-all"),
+                    emptyLabel = i18n.translate("web.notifications.empty"),
+                    markAllReadLabel = i18n.translate("web.notifications.mark.all.read"),
+                    markReadLabel = i18n.translate("web.notifications.mark.read"),
+                    readLabel = i18n.translate("web.notifications.read"),
+                ),
         )
     }
 

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -7,6 +7,9 @@ import io.github.rygel.outerstellar.platform.model.ValidationException
 import io.github.rygel.outerstellar.platform.security.SecurityRules
 import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRepository
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
@@ -26,9 +29,6 @@ import org.http4k.format.Jackson
 import org.http4k.template.TemplateRenderer
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
-import java.time.Duration
-import java.time.Instant
-import java.util.UUID
 
 private const val COOKIE_MAX_AGE_DAYS = 365L
 private const val REQUEST_ID_HEADER = "X-Request-Id"
@@ -47,8 +47,7 @@ private fun isNonPagePath(path: String): Boolean =
 
 /** Adds ETag headers based on response body hash and returns 304 Not Modified when matched. */
 val etagCachingFilter: Filter = Filter { next: HttpHandler ->
-    {
-            request ->
+    { request ->
         val response = next(request)
         if (response.status == Status.OK && response.header("ETag") == null) {
             val body = response.bodyString()
@@ -68,8 +67,7 @@ val etagCachingFilter: Filter = Filter { next: HttpHandler ->
 
 /** Adds Cache-Control headers for static assets (CSS, JS, images, fonts). */
 val staticCacheControlFilter: Filter = Filter { next: HttpHandler ->
-    {
-            request ->
+    { request ->
         val response = next(request)
         if (isStaticAsset(request.uri.path)) {
             response.header("Cache-Control", "public, max-age=$STATIC_ASSET_MAX_AGE, immutable")
@@ -80,8 +78,7 @@ val staticCacheControlFilter: Filter = Filter { next: HttpHandler ->
 }
 
 fun analyticsPageViewFilter(analytics: AnalyticsService): Filter = Filter { next ->
-    {
-            request ->
+    { request ->
         val response = next(request)
         val isTrackablePage = request.method == Method.GET && !isNonPagePath(request.uri.path)
         if (isTrackablePage) {
@@ -130,8 +127,7 @@ object Filters {
     private val logger = LoggerFactory.getLogger(Filters::class.java)
 
     val correlationId: Filter = Filter { next: HttpHandler ->
-        {
-                request ->
+        { request ->
             val requestId = request.header(REQUEST_ID_HEADER) ?: java.util.UUID.randomUUID().toString()
             MDC.put("requestId", requestId.take(LOG_ID_LENGTH))
             MDC.put("method", request.method.name)
@@ -146,8 +142,7 @@ object Filters {
     }
 
     fun cors(allowedOrigins: String): Filter = Filter { next: HttpHandler ->
-        {
-                request ->
+        { request ->
             if (request.method == org.http4k.core.Method.OPTIONS) {
                 Response(Status.NO_CONTENT)
                     .header("Access-Control-Allow-Origin", allowedOrigins)
@@ -164,8 +159,7 @@ object Filters {
     }
 
     fun securityHeaders(cspPolicy: String = DEFAULT_CSP_POLICY): Filter = Filter { next: HttpHandler ->
-        {
-                request ->
+        { request ->
             next(request)
                 .header("X-Content-Type-Options", "nosniff")
                 .header("X-Frame-Options", "DENY")
@@ -182,8 +176,7 @@ object Filters {
     }
 
     val requestLogging: Filter = Filter { next: HttpHandler ->
-        {
-                request ->
+        { request ->
             val start = System.currentTimeMillis()
             val response = next(request)
             val duration = System.currentTimeMillis() - start
@@ -207,8 +200,7 @@ object Filters {
     val telemetry: Filter = ServerFilters.OpenTelemetryTracing(Telemetry.openTelemetry)
 
     fun devAutoLogin(enabled: Boolean, userRepository: UserRepository): Filter = Filter { next ->
-        {
-                request ->
+        { request ->
             if (enabled && request.cookie(WebContext.SESSION_COOKIE) == null) {
                 val admin = userRepository.findByUsername("admin")
                 if (admin != null) {
@@ -235,8 +227,7 @@ object Filters {
         jwtService: io.github.rygel.outerstellar.platform.security.JwtService? = null,
         pluginNavItems: List<PluginNavItem> = emptyList(),
     ): Filter = Filter { next: HttpHandler ->
-        {
-                request ->
+        { request ->
             val context =
                 WebContext(request, devDashboardEnabled, userRepository, appVersion, jwtService, pluginNavItems)
             val contextUser =
@@ -293,8 +284,7 @@ object Filters {
         sessionCookieSecure: Boolean,
         activityUpdater: io.github.rygel.outerstellar.platform.security.AsyncActivityUpdater? = null,
     ): Filter = Filter { next: HttpHandler ->
-        {
-                request ->
+        { request ->
             val user =
                 try {
                     request.webContext.user
@@ -329,8 +319,7 @@ object Filters {
 
     // Bridge WebContext user into SecurityRules
     val securityFilter: Filter = Filter { next: HttpHandler ->
-        {
-                request ->
+        { request ->
             val user =
                 try {
                     request.webContext.user
@@ -350,8 +339,7 @@ object Filters {
      * - Exempts `/api/v1/` routes (Bearer-token auth) and `/oauth/` routes.
      */
     fun csrfProtection(sessionCookieSecure: Boolean, enabled: Boolean = true): Filter = Filter { next ->
-        {
-                request ->
+        { request ->
             if (!enabled) return@Filter next(request)
 
             val unsafeMethods = setOf(Method.POST, Method.PUT, Method.DELETE, Method.PATCH)
@@ -366,8 +354,8 @@ object Filters {
 
                 if (
                     cookieToken == null ||
-                    submitted == null ||
-                    !java.security.MessageDigest.isEqual(cookieToken.toByteArray(), submitted.toByteArray())
+                        submitted == null ||
+                        !java.security.MessageDigest.isEqual(cookieToken.toByteArray(), submitted.toByteArray())
                 ) {
                     logger.warn("CSRF check failed for {} {}", request.method, path)
                     Response(Status.FORBIDDEN).body("Invalid or missing CSRF token")
@@ -415,8 +403,7 @@ object Filters {
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     fun globalErrorHandler(pageFactory: WebPageFactory, renderer: TemplateRenderer): Filter =
         Filter { next: HttpHandler ->
-            {
-                    request ->
+            { request ->
                 try {
                     val response = next(request)
                     if (response.status == Status.NOT_FOUND) {

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PlatformPlugin.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PlatformPlugin.kt
@@ -73,7 +73,6 @@ data class PluginContext(
             config: AppConfig = AppConfig(),
             analytics: AnalyticsService = NoOpAnalyticsService(),
             notificationService: NotificationService? = null,
-            pageFactory: WebPageFactory = WebPageFactory(),
         ): PluginContext =
             PluginContext(
                 renderer = renderer,
@@ -82,7 +81,7 @@ data class PluginContext(
                 userRepository = userRepository,
                 analytics = analytics,
                 notificationService = notificationService,
-                pageFactory = pageFactory,
+                pageFactory = WebPageFactory(),
             )
     }
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PlatformPlugin.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PlatformPlugin.kt
@@ -3,12 +3,17 @@ package io.github.rygel.outerstellar.platform.web
 import io.github.rygel.outerstellar.platform.AppConfig
 import io.github.rygel.outerstellar.platform.PluginMigrationSource
 import io.github.rygel.outerstellar.platform.analytics.AnalyticsService
+import io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService
 import io.github.rygel.outerstellar.platform.security.SecurityService
+import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRepository
 import io.github.rygel.outerstellar.platform.service.NotificationService
 import org.http4k.contract.ContractRoute
 import org.http4k.core.Filter
+import org.http4k.core.Request
+import org.http4k.lens.LensFailure
 import org.http4k.template.TemplateRenderer
+import org.http4k.template.ViewModel
 import org.koin.core.module.Module
 
 /**
@@ -29,7 +34,58 @@ data class PluginContext(
     val analytics: AnalyticsService,
     val notificationService: NotificationService?,
     val pageFactory: WebPageFactory,
-)
+) {
+    /**
+     * Returns the authenticated user for this request, or null if no user is logged in. This is a convenience wrapper
+     * around [SecurityRules.USER_KEY] that handles the lens failure gracefully.
+     */
+    fun currentUser(request: Request): User? =
+        try {
+            request.webContext.user
+        } catch (_: LensFailure) {
+            null
+        }
+
+    /**
+     * Wraps a plugin [ViewModel] in a [Page] with the platform's shell (nav, theme, CSRF token, etc.). This is the
+     * recommended way for plugins to render full pages that integrate with the platform layout.
+     *
+     * The resulting [Page] includes the CSRF token in the shell, so plugin templates can use `${model.shell.csrfToken}`
+     * in form hidden fields without manual extraction.
+     */
+    fun <T : ViewModel> buildPage(request: Request, pageTitle: String, activeSection: String, data: T): Page<T> {
+        val ctx = request.webContext
+        return Page(shell = ctx.shell(pageTitle, activeSection), data = data)
+    }
+
+    companion object {
+        /**
+         * Creates a [PluginContext] with sensible defaults for testing. Pass only the services your plugin actually
+         * uses; the rest default to no-ops or minimal stubs.
+         *
+         * [securityService] and [userRepository] are required because they cannot be stubbed without a mocking library.
+         * Use `mockk(relaxed = true)` for both in your test setup.
+         */
+        fun forTesting(
+            renderer: TemplateRenderer,
+            securityService: SecurityService,
+            userRepository: UserRepository,
+            config: AppConfig = AppConfig(),
+            analytics: AnalyticsService = NoOpAnalyticsService(),
+            notificationService: NotificationService? = null,
+            pageFactory: WebPageFactory = WebPageFactory(),
+        ): PluginContext =
+            PluginContext(
+                renderer = renderer,
+                config = config,
+                securityService = securityService,
+                userRepository = userRepository,
+                analytics = analytics,
+                notificationService = notificationService,
+                pageFactory = pageFactory,
+            )
+    }
+}
 
 /**
  * Single-plugin contract. One outerstellar-platform host accepts exactly one plugin.

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PlatformPlugin.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PlatformPlugin.kt
@@ -60,27 +60,27 @@ data class PluginContext(
 
     companion object {
         /**
-         * Creates a [PluginContext] with sensible defaults for testing. Pass only the services your plugin actually
-         * uses; the rest default to no-ops or minimal stubs.
+         * Creates a [PluginContext] with sensible defaults for testing. Only the three services that cannot be
+         * stubbed without a mocking library are required — use `mockk(relaxed = true)` for them.
          *
-         * [securityService] and [userRepository] are required because they cannot be stubbed without a mocking library.
-         * Use `mockk(relaxed = true)` for both in your test setup.
+         * To override other defaults, use `.copy()` on the returned instance:
+         * ```kotlin
+         * val ctx = PluginContext.forTesting(renderer, mockk(relaxed = true), mockk(relaxed = true))
+         *     .copy(config = AppConfig(devMode = true))
+         * ```
          */
         fun forTesting(
             renderer: TemplateRenderer,
             securityService: SecurityService,
             userRepository: UserRepository,
-            config: AppConfig = AppConfig(),
-            analytics: AnalyticsService = NoOpAnalyticsService(),
-            notificationService: NotificationService? = null,
         ): PluginContext =
             PluginContext(
                 renderer = renderer,
-                config = config,
+                config = AppConfig(),
                 securityService = securityService,
                 userRepository = userRepository,
-                analytics = analytics,
-                notificationService = notificationService,
+                analytics = NoOpAnalyticsService(),
+                notificationService = null,
                 pageFactory = WebPageFactory(),
             )
     }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiter.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiter.kt
@@ -1,14 +1,14 @@
 package io.github.rygel.outerstellar.platform.web
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.slf4j.LoggerFactory
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicLong
 
 private val logger = LoggerFactory.getLogger("io.github.rygel.outerstellar.platform.web.RateLimiter")
 
@@ -64,8 +64,7 @@ fun rateLimitFilter(
             .build<String, TokenBucket>()
 
     return Filter { next: HttpHandler ->
-        {
-                request ->
+        { request ->
             val path = request.uri.path
             if (pathPrefixes.any { path.startsWith(it) }) {
                 val clientIp =

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <java.version>21</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <kotlin.version>2.3.10</kotlin.version>
-        <outerstellar.version>1.0.11</outerstellar.version>
+        <outerstellar.version>1.0.13</outerstellar.version>
         <http4k.version>6.37.0.0</http4k.version>
         <flyway.version>12.1.1</flyway.version>
         <postgresql.version>42.7.10</postgresql.version>


### PR DESCRIPTION
## Summary
Three improvements to the plugin API based on real-world plugin development feedback:

1. **`PluginContext.currentUser(request): User?`** — One-liner to get the authenticated user. Handles `LensFailure` gracefully so plugins don't need to catch exceptions or manually extract from `WebContext`.

2. **`PluginContext.buildPage(request, title, section, data): Page<T>`** — Wraps a plugin `ViewModel` in the platform's `Page<T>` shell with nav, theme, CSRF token, etc. Solves both the "how do I render a full page" and "how do I get CSRF tokens into my templates" problems.

3. **`PluginContext.forTesting(renderer, securityService, userRepository)`** — Factory with sensible defaults. Analytics defaults to `NoOpAnalyticsService`, notifications to null, config to `AppConfig()`, pageFactory to `WebPageFactory()`. Only three required params instead of seven.

## Test plan
- [ ] `mvn compile` passes
- [ ] Existing tests pass (no breaking changes — additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)