### PR TITLE
release: v1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.3.5] – 2026-03-28
+
+### Security
+- `globalErrorHandler`: HTMX error responses now only expose `e.message` for `OuterstellarException` subclasses (user-facing, intentional messages). Generic JVM exceptions (JDBI SQL errors, NPEs, etc.) return a safe `"Action failed"` fallback, preventing internal details from leaking to any client that sends `HX-Request: true`.
+- `devAutoLogin`: Added loopback guard — rejects auto-login when `X-Forwarded-For` is present (proxy) or `Host` is a non-loopback address. Eliminates the misconfiguration risk where a production deployment with `devMode=true` would auto-authenticate remote clients as admin.
+
+### Performance
+- `platform-web` tests now use `TemplateEngine.createPrecompiled()` via `jte.production=true` Surefire property — eliminates runtime JTE compilation, saving ~60 s per CI run
+- Shared `TemplateRenderer` cached as `by lazy` in `H2WebTest.Companion` — one engine instance reused across all tests in the JVM process
+
+### Changed
+- Bumped `outerstellar-framework` from 1.0.13 to 1.0.14
+- Bumped `http4k` from 6.37.0.0 to 6.38.0.0
+- Bumped `jOOQ` from 3.20.11 to 3.21.1
+- Bumped `junit` from 5.12.2 to 5.14.3
+- Bumped `flyway` from 12.1.1 to 12.2.0
+
+### CI
+- Fixed `codeql-action` SHA comment from generic `# v4` to precise `# v4.34.1` (resolves zizmor/Scorecard mismatch warning)
+
+---
+
 ## [1.3.4] – 2026-03-26
 
 ### Fixed


### PR DESCRIPTION
## Summary

Bumps version to 1.3.5 and adds the CHANGELOG entry. All the actual code changes (security fixes, performance improvements, dep bumps) are already in develop from previous merges.

**Included in this release:**
- **Security**: `globalErrorHandler` HTMX error leak fix; `devAutoLogin` loopback guard
- **Performance**: JTE precompiled templates in tests (`jte.production=true`); cached `TemplateRenderer` in `H2WebTest.Companion`
- **Dependencies**: http4k 6.38.0.0, jOOQ 3.21.1, JUnit 5.14.3, Flyway 12.2.0, outerstellar-framework 1.0.14
- **CI**: `codeql-action` SHA comment corrected to `# v4.34.1`

## Test plan

- [x] All 502 platform-web unit/integration tests pass locally
- [ ] CI passes
- [ ] Merge into develop, then develop → main

🤖 Generated with [Claude Code](https://claude.com/claude-code)