### PR TITLE
fix: auto-trigger CI on bot-created sync PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  workflow_dispatch:
 
 permissions: {}
 

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   sync:
@@ -46,5 +47,9 @@ jobs:
             --head "$SYNC_BRANCH" \
             --title "sync: merge main into develop" \
             --body "Automated sync of main into develop after release merge."
+
+          # GitHub does not trigger CI on PRs created by the Actions bot.
+          # Explicitly dispatch the CI workflow on the sync branch so checks run.
+          gh workflow run ci.yml --ref "$SYNC_BRANCH"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub does not fire CI on PRs created by the Actions bot. After each sync PR is created, the workflow now explicitly dispatches the CI workflow on the sync branch via `gh workflow run ci.yml --ref "$SYNC_BRANCH"`. Requires `actions: write` permission and `workflow_dispatch` trigger on CI.