### PR TITLE
fix: OWASP dependency check failing due to unregistered plugin prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
           restore-keys: nvd-
 
       - name: OWASP dependency check
-        run: mvn dependency-check:aggregate -DskipTests
+        run: mvn org.owasp:dependency-check-maven:aggregate -DskipTests
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
 


### PR DESCRIPTION
Replace `dependency-check:aggregate` (short prefix — requires `org.owasp` in Maven plugin groups) with the fully-qualified `org.owasp:dependency-check-maven:aggregate`. This has been causing the Security job to fail on every CI run.