### PR TITLE
chore(deps): bump http4k, opentelemetry, angus-mail, assertj-core

### DIFF
--- a/platform-desktop-javafx/pom.xml
+++ b/platform-desktop-javafx/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.27.3</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/viewmodel/SyncViewModel.kt
+++ b/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/viewmodel/SyncViewModel.kt
@@ -114,6 +114,10 @@ class SyncViewModel(
                 }
 
                 override fun onSessionExpired() {
+                    val s = engine.state
+                    isLoggedIn = s.isLoggedIn
+                    userName = s.userName
+                    userRole = s.userRole
                     status = i18nService.translate("swing.session.expired")
                     notifyObservers()
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <kotlin.version>2.3.10</kotlin.version>
         <outerstellar.version>1.0.14</outerstellar.version>
-        <http4k.version>6.46.0.0</http4k.version>
+        <http4k.version>6.46.1.0</http4k.version>
         <netty.version>4.2.13.Final</netty.version>
         <flyway.version>12.6.0</flyway.version>
         <postgresql.version>42.7.11</postgresql.version>
@@ -89,7 +89,7 @@
         <micrometer.version>1.16.5</micrometer.version>
         <resilience4j.version>2.4.0</resilience4j.version>
         <caffeine.version>3.2.4</caffeine.version>
-        <opentelemetry.version>1.61.0</opentelemetry.version>
+        <opentelemetry.version>1.62.0</opentelemetry.version>
 
         <jackson.version>2.21.3</jackson.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -97,7 +97,7 @@
         <jbcrypt.version>0.4</jbcrypt.version>
         <java-jwt.version>4.5.2</java-jwt.version>
         <hikaricp.version>7.0.2</hikaricp.version>
-        <angus.mail.version>2.0.4</angus.mail.version>
+        <angus.mail.version>2.0.5</angus.mail.version>
         <jakarta.mail.api.version>2.1.5</jakarta.mail.api.version>
         <jakarta.activation.api.version>2.1.4</jakarta.activation.api.version>
         <playwright.version>1.59.0</playwright.version>


### PR DESCRIPTION
## Summary
- Bump http4k 6.46.0.0 → 6.46.1.0
- Bump OpenTelemetry 1.61.0 → 1.62.0
- Bump angus-mail 2.0.4 → 2.0.5
- Bump assertj-core 3.27.3 → 3.27.7 (fixes CVE-2026-24400 XXE in `isXmlEqualTo`)
- Fix desktop `SyncViewModel.onSessionExpired()` race condition — sync `isLoggedIn`/`userName`/`userRole` from engine state to prevent flaky test failure in CI
- Kotlin 2.3.10 intentionally **not** bumped — detekt 1.23.8 only supports up to Kotlin 2.0.21; would need detekt 2.0.0-alpha (breaking changes)

Full `mvn clean verify` passed (excluding desktop). Desktop tests passed in Podman (126 tests, 0 failures).