### PR TITLE
chore(deps): bump ktfmt 0.61 → 0.62

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <pmd.version>3.28.0</pmd.version>
         <spotbugs.version>4.9.8.3</spotbugs.version>
         <spotless.version>3.4.0</spotless.version>
-        <ktfmt.version>0.61</ktfmt.version>
+        <ktfmt.version>0.62</ktfmt.version>
         <jacoco.version>0.8.14</jacoco.version>
         <extra-enforcer-rules.version>1.12.0</extra-enforcer-rules.version>
         <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>


### PR DESCRIPTION
## Summary
- Bump ktfmt 0.61 → 0.62 for Kotlin 2.3.20+ compatibility (adds `CONTEXT_PARAMETER_LIST` handling)
- Checked plugin updates — all others up to date; native-maven-plugin 1.1.0 available but skipped (major bump)
- Full `mvn clean verify` passed; desktop tests passed in Podman (126 tests, 0 failures)