### PR TITLE
fix: publish workflow 401 — wrong env var name for Maven auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,4 +85,4 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         run: mvn deploy -DskipTests -Denforcer.skip=true
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}


### PR DESCRIPTION
The deploy step was setting \ but Maven's settings.xml (written by setup-java) references \ as the password env var. Renamed to match.