### PR TITLE
chore(deps): upgrade Testcontainers 1.21.0 to 2.0.5 with artifact ID migration

### DIFF
--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -88,12 +88,12 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/platform-persistence-jdbi/pom.xml
+++ b/platform-persistence-jdbi/pom.xml
@@ -76,12 +76,12 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/platform-persistence-jooq/pom.xml
+++ b/platform-persistence-jooq/pom.xml
@@ -73,12 +73,12 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -93,12 +93,12 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <postgresql.version>42.7.11</postgresql.version>
         <jooq.version>3.21.2</jooq.version>
         <jdbi.version>3.53.0</jdbi.version>
-        <testcontainers.version>1.21.0</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
         <jte.version>3.2.4</jte.version>
         <flatlaf.version>3.7.1</flatlaf.version>
         <junit.version>6.0.3</junit.version>


### PR DESCRIPTION
## Summary

Fixes #172 — Dependabot bumped testcontainers-bom from 1.21.0 to 2.0.5, but TC 2.0 renamed its Maven artifact IDs:

- `postgresql` -> `testcontainers-postgresql`
- `junit-jupiter` -> `testcontainers-junit-jupiter`

Without these renames, the BOM doesn't resolve versions and all module builds fail.

### Changes
- Updated artifact IDs in 4 module POMs: platform-persistence-jooq, platform-persistence-jdbi, platform-web, platform-desktop
- Java/Kotlin import paths unchanged (`org.testcontainers.containers.PostgreSQLContainer` stays the same)

### Test plan
- [x] `mvn clean install -DskipTests` passes
- [ ] CI green on this PR