### PR TITLE
fix: isolate platform JTE classes to prevent fat JAR conflicts

### DIFF
--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -253,6 +253,7 @@
                         <configuration>
                             <sourceDirectory>${project.basedir}/src/main/jte</sourceDirectory>
                             <contentType>Html</contentType>
+                            <packageName>gg.jte.generated.precompiled.outerstellar</packageName>
                         </configuration>
                     </execution>
                 </executions>

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfra.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfra.kt
@@ -13,6 +13,8 @@ import org.http4k.template.TemplateRenderer
 import org.http4k.template.ViewModel
 import org.http4k.template.ViewNotFound
 
+private const val PLATFORM_JTE_PACKAGE = "gg.jte.generated.precompiled.outerstellar"
+
 fun TemplateRenderer.render(viewModel: ViewModel, status: Status = Status.OK): Response =
     Response(status)
         .header("content-type", ContentType.TEXT_HTML.toHeaderValue() + "; charset=utf-8")
@@ -24,7 +26,7 @@ fun createRenderer(): TemplateRenderer {
 
     val templateEngine =
         if (isProduction) {
-            TemplateEngine.createPrecompiled(gg.jte.ContentType.Html)
+            TemplateEngine.createPrecompiled(null, gg.jte.ContentType.Html, null, PLATFORM_JTE_PACKAGE)
         } else {
             val projectDirectory = Path.of(System.getProperty("user.dir"))
             val sourceTemplates = projectDirectory.resolve(Path.of("web", "src", "main", "jte"))


### PR DESCRIPTION
## Summary

- Configures the JTE Maven plugin in `platform-web` to generate template classes in `gg.jte.generated.precompiled.outerstellar` instead of the default `gg.jte.generated.precompiled`
- Updates `createRenderer()` to target the same isolated package when creating the production engine

## Problem

When platform-web is consumed as a library (e.g. by mirrorlessdb), the consuming app's JTE Maven plugin generates its own `gg.jte.generated.precompiled.JteindexGenerated` class. In the assembled fat JAR this overwrites platform-web's compiled template classes in `gg.jte.generated.precompiled.io.github.rygel.outerstellar.platform.web.*`, causing `ViewNotFound` for `ErrorPage` and all other platform templates at runtime — even though the `.class` files are physically present in the JAR.

The bug only manifests in production (`JTE_PRODUCTION=true`); dev mode uses `DirectoryCodeResolver`/`ResourceCodeResolver` which bypasses the issue entirely.

## Fix

Isolate platform template classes in a unique sub-package. The consuming app's generated classes stay in the default package; the platform's stay in `*.outerstellar`. No class can overwrite another, and `createPrecompiled()` points at the right namespace.

**No changes required in consuming applications.**

## Test plan

- [x] `mvn verify -pl platform-web -am` passes locally
- [ ] Deploy to staging with `JTE_PRODUCTION=true` and trigger a server error to confirm `ErrorPage` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)