### PR TITLE
ci: parallelize tests, add caching, split quality checks

### DIFF
--- a/.github/workflows/ci-docker-e2e.yml
+++ b/.github/workflows/ci-docker-e2e.yml
@@ -29,7 +29,6 @@ jobs:
       contents: read
     env:
       GH_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Password seeded into the container and read by tests via E2E_ADMIN_PASSWORD
       E2E_ADMIN_PASSWORD: e2eTestPassword123
 
     services:
@@ -72,8 +71,18 @@ jobs:
       - name: Install Node dependencies
         run: npm ci --no-audit --no-fund
 
-      - name: Build Docker image
-        run: docker build -f docker/Dockerfile -t outerstellar-platform:e2e .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Build Docker image with layer caching
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          tags: outerstellar-platform:e2e
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Start application container
         run: |
@@ -111,11 +120,11 @@ jobs:
             -pl platform-core,platform-persistence-jooq,platform-sync-client,platform-security,platform-web \
             -DskipTests -Dexec.skip=true -q \
             -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true \
-            -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true -Djacoco.skip=true
+            -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true \
+            -Djacoco.skip=true -Denforcer.skip=true
 
       - name: Run Docker smoke tests
         env:
-          # Keep Playwright browsers inside target/ so they are cleaned up by mvn clean
           PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/platform-web/target/playwright-browsers
         run: >
           mvn test -pl platform-web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,20 +51,9 @@ jobs:
       - name: Populate dependency cache
         run: mvn dependency:go-offline -q 2>/dev/null || true
 
-      - name: Compile, test-compile, and install all modules
+      - name: Compile, install, and run fast quality checks
         run: >
-          mvn install -T 1C -DskipTests -q
-          -Dcheckstyle.skip=true
-          -Dpmd.skip=true
-          -Dcpd.skip=true
-          -Dspotbugs.skip=true
-          -Djacoco.skip=true
-          -Ddetekt.skip=true
-          -Denforcer.skip=true
-
-      - name: Run fast quality checks (Spotless + Detekt)
-        run: >
-          mvn spotless:check detekt:check -T 1C
+          mvn install -T 1C -DskipTests
           -Dcheckstyle.skip=true
           -Dpmd.skip=true
           -Dcpd.skip=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-test:
-    name: Build, Test, and Quality
+  build:
+    name: Build and Quality Gate
     runs-on: ubuntu-latest
     environment: ci
     permissions:
@@ -48,8 +48,38 @@ jobs:
       - name: Install Node dependencies
         run: npm ci --no-audit --no-fund
 
-      - name: Build and run all checks
-        run: mvn verify -T 1C -pl platform-core,platform-persistence-jooq,platform-persistence-jdbi,platform-sync-client,platform-security,platform-web
+      - name: Populate dependency cache
+        run: mvn dependency:go-offline -q 2>/dev/null || true
+
+      - name: Compile, test-compile, and install all modules
+        run: >
+          mvn install -T 1C -DskipTests -q
+          -Dcheckstyle.skip=true
+          -Dpmd.skip=true
+          -Dcpd.skip=true
+          -Dspotbugs.skip=true
+          -Djacoco.skip=true
+          -Ddetekt.skip=true
+          -Denforcer.skip=true
+
+      - name: Run fast quality checks (Spotless + Detekt)
+        run: >
+          mvn spotless:check detekt:check -T 1C
+          -Dcheckstyle.skip=true
+          -Dpmd.skip=true
+          -Dcpd.skip=true
+          -Dspotbugs.skip=true
+          -Djacoco.skip=true
+          -Denforcer.skip=true
+
+      - name: Run heavy quality checks (main/develop push only)
+        if: github.event_name == 'push'
+        run: >
+          mvn checkstyle:check pmd:check pmd:cpd-check spotbugs:check -T 1C
+          -Dspotless.check.skip=true
+          -Ddetekt.skip=true
+          -Djacoco.skip=true
+          -Denforcer.skip=true
 
       - name: Cache build output for downstream jobs
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -57,22 +87,87 @@ jobs:
           path: |
             platform-core/target/
             platform-persistence-jooq/target/
+            platform-persistence-jdbi/target/
             platform-sync-client/target/
             platform-security/target/
             platform-web/target/
           key: build-${{ github.sha }}
 
-      - name: Upload JaCoCo coverage reports
+  unit-tests:
+    name: Unit Tests (${{ matrix.modules }})
+    needs: build
+    runs-on: ubuntu-latest
+    environment: ci
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - modules: core+security+sync
+            pl: platform-core,platform-security,platform-sync-client
+          - modules: persistence
+            pl: platform-persistence-jooq,platform-persistence-jdbi
+          - modules: web
+            pl: platform-web
+    env:
+      GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: github-rygel
+          server-username: GITHUB_ACTOR
+          server-password: GH_PACKAGES_TOKEN
+
+      - name: Restore build output
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            platform-core/target/
+            platform-persistence-jooq/target/
+            platform-persistence-jdbi/target/
+            platform-sync-client/target/
+            platform-security/target/
+            platform-web/target/
+          key: build-${{ github.sha }}
+
+      - name: Install parent POM and dependencies
+        run: >
+          mvn install -N -q
+          && mvn install -pl platform-core,platform-security,platform-sync-client,platform-persistence-jooq,platform-persistence-jdbi
+          -DskipTests -q
+          -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true
+          -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true
+          -Djacoco.skip=true -Denforcer.skip=true
+
+      - name: Run unit tests with coverage
+        run: >
+          mvn verify -pl ${{ matrix.pl }}
+          -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true
+          -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true
+          -Dspotless.check.skip=true -Denforcer.skip=true
+
+      - name: Upload coverage reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: coverage-reports
+          name: coverage-${{ matrix.modules }}
           path: '**/target/site/jacoco/'
           retention-days: 14
 
   desktop-tests:
     name: Desktop Tests (Xvfb)
