### PR TITLE
fix: security, usability, and architecture improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,17 @@ This file defines repository-specific guardrails for coding agents and contribut
   - `mvn -pl platform-persistence-jooq test`
 - Minimum for Swing UI/theming changes:
   - `mvn -pl platform-desktop -Ptests-headless test`
-- **Desktop/Swing tests must NEVER run directly on the host machine.** They capture mouse and keyboard, which is disruptive and non-negotiable. Always use `-Ptests-headless` which runs them inside a Podman/Docker container with Xvfb. Running `mvn -pl platform-desktop test` without a headless profile is forbidden.
+- **Desktop/Swing tests must NEVER run directly on the host machine.** They capture mouse and keyboard, which is disruptive and non-negotiable. Always run them inside the Podman container:
+  ```bash
+  podman build -t outerstellar-test-desktop -f docker/Dockerfile.test-desktop .
+  podman run --rm --network host \
+    -v "${PWD}:/app:Z" \
+    -v "${HOME}/.m2/settings.xml:/root/.m2/settings.xml:Z" \
+    -v "${HOME}/.m2/repository:/root/.m2/repository:Z" \
+    -v "/var/run/docker.sock:/var/run/docker.sock:Z" \
+    outerstellar-test-desktop
+  ```
+  The container starts Xvfb internally. `--network host` is required so Testcontainers can reach its PostgreSQL sibling containers. Running `mvn -pl platform-desktop test` on the host is forbidden.
 - After any `mvn clean install -DskipTests` that changes compiled production code in a dependency module, the dependent module's test classpath may hold stale classes. Always do a full `mvn clean install -DskipTests` before running tests in downstream modules.
 
 ## Safety and repository hygiene

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - `SQLDialect.H2` removed from `PersistenceModule` — always uses `SQLDialect.POSTGRES`
-- Maven `test-db` profile auto-starts Podman PostgreSQL for local test runs
-- CI uses GitHub Actions PostgreSQL service containers
+- All test base classes use Testcontainers `PostgreSQLContainer` for ephemeral test databases
 - `flyway-database-postgresql` added to persistence modules (required by Flyway 12+)
 
 ---

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - "8080:8080"
     environment:
       - APP_PROFILE=prod
-      - SESSIONCOOKIESECURE=false
       - ADMIN_PASSWORD=admin123
     volumes:
       - app-data:/app/data

--- a/docker/podman-compose.yml
+++ b/docker/podman-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql
+      - postgres_data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U outerstellar -d outerstellar"]
       interval: 5s

--- a/docs/architecture-review.md
+++ b/docs/architecture-review.md
@@ -24,9 +24,9 @@ The build enforces Detekt, SpotBugs, Checkstyle, PMD, Spotless/Ktlint, JaCoCo, E
 
 The bidirectional sync between desktop and web demonstrates dirty tracking, timestamp-based conflict detection, optimistic locking, and an outbox pattern. This is a non-trivial working example, not a toy.
 
-### H2 as the persistence engine
+### PostgreSQL as the persistence engine
 
