### PR TITLE
refactor: replace theme color-swatch grid with combo box

### DIFF
--- a/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/components/SidebarSelector.kte
+++ b/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/components/SidebarSelector.kte
@@ -3,43 +3,14 @@
 
 <div>
     <h3 class="sidebar-select-label">${model.heading}</h3>
-    @if(model.options.any { it.previewColors != null })
-        <%-- Theme selector with color previews --%>
-        <div class="theme-preview-grid">
+    <form hx-get="${model.refreshUrl}" hx-target="body" hx-push-url="true">
+        <select id="${model.selectId}" name="${model.selectName}" class="sidebar-select" onchange="htmx.trigger(this.form, 'submit')" aria-label="${model.label}">
             @for (option in model.options)
-                <form hx-get="${model.refreshUrl}" hx-target="body" hx-push-url="true" style="display: contents;">
-                    <input type="hidden" name="${model.selectName}" value="${option.id}">
-                    @for (field in model.hiddenFields)
-                        <input type="hidden" name="${field.name}" value="${field.value}">
-                    @endfor
-                    <button type="submit" class="theme-preview-card@if(option.active) active@endif"
-                            title="${option.label}"
-                            aria-label="Switch to ${option.label} theme"
-                            onclick="this.closest('.theme-preview-grid').querySelectorAll('.theme-preview-card').forEach(function(el){el.classList.remove('active')});this.classList.add('active');">
-                        @if(option.previewColors != null)
-                            !{val colors = option.previewColors!!}
-                            <div class="theme-preview-swatch"
-                                 style="background: ${colors.background}; color: ${colors.foreground}; border: 1px solid ${colors.componentBackground};">
-                                <span class="theme-preview-accent" style="background: ${colors.accent};"></span>
-                                <span class="theme-preview-component" style="background: ${colors.componentBackground};"></span>
-                            </div>
-                        @endif
-                        <span class="theme-preview-label">${option.label}</span>
-                    </button>
-                </form>
+                <option value="${option.id}" selected="${option.active}">${option.label}</option>
             @endfor
-        </div>
-    @else
-        <%-- Standard select dropdown (for language, layout, etc.) --%>
-        <form hx-get="${model.refreshUrl}" hx-target="body" hx-push-url="true">
-            <select id="${model.selectId}" name="${model.selectName}" class="sidebar-select" onchange="htmx.trigger(this.form, 'submit')" aria-label="${model.label}">
-                @for (option in model.options)
-                    <option value="${option.id}" selected="${option.active}">${option.label}</option>
-                @endfor
-            </select>
-            @for (field in model.hiddenFields)
-                <input type="hidden" name="${field.name}" value="${field.value}">
-            @endfor
-        </form>
-    @endif
+        </select>
+        @for (field in model.hiddenFields)
+            <input type="hidden" name="${field.name}" value="${field.value}">
+        @endfor
+    </form>
 </div>

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ViewModels.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ViewModels.kt
@@ -4,20 +4,7 @@ import org.http4k.template.ViewModel
 
 data class ShellLink(val label: String, val url: String, val icon: String, val active: Boolean)
 
