### PR TITLE
fix: use GITHUB_TOKEN for publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,8 @@ jobs:
           server-id: github-rygel
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js 20
         if: steps.check.outputs.exists == 'false'

--- a/platform-desktop/src/test/kotlin/io/github/rygel/outerstellar/platform/swing/SwingAppE2ETest.kt
+++ b/platform-desktop/src/test/kotlin/io/github/rygel/outerstellar/platform/swing/SwingAppE2ETest.kt
@@ -131,7 +131,7 @@ class SwingAppE2ETest {
     fun `changing theme from settings updates key ui surfaces`() {
         val w = window!!
 
-        w.menuItem("settingsItem").click()
+        clickMenuItemThroughMenu(w, "settingsItem")
         w.dialog().comboBox("themeCombo").selectItem("Dark")
         w.dialog().button("applyButton").click()
 
@@ -141,7 +141,7 @@ class SwingAppE2ETest {
 
         assertThemeApplied(w, "Dark")
 
-        w.menuItem("settingsItem").click()
+        clickMenuItemThroughMenu(w, "settingsItem")
         w.dialog().comboBox("themeCombo").selectItem("Light")
         w.dialog().button("applyButton").click()
 
@@ -150,6 +150,18 @@ class SwingAppE2ETest {
         }
 
         assertThemeApplied(w, "Light")
+    }
+
+    private fun clickMenuItemThroughMenu(w: FrameFixture, menuItemName: String) {
+        val menu = GuiActionRunner.execute<javax.swing.JMenu> {
+            val rootMenu = (w.target() as JFrame).jMenuBar.getMenu(0)
+            rootMenu.isSelected = false
+            rootMenu.popup?.isVisible = false
+            rootMenu
+        }!!
+        w.menuItem(menu.name).click()
+        Thread.sleep(150)
+        w.menuItem(menuItemName).click()
     }
 
     private fun waitUntil(timeoutMs: Long, condition: BooleanSupplier) {

--- a/platform-desktop/src/test/kotlin/io/github/rygel/outerstellar/platform/swing/SwingAppE2ETest.kt
+++ b/platform-desktop/src/test/kotlin/io/github/rygel/outerstellar/platform/swing/SwingAppE2ETest.kt
@@ -156,7 +156,7 @@ class SwingAppE2ETest {
         val menu = GuiActionRunner.execute<javax.swing.JMenu> {
             val rootMenu = (w.target() as JFrame).jMenuBar.getMenu(0)
             rootMenu.isSelected = false
-            rootMenu.popup?.isVisible = false
+            rootMenu.popupMenu.isVisible = false
             rootMenu
         }!!
         w.menuItem(menu.name).click()


### PR DESCRIPTION
## Summary
- Switch publish workflow from `GH_PACKAGES_TOKEN` (custom secret) to the built-in `GITHUB_TOKEN`
- The `GH_PACKAGES_TOKEN` has been returning 401 Unauthorized on every push-to-main publish (v1.5.0, v1.4.2, v1.4.1 all failed the same way)
- The built-in `GITHUB_TOKEN` with `packages: write` permission works reliably without any custom secret maintenance