-H2 is the intentional and permanent choice for this platform. It provides zero-setup local persistence, works identically for both web server and Swing desktop, integrates cleanly with Flyway and jOOQ, and keeps the platform runnable without any external infrastructure. This is a deliberate design decision, not a limitation.
+PostgreSQL is the sole database engine for this platform. It provides robust production-grade persistence, works identically for both web server and Swing desktop (via Testcontainers for tests), integrates cleanly with Flyway and jOOQ, and keeps the platform runnable with a simple `podman-compose up` for local development.
 
 ## Package root convention
 

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
@@ -392,11 +392,11 @@ private fun buildBaseApp(
 private fun buildHealthResponse(userRepository: UserRepository): Response {
     val checks = mutableMapOf<String, Any>("status" to "UP")
     try {
-        val userCount = userRepository.countAll()
-        checks["database"] = mapOf("status" to "UP", "users" to userCount)
+        userRepository.countAll()
+        checks["database"] = mapOf("status" to "UP")
     } catch (e: Exception) {
         checks["status"] = "DOWN"
-        checks["database"] = mapOf("status" to "DOWN", "error" to (e.message ?: "unknown"))
+        checks["database"] = mapOf("status" to "DOWN", "error" to "Database connection failed")
     }
     checks["timestamp"] = java.time.Instant.now().toString()
     val status = if (checks["status"] == "UP") Status.OK else Status.SERVICE_UNAVAILABLE

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/Main.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/Main.kt
@@ -45,11 +45,8 @@ fun main() {
 
     val adminPassword =
         System.getenv("ADMIN_PASSWORD")
-            ?: java.util.UUID.randomUUID().toString().also { generated ->
-                logger.warn(
-                    "ADMIN_PASSWORD env var not set. Using generated password for first-boot admin: {}",
-                    generated,
-                )
+            ?: java.util.UUID.randomUUID().toString().also {
+                logger.warn("ADMIN_PASSWORD env var not set. A random password was generated for first-boot admin.")
                 logger.warn("Set ADMIN_PASSWORD to a secure value before deploying to production.")
             }
     if (main.userRepository.findByUsername("admin") == null) {

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/WebModule.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/WebModule.kt
@@ -33,7 +33,7 @@ val webModule
     get() = module {
         includes(adminWebModule)
         single(named("jdbcUrl")) { get<AppConfig>().jdbcUrl }
-        single(named("serverBaseUrl")) { "http://localhost:8080" }
+        single(named("serverBaseUrl")) { "http://localhost:${get<AppConfig>().port}" }
         single(named("appBaseUrl")) { get<AppConfig>().appBaseUrl }
         single<TemplateRenderer> { createRenderer() }
         single {

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/HealthCheckIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/HealthCheckIntegrationTest.kt
@@ -1,8 +1,5 @@
 package io.github.rygel.outerstellar.platform.web
 
-import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
-import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -21,8 +18,6 @@ import org.junit.jupiter.api.BeforeEach
  * - Response is JSON with content-type application/json
  * - Response contains "status": "UP"
  * - Response contains "database" object with "status": "UP"
- * - Response contains user count in database.users
- * - User count increases after registering a new user
  * - Response contains "timestamp" field
  * - No authentication required
  */
@@ -69,7 +64,6 @@ class HealthCheckIntegrationTest : WebTest() {
     fun `GET health database status is UP`() {
         val response = app(Request(GET, "/health"))
         val body = response.bodyString()
-        // database.status should be UP
         val databaseIdx = body.indexOf("database")
         assertTrue(databaseIdx >= 0, "Should contain database section")
         val dbSection = body.substring(databaseIdx)
@@ -85,36 +79,16 @@ class HealthCheckIntegrationTest : WebTest() {
 
     @Test
     fun `GET health does not require authentication`() {
-        // No auth header, no cookies — should still succeed
         val response = app(Request(GET, "/health"))
         assertEquals(Status.OK, response.status)
     }
 
     @Test
-    fun `GET health user count reflects actual users in database`() {
-        // Add a user and check count increases
-        val userBefore = parseUserCount(app(Request(GET, "/health")).bodyString())
-
-        val newUser =
-            User(
-                id = UUID.randomUUID(),
-                username = "healthcheckuser",
-                email = "healthcheck@test.com",
-                passwordHash = "x".repeat(60),
-                role = UserRole.USER,
-            )
-        userRepository.save(newUser)
-
-        val userAfter = parseUserCount(app(Request(GET, "/health")).bodyString())
-        assertTrue(
-            userAfter > userBefore,
-            "User count should increase after saving user: before=$userBefore, after=$userAfter",
-        )
-    }
-
-    private fun parseUserCount(body: String): Int {
-        // Extract users count from JSON: "users":N
-        val match = """"users"\s*:\s*(\d+)""".toRegex().find(body)
-        return match?.groupValues?.get(1)?.toIntOrNull() ?: -1
+    fun `GET health does not expose internal details`() {
+        val response = app(Request(GET, "/health"))
+        val body = response.bodyString()
+        assertEquals(-1, body.indexOf("jdbc:"), "Should not expose JDBC URL")
+        assertEquals(-1, body.indexOf("users"), "Should not expose user count")
+        assertEquals(-1, body.indexOf("Exception"), "Should not expose exception traces")
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #166 (H2→PostgreSQL migration). Security hardening and usability fixes:
- Stop logging generated admin password in plaintext
- Remove SESSIONCOOKIESECURE=false override from docker-compose.yml
- Sanitize /health endpoint: remove user count and raw DB error messages
- Fix podman-compose.yml PostgreSQL volume mount path
- Update stale H2 references in architecture-review.md
- Fix CHANGELOG accuracy (remove nonexistent test-db profile)
- Document desktop container test requirements in AGENTS.md
- Derive serverBaseUrl from AppConfig.port instead of hardcoding

## Test plan
- [x] HealthCheckIntegrationTest updated (8 tests pass)
- [x] mvn clean install -DskipTests passes all 9 modules
- [x] CI on #166 already passed for the Docker E2E + build changes