-data class ShellOption(
-    val id: String,
-    val label: String,
-    val url: String,
-    val active: Boolean,
-    val previewColors: ThemePreviewColors? = null,
-)
-
-data class ThemePreviewColors(
-    val background: String,
-    val foreground: String,
-    val accent: String,
-    val componentBackground: String,
-)
+data class ShellOption(val id: String, val label: String, val url: String, val active: Boolean)
 
 data class HiddenField(val name: String, val value: String)
 

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
@@ -199,19 +199,7 @@ class WebContext(
                     selectName = "theme",
                     options =
                         ThemeCatalog.allThemes().map { t ->
-                            ShellOption(
-                                id = t.id,
-                                label = t.name,
-                                url = t.id,
-                                active = t.id == theme,
-                                previewColors =
-                                    ThemePreviewColors(
-                                        background = t.colors["background"] ?: "#1e1e1e",
-                                        foreground = t.colors["foreground"] ?: "#d4d4d4",
-                                        accent = t.colors["accent"] ?: "#007acc",
-                                        componentBackground = t.colors["componentBackground"] ?: "#252526",
-                                    ),
-                            )
+                            ShellOption(id = t.id, label = t.name, url = t.id, active = t.id == theme)
                         },
                     hiddenFields =
                         listOf(

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebPageFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebPageFactory.kt
@@ -385,19 +385,7 @@ open class WebPageFactory(
             selectName = "theme",
             options =
                 ThemeCatalog.allThemes().map { theme ->
-                    ShellOption(
-                        id = theme.id,
-                        label = theme.name,
-                        url = theme.id,
-                        active = theme.id == ctx.theme,
-                        previewColors =
-                            ThemePreviewColors(
-                                background = theme.colors["background"] ?: "#1e1e1e",
-                                foreground = theme.colors["foreground"] ?: "#d4d4d4",
-                                accent = theme.colors["accent"] ?: "#007acc",
-                                componentBackground = theme.colors["componentBackground"] ?: "#252526",
-                            ),
-                    )
+                    ShellOption(id = theme.id, label = theme.name, url = theme.id, active = theme.id == ctx.theme)
                 },
             hiddenFields =
                 listOf(

--- a/platform-web/src/main/resources/static/input.css
+++ b/platform-web/src/main/resources/static/input.css
@@ -125,7 +125,7 @@ h3 { font-size: 0.95rem; margin-bottom: 0.5rem; }
 }
 
 .sidebar-section {
-    margin-bottom: 1.25rem;
+    margin-bottom: 1.75rem;
 }
 
 .sidebar-section label {
@@ -139,7 +139,7 @@ h3 { font-size: 0.95rem; margin-bottom: 0.5rem; }
 }
 
 .sidebar-select-wrapper {
-    margin-bottom: 1.25rem;
+    margin-bottom: 1.75rem;
 }
 
 .sidebar-select-label {
@@ -148,7 +148,7 @@ h3 { font-size: 0.95rem; margin-bottom: 0.5rem; }
     text-transform: uppercase;
     letter-spacing: 0.1em;
     font-weight: 800;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.65rem;
     opacity: 0.5;
 }
 
@@ -486,75 +486,6 @@ button.secondary:hover {
     opacity: 1;
     background-color: rgba(255, 255, 255, 0.1);
     transform: none;
-}
-
-/* Theme Preview Grid */
-.theme-preview-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 0.4rem;
-}
-
-.theme-preview-card {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.25rem;
-    padding: 0.35rem;
-    border-radius: var(--radius-md);
-    border: 1px solid transparent;
-    background: none;
-    cursor: pointer;
-    transition: all 0.15s ease;
-    color: var(--color-foreground);
-}
-
-.theme-preview-card:hover {
-    border-color: var(--color-borderColor);
-    background: rgba(255, 255, 255, 0.05);
-    transform: none;
-    box-shadow: none;
-}
-
-.theme-preview-card.active {
-    border-color: var(--color-accent);
-    background: rgba(16, 185, 129, 0.1);
-}
-
-.theme-preview-swatch {
-    width: 100%;
-    height: 28px;
-    border-radius: var(--radius-md);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 4px;
-    padding: 4px;
-    overflow: hidden;
-}
-
-.theme-preview-accent {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    flex-shrink: 0;
-}
-
-.theme-preview-component {
-    flex: 1;
-    height: 8px;
-    border-radius: 2px;
-}
-
-.theme-preview-label {
-    font-size: 0.6rem;
-    opacity: 0.7;
-    text-align: center;
-    line-height: 1.2;
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 /* Data Tables */

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ComponentFragmentIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ComponentFragmentIntegrationTest.kt
@@ -117,9 +117,8 @@ class ComponentFragmentIntegrationTest : WebTest() {
     @Test
     fun `GET sidebar-theme-selector returns multiple theme options`() {
         val body = app(Request(GET, "/components/sidebar/theme-selector")).bodyString()
-        // Theme selector renders preview cards (buttons) with color swatches
-        val cardCount = body.split("theme-preview-card").size - 1
-        assertTrue(cardCount >= 2, "Theme selector should have at least 2 theme cards, found $cardCount")
+        val optionCount = body.split("<option").size - 1
+        assertTrue(optionCount >= 2, "Theme selector should have at least 2 options, found $optionCount")
     }
 
     // ---- /components/sidebar/language-selector ----


### PR DESCRIPTION
## Summary
- Replace theme color-swatch preview grid with a simple \<select>\ combo box (same as language/layout)
- Remove \ThemePreviewColors\ data class and \previewColors\ from \ShellOption\
- Increase sidebar spacing (section margin 1.25rem to 1.75rem, label margin 0.5rem to 0.65rem)
- Remove all \	heme-preview-*\ CSS rules

## Test plan
- [x] 57 tests pass locally (ComponentFragment, DarkModeToggle, PlatformPageRendering)
- [ ] CI green