### PR TITLE
feat(security): add AdminStatsService with newUsersLast30Days

### DIFF
--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepository.kt
@@ -211,6 +211,15 @@ class JdbiUserRepository(private val jdbi: Jdbi) : UserRepository {
         }
     }
 
+    override fun countUsersSince(cutoff: LocalDateTime): Long =
+        jdbi.withHandle<Long, Exception> { handle ->
+            handle
+                .createQuery("SELECT COUNT(*) FROM plt_users WHERE created_at >= :cutoff")
+                .bind("cutoff", cutoff)
+                .mapTo(Long::class.java)
+                .one()
+        }
+
     private fun mapUser(rs: java.sql.ResultSet): User {
         val lastActivity = rs.getTimestamp("last_activity_at")
         return User(

--- a/platform-persistence-jdbi/src/main/resources/db/migration/V6__admin_stats_indexes.sql
+++ b/platform-persistence-jdbi/src/main/resources/db/migration/V6__admin_stats_indexes.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_plt_users_created_at ON plt_users (created_at);

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepositoryStatsTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepositoryStatsTest.kt
@@ -1,0 +1,75 @@
+package io.github.rygel.outerstellar.platform.persistence
+
+import java.time.LocalDateTime
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JdbiUserRepositoryStatsTest : JdbiTest() {
+
+    private val repo by lazy { JdbiUserRepository(jdbi) }
+
+    private fun insertUser(username: String, createdAt: LocalDateTime) {
+        jdbi.useHandle<Exception> { handle ->
+            handle.execute(
+                "INSERT INTO plt_users (id, username, email, password_hash, role, enabled, created_at) VALUES (?, ?, ?, ?, 'USER', true, ?)",
+                UUID.randomUUID(),
+                username,
+                "$username@example.com",
+                "hash_$username",
+                createdAt,
+            )
+        }
+    }
+
+    @Test
+    fun `countUsersSince returns only users created after cutoff`() {
+        val oldDate = LocalDateTime.of(2024, 1, 1, 0, 0)
+        val recentDate = LocalDateTime.of(2025, 5, 1, 0, 0)
+        val cutoff = LocalDateTime.of(2025, 4, 1, 0, 0)
+
+        insertUser("stats_old1", oldDate)
+        insertUser("stats_old2", oldDate.plusDays(10))
+        insertUser("stats_recent1", recentDate)
+        insertUser("stats_recent2", recentDate.plusDays(5))
+
+        assertEquals(2L, repo.countUsersSince(cutoff))
+    }
+
+    @Test
+    fun `countUsersSince returns zero when all users are older`() {
+        insertUser("stats_ancient", LocalDateTime.of(2020, 1, 1, 0, 0))
+
+        assertEquals(0L, repo.countUsersSince(LocalDateTime.of(2025, 1, 1, 0, 0)))
+    }
+
+    @Test
+    fun `countUsersSince returns all users when cutoff is in the past`() {
+        insertUser("stats_user1", LocalDateTime.of(2024, 6, 1, 0, 0))
+        insertUser("stats_user2", LocalDateTime.of(2024, 8, 1, 0, 0))
+
+        assertEquals(2L, repo.countUsersSince(LocalDateTime.of(2023, 1, 1, 0, 0)))
+    }
+
+    @Test
+    fun `countUsersSince with empty table returns zero`() {
+        assertEquals(0L, repo.countUsersSince(LocalDateTime.of(2020, 1, 1, 0, 0)))
+    }
+
+    @Test
+    fun `countUsersSince includes user created exactly at cutoff`() {
+        val cutoff = LocalDateTime.of(2025, 5, 1, 12, 0)
+        insertUser("stats_exact", cutoff)
+
+        assertEquals(1L, repo.countUsersSince(cutoff))
+    }
+
+    @Test
+    fun `countAll returns total user count`() {
+        insertUser("stats_count1", LocalDateTime.of(2024, 1, 1, 0, 0))
+        insertUser("stats_count2", LocalDateTime.of(2025, 1, 1, 0, 0))
+        insertUser("stats_count3", LocalDateTime.of(2025, 5, 1, 0, 0))
+
+        assertEquals(3L, repo.countAll())
+    }
+}

--- a/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepository.kt
+++ b/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepository.kt
@@ -129,4 +129,12 @@ class JooqUserRepository(private val dsl: DSLContext) : UserRepository {
             .where(PLT_USERS.ID.eq(userId))
             .execute()
     }
+
+    override fun countUsersSince(cutoff: LocalDateTime): Long {
+        val cutoffOffset = cutoff.atZone(ZoneOffset.UTC).toOffsetDateTime()
+        return dsl.selectCount()
+            .from(PLT_USERS)
+            .where(PLT_USERS.CREATED_AT.ge(cutoffOffset))
+            .fetchOne(0, Long::class.java) ?: 0L
+    }
 }

--- a/platform-persistence-jooq/src/main/resources/db/migration/V6__admin_stats_indexes.sql
+++ b/platform-persistence-jooq/src/main/resources/db/migration/V6__admin_stats_indexes.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_plt_users_created_at ON plt_users (created_at);

--- a/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepositoryStatsTest.kt
+++ b/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepositoryStatsTest.kt
@@ -1,0 +1,83 @@
+package io.github.rygel.outerstellar.platform.persistence
+
+import io.github.rygel.outerstellar.platform.security.User
+import io.github.rygel.outerstellar.platform.security.UserRole
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JooqUserRepositoryStatsTest : JooqTest() {
+
+    private val repo by lazy { JooqUserRepository(dsl) }
+
+    private fun insertUser(username: String, createdAt: LocalDateTime) {
+        val id = UUID.randomUUID()
+        repo.save(
+            User(
+                id = id,
+                username = username,
+                email = "$username@example.com",
+                passwordHash = "hash_$username",
+                role = UserRole.USER,
+            )
+        )
+        dsl.execute(
+            "UPDATE plt_users SET created_at = ? WHERE id = ?",
+            java.sql.Timestamp.from(createdAt.toInstant(ZoneOffset.UTC)),
+            id,
+        )
+    }
+
+    @Test
+    fun `countUsersSince returns only users created after cutoff`() {
+        val oldDate = LocalDateTime.of(2024, 1, 1, 0, 0)
+        val recentDate = LocalDateTime.of(2025, 5, 1, 0, 0)
+        val cutoff = LocalDateTime.of(2025, 4, 1, 0, 0)
+
+        insertUser("stats_old1", oldDate)
+        insertUser("stats_old2", oldDate.plusDays(10))
+        insertUser("stats_recent1", recentDate)
+        insertUser("stats_recent2", recentDate.plusDays(5))
+
+        assertEquals(2L, repo.countUsersSince(cutoff))
+    }
+
+    @Test
+    fun `countUsersSince returns zero when all users are older`() {
+        insertUser("stats_ancient", LocalDateTime.of(2020, 1, 1, 0, 0))
+
+        assertEquals(0L, repo.countUsersSince(LocalDateTime.of(2025, 1, 1, 0, 0)))
+    }
+
+    @Test
+    fun `countUsersSince returns all users when cutoff is in the past`() {
+        insertUser("stats_user1", LocalDateTime.of(2024, 6, 1, 0, 0))
+        insertUser("stats_user2", LocalDateTime.of(2024, 8, 1, 0, 0))
+
+        assertEquals(2L, repo.countUsersSince(LocalDateTime.of(2023, 1, 1, 0, 0)))
+    }
+
+    @Test
+    fun `countUsersSince with empty table returns zero`() {
+        assertEquals(0L, repo.countUsersSince(LocalDateTime.of(2020, 1, 1, 0, 0)))
+    }
+
+    @Test
+    fun `countUsersSince includes user created exactly at cutoff`() {
+        val cutoff = LocalDateTime.of(2025, 5, 1, 12, 0)
+        insertUser("stats_exact", cutoff)
+
+        assertEquals(1L, repo.countUsersSince(cutoff))
+    }
+
+    @Test
+    fun `countAll returns total user count`() {
+        insertUser("stats_count1", LocalDateTime.of(2024, 1, 1, 0, 0))
+        insertUser("stats_count2", LocalDateTime.of(2025, 1, 1, 0, 0))
+        insertUser("stats_count3", LocalDateTime.of(2025, 5, 1, 0, 0))
+
+        assertEquals(3L, repo.countAll())
+    }
+}

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AdminStatsService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AdminStatsService.kt
@@ -1,0 +1,10 @@
+package io.github.rygel.outerstellar.platform.security
+
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+class AdminStatsService(private val userRepository: UserRepository) {
+    fun newUsersLast30Days(): Long = userRepository.countUsersSince(LocalDateTime.now(ZoneOffset.UTC).minusDays(30))
+
+    fun totalUsers(): Long = userRepository.countAll()
+}

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/Models.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/Models.kt
@@ -1,6 +1,7 @@
 package io.github.rygel.outerstellar.platform.security
 
 import java.time.Instant
+import java.time.LocalDateTime
 import java.util.UUID
 
 enum class UserRole {
@@ -58,6 +59,8 @@ interface UserRepository {
     fun updateNotificationPreferences(userId: UUID, emailEnabled: Boolean, pushEnabled: Boolean)
 
     fun updatePreferences(userId: UUID, language: String?, theme: String?, layout: String?)
+
+    fun countUsersSince(cutoff: LocalDateTime): Long
 }
 
 interface PasswordResetRepository {

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AdminStatsServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AdminStatsServiceTest.kt
@@ -1,0 +1,63 @@
+package io.github.rygel.outerstellar.platform.security
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.BeforeEach
+
+class AdminStatsServiceTest {
+
+    private lateinit var userRepository: UserRepository
+    private lateinit var service: AdminStatsService
+
+    @BeforeEach
+    fun setup() {
+        userRepository = mockk(relaxed = true)
+        service = AdminStatsService(userRepository)
+    }
+
+    @Test
+    fun `newUsersLast30Days delegates to countUsersSince with 30-day cutoff`() {
+        every { userRepository.countUsersSince(any()) } returns 5L
+
+        val result = service.newUsersLast30Days()
+
+        assertEquals(5L, result)
+        verify {
+            userRepository.countUsersSince(
+                match { cutoff ->
+                    val expectedCutoff = LocalDateTime.now(ZoneOffset.UTC).minusDays(30)
+                    cutoff.isAfter(expectedCutoff.minusSeconds(2)) && cutoff.isBefore(expectedCutoff.plusSeconds(2))
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `newUsersLast30Days returns zero when no recent users`() {
+        every { userRepository.countUsersSince(any()) } returns 0L
+
+        assertEquals(0L, service.newUsersLast30Days())
+    }
+
+    @Test
+    fun `totalUsers delegates to countAll`() {
+        every { userRepository.countAll() } returns 42L
+
+        val result = service.totalUsers()
+
+        assertEquals(42L, result)
+        verify { userRepository.countAll() }
+    }
+
+    @Test
+    fun `totalUsers returns zero when no users exist`() {
+        every { userRepository.countAll() } returns 0L
+
+        assertEquals(0L, service.totalUsers())
+    }
+}

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/AdminWebModule.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/AdminWebModule.kt
@@ -2,6 +2,7 @@ package io.github.rygel.outerstellar.platform.di
 
 import io.github.rygel.outerstellar.platform.persistence.JooqNotificationRepository
 import io.github.rygel.outerstellar.platform.persistence.NotificationRepository
+import io.github.rygel.outerstellar.platform.security.AdminStatsService
 import io.github.rygel.outerstellar.platform.service.NotificationService
 import io.github.rygel.outerstellar.platform.web.AdminPageFactory
 import org.koin.dsl.module
@@ -11,4 +12,5 @@ val adminWebModule
         single<NotificationRepository> { JooqNotificationRepository(get()) }
         single { NotificationService(get()) }
         single { AdminPageFactory(get(), get()) }
+        single { AdminStatsService(get()) }
     }


### PR DESCRIPTION
## Summary
- Add `AdminStatsService` with `newUsersLast30Days()` and `totalUsers()` for dashboard statistics
- Add `UserRepository.countUsersSince(cutoff)` to interface + JDBI + jOOQ implementations
- Add `V6__admin_stats_indexes.sql` migration for `plt_users(created_at)` index
- Wire `AdminStatsService` in `AdminWebModule`
- 4 unit tests + 12 integration tests (6 JDBI + 6 jOOQ)

Closes #212