### PR TITLE
perf: use precompiled JTE templates in tests and cache renderer

### DIFF
--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -264,6 +264,10 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <parallel>none</parallel>
+                    <systemPropertyVariables>
+                        <!-- Use precompiled JTE templates in tests — avoids 60+ s of source compilation per fork -->
+                        <jte.production>true</jte.production>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/H2WebTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/H2WebTest.kt
@@ -101,6 +101,7 @@ abstract class H2WebTest {
 
         // --- Shared repositories (lazy, created once per JVM) ---
 
+        val renderer by lazy { createRenderer() }
         val encoder by lazy { BCryptPasswordEncoder(logRounds = 4) }
         val userRepository by lazy { JooqUserRepository(testDsl) }
         val messageRepository by lazy { JooqMessageRepository(testDsl) }
@@ -145,7 +146,7 @@ abstract class H2WebTest {
                     contactService,
                     outbox,
                     cache,
-                    createRenderer(),
+                    renderer,
                     pageFactory,
                     config,
                     securityService,


### PR DESCRIPTION
## Summary

- Set `jte.production=true` as a Surefire system property in `platform-web/pom.xml` so tests call `TemplateEngine.createPrecompiled()` instead of compiling JTE templates from source on each test run — expected to save ~60+ seconds per CI run
- Cache the `TemplateRenderer` in `H2WebTest.Companion` via `by lazy` so `buildApp()` reuses one instance across the JVM process instead of creating a new engine per test call

## Test plan

- [x] All 502 platform-web unit/integration tests pass locally (`mvn test -pl platform-web -DexcludedGroups=e2e,performance`)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)