### PR TITLE
fix(security): sanitize API errors, drop CORS wildcard, fix async, add JWT warning, fix deps

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,9 +20,9 @@ Architecture, security, and maintainability improvements identified during code 
   Token is sent as `?token=$tokenValue` in the reset link, leaking via Referer header, browser history, and server logs. Should use POST-based submission.
   — `platform-security/.../security/PasswordResetService.kt:38`
 
-- [ ] **Session cookie `Secure` flag defaults to `false`**
-  The `sessionCookieSecure` config defaults to `false`, transmitting session cookies over unencrypted HTTP. Should default to `true` for production profiles.
-  — `platform-core/.../AppConfig.kt:49`
+- [x] ~~**Session cookie `Secure` flag defaults to `false`**~~
+  Fixed — both the data class default and YAML/env fallback now default to `true`.
+  — `platform-core/.../AppConfig.kt:51`
 
 ### Hardcoded Values
 
@@ -54,33 +54,27 @@ Architecture, security, and maintainability improvements identified during code 
 
 ### Security
 
-- [ ] **Invalidate all user sessions on password change**
-  When a user changes their password, existing sessions remain valid. An attacker who compromised a session can continue using it even after the password is changed.
-  — `platform-security/.../security/SecurityService.kt:109-123`
+- [x] ~~**Invalidate all user sessions on password change**~~
+  Fixed in PR #229 — `sessionRepository?.deleteByUserId()` called in `changePassword()`.
 
 - [ ] **Add dependency vulnerability scanning to CI**
   No OWASP Dependency-Check, Snyk, or Dependabot is configured. Dependency vulnerabilities go undetected.
   — CI pipeline, `.github/dependabot.yml` (missing)
 
-- [ ] **Persist authentication failures to audit table**
-  Failed login attempts are only logged via SLF4J, not persisted. This makes forensic analysis harder.
-  — `platform-security/.../security/SecurityService.kt:59-83`
+- [x] ~~**Persist authentication failures to audit table**~~
+  Fixed in PR #229 — `AUTHENTICATION_FAILED` entries for all failure paths.
 
-- [ ] **Add audit logging for API key operations**
-  `ApiKeyService` creates and deletes API keys without calling `audit()`.
-  — `platform-security/.../security/ApiKeyService.kt`
+- [x] ~~**Add audit logging for API key operations**~~
+  Fixed in PR #229 — `API_KEY_CREATED` and `API_KEY_DELETED` audit entries.
 
-- [ ] **Add SameSite/Secure flags to preference cookies**
-  `app_lang`, `app_theme`, `app_layout`, `app_shell` cookies are created without `SameSite`, `Secure`, or `HttpOnly` flags.
-  — `platform-web/.../web/Filters.kt:284-299`
+- [x] ~~**Add SameSite/Secure flags to preference cookies**~~
+  Fixed in PR #229 — `SameSite.Strict` + configurable `Secure` flag via `sessionCookieSecure`.
 
-- [ ] **CSP `connect-src` allows `ws:` (unencrypted WebSocket)**
-  Should be `wss:` only in production to match HSTS policy.
-  — `platform-web/.../web/Filters.kt:41-47`
+- [x] ~~**CSP `connect-src` allows `ws:` (unencrypted WebSocket)**~~
+  Fixed in PR #229 — removed `ws:`, only `wss:` remains.
 
-- [ ] **CSP missing `base-uri` and `form-action` directives**
-  Add `base-uri 'self'; form-action 'self'` for defense-in-depth against base-tag hijacking and form submission to external sites.
-  — `platform-web/.../web/Filters.kt:41-47`
+- [x] ~~**CSP missing `base-uri` and `form-action` directives**~~
+  Fixed in PR #229 — added `base-uri 'self'; form-action 'self'`.
 
 - [ ] **Login rate limiting is per-IP, not per-account**
   Attacker can brute-force a single account through IP rotation.