-    needs: build-and-test
+    needs: build
     runs-on: ubuntu-latest
     environment: ci
     permissions:
@@ -102,6 +197,7 @@ jobs:
           path: |
             platform-core/target/
             platform-persistence-jooq/target/
+            platform-persistence-jdbi/target/
             platform-sync-client/target/
             platform-security/target/
             platform-web/target/
@@ -110,27 +206,27 @@ jobs:
       - name: Install Xvfb
         run: sudo apt-get update -qq && sudo apt-get install -y -qq xvfb
 
-      - name: Install parent POM locally
-        run: mvn install -N -q
-
-      - name: Install cached modules
-        run: mvn install -pl platform-core,platform-persistence-jooq,platform-sync-client,platform-security -DskipTests -q
+      - name: Install parent POM and modules locally
+        run: >
+          mvn install -N -q
+          && mvn install
+          -pl platform-core,platform-persistence-jooq,platform-sync-client,platform-security
+          -DskipTests -q
+          -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true
+          -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true
+          -Djacoco.skip=true -Denforcer.skip=true
 
       - name: Run desktop tests with virtual display
         run: >
           xvfb-run --auto-servernum mvn test -pl platform-desktop
           -Ddesktop.headless=false
-          -Ddetekt.skip=true
-          -Dcheckstyle.skip=true
-          -Dpmd.skip=true
-          -Dcpd.skip=true
-          -Dspotbugs.skip=true
-          -Dspotless.apply.skip=true
+          -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true
+          -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true
           -Djacoco.skip=true
 
   e2e-tests:
     name: Playwright E2E Tests
-    needs: build-and-test
+    needs: build
     runs-on: ubuntu-latest
     environment: ci
     permissions:
@@ -160,16 +256,21 @@ jobs:
           path: |
             platform-core/target/
             platform-persistence-jooq/target/
+            platform-persistence-jdbi/target/
             platform-sync-client/target/
             platform-security/target/
             platform-web/target/
           key: build-${{ github.sha }}
 
-      - name: Install parent POM locally
-        run: mvn install -N -q
-
-      - name: Install cached modules
-        run: mvn install -pl platform-core,platform-persistence-jooq,platform-sync-client,platform-security,platform-web -DskipTests -Dexec.skip=true -q
+      - name: Install parent POM and modules locally
+        run: >
+          mvn install -N -q
+          && mvn install
+          -pl platform-core,platform-persistence-jooq,platform-sync-client,platform-security,platform-web
+          -DskipTests -Dexec.skip=true -q
+          -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true
+          -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true
+          -Djacoco.skip=true -Denforcer.skip=true
 
       - name: Run E2E tests
         run: >
@@ -177,14 +278,32 @@ jobs:
           -Dgroups=e2e
           -DexcludedGroups=
           -Denforcer.skip=true
-          -Dcheckstyle.skip=true
-          -Dpmd.skip=true
-          -Dcpd.skip=true
-          -Dspotbugs.skip=true
-          -Dspotless.apply.skip=true
-          -Djacoco.skip=true
-          -Ddetekt.skip=true
-          -Dexec.skip=true
+          -Dcheckstyle.skip=true -Dpmd.skip=true -Dcpd.skip=true
+          -Dspotbugs.skip=true -Dspotless.apply.skip=true
+          -Djacoco.skip=true -Ddetekt.skip=true -Dexec.skip=true
+
+  coverage:
+    name: Coverage Report
+    needs: unit-tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: always()
+
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: coverage-*
+          path: coverage-reports
+          merge-multiple: true
+
+      - name: Upload merged coverage reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-reports
+          path: coverage-reports/
+          retention-days: 14
 
   security:
     name: Security (OWASP + Enforcer)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build and Quality Gate
+    name: Build, Test, and Quality
     runs-on: ubuntu-latest
     environment: ci
     permissions:


### PR DESCRIPTION
## Summary

- **Split monolithic build+test job into parallel pipeline**: Build gate, then 3 parallel unit-test matrix shards + desktop tests + E2E tests, all running simultaneously
- **Skip heavy quality checks on PRs**: Only Spotless + Detekt run on PRs (~3m build); Checkstyle, PMD, SpotBugs run only on push to main/develop
- **Docker layer caching**: Docker E2E uses Buildx with GHA cache for persistent layer cache across runs
- **Better Maven caching**: dependency:go-offline warms cache, added missing platform-persistence-jdbi/target/ to build output cache, all quality plugins skipped in downstream install steps

## Expected wall-clock improvement

| Scenario | Before | After |
|----------|--------|-------|
| PR | ~10m30s | ~4-5m |
| Push to main/develop | ~10m30s | ~5-6m |
| Docker E2E (repeat) | ~21m | ~12-15m |

## Pipeline architecture

Build + Quality Gate (3m PR, 4.5m push) -> Unit Tests (3 parallel matrix shards) + Desktop Tests (Xvfb) + E2E Tests (Playwright) -> Coverage Report