### PR TITLE
chore: set version to 1.5.1-SNAPSHOT

### DIFF
--- a/platform-core/pom.xml
+++ b/platform-core/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
 
     </parent>
 

--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
 
     </parent>
 

--- a/platform-persistence-jdbi/pom.xml
+++ b/platform-persistence-jdbi/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
 
     </parent>
 

--- a/platform-persistence-jooq/pom.xml
+++ b/platform-persistence-jooq/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
 
     </parent>
 

--- a/platform-security/pom.xml
+++ b/platform-security/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
 
     </parent>
 

--- a/platform-seed/pom.xml
+++ b/platform-seed/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
 
     </parent>
 

--- a/platform-sync-client/pom.xml
+++ b/platform-sync-client/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
 
     </parent>
 

--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.5.0</version>
+        <version>1.5.1-SNAPSHOT</version>
 
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.rygel</groupId>
     <artifactId>outerstellar-platform-parent</artifactId>
 
-    <version>1.5.0</version>
+    <version>1.5.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Bump version from 1.5.0 to 1.5.1-SNAPSHOT for development. After merge, the publish workflow will be triggered to deploy to GitHub Packages.