@@ -248,6 +242,16 @@ Integrate [fragments4k](https://github.com/rygel/fragments4k) (v0.6.5+) for SEO 
 ---
 
 ## Completed
+
+- [x] **Invalidate all user sessions on password change** (PR #229)
+- [x] **Persist authentication failures to audit table** (PR #229)
+- [x] **Add audit logging for API key operations** (PR #229)
+- [x] **Add SameSite/Secure flags to preference cookies** (PR #229)
+- [x] **Harden CSP: base-uri, form-action, remove ws:** (PR #229)
+- [x] **Session cookie `Secure` flag defaults to `true`**
+- [x] **Account lockout after failed logins** (PR #227)
+- [x] **HSTS header** (PR #225)
+- [x] **SSRF protection for IPv6, DNS rebinding** (PR #225)
 
 - [x] **Targeted cache invalidation in `MessageService`**
   — `platform-core/.../service/MessageService.kt` lines 129–130, 150–152, 197, 207–208, 240–242, 276–278

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
@@ -108,7 +108,7 @@ data class AppConfig(
                 devMode = yaml.bool("devMode", env, "DEVMODE", false),
                 sessionCookieSecure = yaml.bool("sessionCookieSecure", env, "SESSIONCOOKIESECURE", true),
                 sessionTimeoutMinutes = timeout,
-                corsOrigins = yaml.str("corsOrigins", env, "CORSORIGINS", "*"),
+                corsOrigins = yaml.str("corsOrigins", env, "CORSORIGINS", ""),
                 csrfEnabled = yaml.bool("csrfEnabled", env, "CSRFENABLED", true),
                 segment = buildSegmentConfig(yaml["segment"] as? Map<String, Any>, env),
                 email = buildEmailConfig(yaml["email"] as? Map<String, Any>, env),

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/analytics/SegmentAnalyticsService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/analytics/SegmentAnalyticsService.kt
@@ -82,10 +82,18 @@ class SegmentAnalyticsService(writeKey: String) : AnalyticsService {
                     .header("Authorization", authHeader)
                     .POST(HttpRequest.BodyPublishers.ofString(json.encodeToString(JsonObject.serializer(), payload)))
                     .build()
-            client.sendAsync(request, HttpResponse.BodyHandlers.discarding()).exceptionally { e ->
-                logger.warn("Segment {} call failed: {}", endpoint, e.message)
-                null
-            }
+            Thread(
+                    {
+                        try {
+                            client.send(request, HttpResponse.BodyHandlers.discarding())
+                        } catch (e: Exception) {
+                            logger.warn("Segment {} call failed: {}", endpoint, e.message)
+                        }
+                    },
+                    "segment-analytics",
+                )
+                .also { it.isDaemon = true }
+                .start()
         } catch (e: IOException) {
             logger.warn("Segment analytics IO error on {}: {}", endpoint, e.message)
         }

--- a/platform-desktop-javafx/pom.xml
+++ b/platform-desktop-javafx/pom.xml
@@ -25,6 +25,10 @@
         </dependency>
         <dependency>
             <groupId>io.github.rygel</groupId>
+            <artifactId>outerstellar-platform-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.rygel</groupId>
             <artifactId>outerstellar-platform-sync-client</artifactId>
         </dependency>
         <dependency>

--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -24,6 +24,10 @@
         </dependency>
         <dependency>
             <groupId>io.github.rygel</groupId>
+            <artifactId>outerstellar-platform-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.rygel</groupId>
             <artifactId>outerstellar-platform-sync-client</artifactId>
         </dependency>
         <dependency>

--- a/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/viewmodel/SyncViewModel.kt
+++ b/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/viewmodel/SyncViewModel.kt
@@ -114,10 +114,9 @@ class SyncViewModel(
                 }
 
                 override fun onSessionExpired() {
-                    val s = engine.state
-                    isLoggedIn = s.isLoggedIn
-                    userName = s.userName
-                    userRole = s.userRole
+                    isLoggedIn = false
+                    userName = ""
+                    userRole = null
                     status = i18nService.translate("swing.session.expired")
                     notifyObservers()
                 }

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/JwtService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/JwtService.kt
@@ -15,6 +15,12 @@ private val logger = LoggerFactory.getLogger("outerstellar.JwtService")
 
 class JwtService(private val config: JwtConfig) {
 
+    init {
+        if (config.enabled && config.secret.isBlank()) {
+            logger.warn("JWT is enabled but secret is blank — JWT authentication will be disabled")
+        }
+    }
+
     /** True only when JWT is enabled and a secret is configured. */
     val isEnabled: Boolean
         get() = config.enabled && config.secret.isNotBlank()

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -481,7 +481,10 @@ object Filters {
         logger.error("Error handling request {}: {}", request.uri, e.message, e)
 
         return if (request.uri.path.startsWith("/api/")) {
-            jsonErrorResponse(status, e.message ?: "An unexpected error occurred", request)
+            val safeMessage =
+                if (e is OuterstellarException) e.message ?: "An unexpected error occurred"
+                else "An unexpected error occurred"
+            jsonErrorResponse(status, safeMessage, request)
         } else if (request.header("HX-Request") == "true") {
             val safeMessage = if (e is OuterstellarException) e.message ?: "Action failed" else "Action failed"
             Response(status).body(safeMessage)


### PR DESCRIPTION
## Summary

- **Sanitize API error messages** — non-`OuterstellarException` errors no longer leak `e.message` in JSON responses (prevents SQL/file path disclosure)
- **Drop CORS wildcard default** — `corsOrigins` fallback changed from `"*"` to `""` (no CORS headers by default; operators must explicitly configure allowed origins)
- **Replace `sendAsync` with sync + daemon thread** in `SegmentAnalyticsService` — aligns with project's synchronous-only architecture
- **Add JWT secret startup warning** — logs a warning when JWT is enabled but the secret is blank
- **Declare `platform-core` as explicit dependency** in `platform-desktop` and `platform-desktop-javafx` pom.xml
- **Update TODO.md** — mark items fixed in PR #229 as completed

## Test plan

- [x] Full reactor `mvn clean verify` passes (Detekt, SpotBugs, JaCoCo, all tests)
- [x] CORS: blank `corsOrigins` means no CORS headers (existing filter behavior preserved)
- [x] API errors: `OuterstellarException` messages still surfaced; other exceptions return generic message
- [x] Analytics: daemon thread pattern matches project convention (`Thread({...}).also { it.isDaemon = true }.start()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)