### PR TITLE
refactor: centralize UserRole enum, extract sync boilerplate, consolidate appBaseUrl

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,13 +8,11 @@ Architecture, security, and maintainability improvements identified during code 
 
 ### Security
 
-- [ ] **CORS defaults to `*` — restrict to specific origins**
-  The `corsOrigins` config defaults to `"*"`, allowing any external origin to make authenticated requests.
-  — `platform-core/.../AppConfig.kt:107`, `platform-web/.../web/Filters.kt:156-170`
+- [x] ~~**CORS defaults to `*` — restrict to specific origins**~~
+  Fixed in PR #230 — default changed from `"*"` to `""` (no CORS headers unless explicitly configured).
 
-- [ ] **Error messages leak internal details in API responses**
-  Unhandled exceptions include `e.message` in JSON error responses, which can leak SQL syntax, file paths, and stack traces.
-  — `platform-web/.../web/Filters.kt:472`
+- [x] ~~**Error messages leak internal details in API responses**~~
+  Fixed in PR #230 — non-`OuterstellarException` errors return generic message in API responses.
 
 - [ ] **Password reset token exposed in URL query parameter**
   Token is sent as `?token=$tokenValue` in the reset link, leaking via Referer header, browser history, and server logs. Should use POST-based submission.
@@ -40,9 +38,8 @@ Architecture, security, and maintainability improvements identified during code 
   Contains main window, all navigation, menu items, translations, and ~50 fields. Extract `SyncWindow` into its own class; split navigation and menu logic.
   — `platform-desktop/.../swing/SwingSyncApp.kt`
 
-- [ ] **Replace `sendAsync` in `SegmentAnalyticsService` with sync + background thread**
-  `client.sendAsync()` violates the project's synchronous-only architectural principle. Use `client.send()` in a daemon thread instead.
-  — `platform-core/.../analytics/SegmentAnalyticsService.kt:85`
+- [x] ~~**Replace `sendAsync` in `SegmentAnalyticsService` with sync + background thread**~~
+  Fixed in PR #230 — replaced with synchronous `client.send()` in a daemon thread.
 
 - [ ] **Reduce generic `catch (Exception)` boilerplate in `DesktopSyncEngine`**
   22 methods duplicate the same try/catch pattern. Extract a higher-order function like `runCatching(operation, onSessionExpired, onError)`.
@@ -95,9 +92,8 @@ Architecture, security, and maintainability improvements identified during code 
   The `app()` function assembles the entire HTTP handler chain directly. `PluginContext` is constructed 4 times redundantly. Extract into smaller assembly functions.
   — `platform-web/.../App.kt`
 
-- [ ] **Declare `platform-core` as explicit dependency in desktop modules**
-  Both `platform-desktop` and `platform-desktop-javafx` get `platform-core` only transitively through `platform-persistence-jooq`. A refactoring of that module's dependencies could silently break them.
-  — `platform-desktop/pom.xml`, `platform-desktop-javafx/pom.xml`
+- [x] ~~**Declare `platform-core` as explicit dependency in desktop modules**~~
+  Fixed in PR #230 — both `platform-desktop` and `platform-desktop-javafx` pom.xml now declare it explicitly.
 
 ### Hardcoded Values
 
@@ -115,9 +111,8 @@ Architecture, security, and maintainability improvements identified during code 
 
 ### Security
 
-- [ ] **JWT secret defaults to empty string with no startup validation**
-  If `enabled=true` is set without a non-empty `secret`, HMAC would use an empty key. Add a startup assertion.
-  — `platform-core/.../AppConfig.kt:26`, `platform-security/.../security/JwtService.kt`
+- [x] ~~**JWT secret defaults to empty string with no startup validation**~~
+  Fixed in PR #230 — added startup warning when JWT is enabled but secret is blank.
 
 - [ ] **Health endpoint is unauthenticated, leaks DB status**
   `/health` returns whether the database is UP or DOWN with no authentication.
@@ -273,4 +268,14 @@ Integrate [fragments4k](https://github.com/rygel/fragments4k) (v0.6.5+) for SEO 
 
 - [x] **Update dependency bumps** (http4k, opentelemetry, angus-mail, assertj-core, ktfmt)
 
-- [x] **Fix desktop `SyncViewModel.onSessionExpired()` race condition**
+- [x] **Fix desktop `SyncViewModel.onSessionExpired()` race condition** (PR #230)
+
+- [x] **CORS wildcard default dropped** (PR #230)
+
+- [x] **API error messages sanitized** (PR #230)
+
+- [x] **SegmentAnalyticsService async violation fixed** (PR #230)
+
+- [x] **JWT secret startup warning added** (PR #230)
+
+- [x] **platform-core declared as explicit dep in desktop modules** (PR #230)

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
@@ -54,13 +54,14 @@ data class AppConfig(
     val csrfEnabled: Boolean = true,
     val segment: SegmentConfig = SegmentConfig(),
     val email: EmailConfig = EmailConfig(),
-    val appBaseUrl: String = "http://localhost:8080",
+    val appBaseUrl: String = DEFAULT_APP_BASE_URL,
     val maxFailedLoginAttempts: Int = DEFAULT_MAX_FAILED_LOGIN_ATTEMPTS,
     val lockoutDurationSeconds: Long = DEFAULT_LOCKOUT_DURATION_SECONDS,
     val jwt: JwtConfig = JwtConfig(),
     val cspPolicy: String = DEFAULT_CSP_POLICY,
 ) {
     companion object {
+        const val DEFAULT_APP_BASE_URL = "http://localhost:8080"
         private val logger = LoggerFactory.getLogger(AppConfig::class.java)
 
         fun fromEnvironment(environment: Map<String, String> = System.getenv()): AppConfig {
@@ -112,7 +113,7 @@ data class AppConfig(
                 csrfEnabled = yaml.bool("csrfEnabled", env, "CSRFENABLED", true),
                 segment = buildSegmentConfig(yaml["segment"] as? Map<String, Any>, env),
                 email = buildEmailConfig(yaml["email"] as? Map<String, Any>, env),
-                appBaseUrl = yaml.str("appBaseUrl", env, "APPBASEURL", "http://localhost:8080"),
+                appBaseUrl = yaml.str("appBaseUrl", env, "APPBASEURL", DEFAULT_APP_BASE_URL),
                 maxFailedLoginAttempts =
                     yaml.int(
                         "maxFailedLoginAttempts",

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/model/AuthModels.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/model/AuthModels.kt
@@ -4,6 +4,11 @@ import java.time.Instant
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 
+enum class UserRole {
+    USER,
+    ADMIN,
+}
+
 @Serializable data class LoginRequest(val username: String, val password: String)
 
 @Serializable data class RegisterRequest(val username: String, val password: String)
@@ -17,7 +22,7 @@ data class UserSummary(
     val id: String,
     val username: String,
     val email: String,
-    val role: String,
+    val role: UserRole,
     val enabled: Boolean,
     val failedLoginAttempts: Int = 0,
     @Contextual val lockedUntil: Instant? = null,

--- a/platform-desktop-javafx/src/main/kotlin/io/github/rygel/outerstellar/platform/fx/controller/MainController.kt
+++ b/platform-desktop-javafx/src/main/kotlin/io/github/rygel/outerstellar/platform/fx/controller/MainController.kt
@@ -1,6 +1,7 @@
 package io.github.rygel.outerstellar.platform.fx.controller
 
 import io.github.rygel.outerstellar.platform.fx.service.FxThemeManager
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.sync.SyncService
 import javafx.fxml.FXML
 import javafx.fxml.FXMLLoader
@@ -116,7 +117,7 @@ class MainController : KoinComponent {
         navLoginBtn.isManaged = !loggedIn
         navLogoutBtn.isVisible = loggedIn
         navLogoutBtn.isManaged = loggedIn
-        navUsersBtn.isVisible = loggedIn && syncService.userRole == "ADMIN"
-        navUsersBtn.isManaged = loggedIn && syncService.userRole == "ADMIN"
+        navUsersBtn.isVisible = loggedIn && syncService.userRole == UserRole.ADMIN.name
+        navUsersBtn.isManaged = loggedIn && syncService.userRole == UserRole.ADMIN.name
     }
 }

--- a/platform-desktop-javafx/src/main/kotlin/io/github/rygel/outerstellar/platform/fx/controller/UsersController.kt
+++ b/platform-desktop-javafx/src/main/kotlin/io/github/rygel/outerstellar/platform/fx/controller/UsersController.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.fx.controller
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.sync.engine.DesktopSyncEngine
 import javafx.application.Platform
@@ -26,7 +27,7 @@ class UsersController : KoinComponent {
     fun initialize() {
         usernameColumn.setCellValueFactory { SimpleStringProperty(it.value.username) }
         emailColumn.setCellValueFactory { SimpleStringProperty(it.value.email) }
-        roleColumn.setCellValueFactory { SimpleStringProperty(it.value.role) }
+        roleColumn.setCellValueFactory { SimpleStringProperty(it.value.role.name) }
         enabledColumn.setCellValueFactory { SimpleStringProperty(it.value.enabled.toString()) }
         loadUsers()
     }
@@ -52,7 +53,7 @@ class UsersController : KoinComponent {
     @FXML
     fun onToggleRole() {
         val selected = usersTable.selectionModel.selectedItem ?: return
-        val newRole = if (selected.role == "ADMIN") "USER" else "ADMIN"
+        val newRole = if (selected.role == UserRole.ADMIN) UserRole.USER.name else UserRole.ADMIN.name
         Thread {
                 engine
                     .setUserRole(selected.id, newRole)

--- a/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/SwingSyncApp.kt
+++ b/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/SwingSyncApp.kt
@@ -7,6 +7,7 @@ import io.github.rygel.outerstellar.platform.di.coreModule
 import io.github.rygel.outerstellar.platform.di.desktopModule
 import io.github.rygel.outerstellar.platform.di.persistenceModule
 import io.github.rygel.outerstellar.platform.model.MessageSummary
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.persistence.MessageCache
 import io.github.rygel.outerstellar.platform.persistence.NoOpMessageCache
 import io.github.rygel.outerstellar.platform.service.MessageService
@@ -638,12 +639,12 @@ class SyncWindow(
         registerItem.isEnabled = !viewModel.isLoggedIn
         changePasswordItem.isEnabled = viewModel.isLoggedIn
 
-        navUsersBtn.isEnabled = viewModel.isLoggedIn && viewModel.userRole == "ADMIN"
+        navUsersBtn.isEnabled = viewModel.isLoggedIn && viewModel.userRole == UserRole.ADMIN.name
         navProfileBtn.isEnabled = viewModel.isLoggedIn
 
         usersModel.rowCount = 0
         viewModel.adminUsers.forEach { user ->
-            usersModel.addRow(arrayOf(user.username, user.email, user.role, user.enabled.toString(), user.id))
+            usersModel.addRow(arrayOf(user.username, user.email, user.role.name, user.enabled.toString(), user.id))
         }
     }
 

--- a/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/viewmodel/SyncViewModel.kt
+++ b/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/viewmodel/SyncViewModel.kt
@@ -4,6 +4,7 @@ import io.github.rygel.outerstellar.i18n.I18nService
 import io.github.rygel.outerstellar.platform.model.ConflictStrategy
 import io.github.rygel.outerstellar.platform.model.ContactNotFoundException
 import io.github.rygel.outerstellar.platform.model.OuterstellarException
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.ValidationException
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.sync.engine.ConnectivityChecker
@@ -324,7 +325,7 @@ class SyncViewModel(
     }
 
     fun toggleUserRole(userId: String, currentRole: String) {
-        val newRole = if (currentRole == "ADMIN") "USER" else "ADMIN"
+        val newRole = if (currentRole == UserRole.ADMIN.name) UserRole.USER.name else UserRole.ADMIN.name
         object : SwingWorker<Unit, Unit>() {
                 override fun doInBackground() {
                     engine.setUserRole(userId, newRole)

--- a/platform-desktop/src/test/kotlin/io/github/rygel/outerstellar/platform/swing/SyncViewModelAdminOperationsTest.kt
+++ b/platform-desktop/src/test/kotlin/io/github/rygel/outerstellar/platform/swing/SyncViewModelAdminOperationsTest.kt
@@ -3,6 +3,7 @@ package io.github.rygel.outerstellar.platform.swing
 import io.github.rygel.outerstellar.i18n.I18nService
 import io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService
 import io.github.rygel.outerstellar.platform.model.AuthTokenResponse
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.swing.viewmodel.SyncViewModel
@@ -46,7 +47,7 @@ class SyncViewModelAdminOperationsTest {
     }
 
     private fun stubUser(id: String = "user-1", role: String = "USER", enabled: Boolean = true) =
-        UserSummary(id = id, username = "bob", email = "bob@test.com", role = role, enabled = enabled)
+        UserSummary(id = id, username = "bob", email = "bob@test.com", role = UserRole.valueOf(role), enabled = enabled)
 
     // ── loadUsers ────────────────────────────────────────────────────────────
 
@@ -183,7 +184,7 @@ class SyncViewModelAdminOperationsTest {
         val vm = loginVm()
         assertTrue(awaitObserver(vm) { vm.toggleUserRole("user-1", currentRole = "USER") })
 
-        assertEquals("ADMIN", vm.adminUsers.first().role)
+        assertEquals(UserRole.ADMIN, vm.adminUsers.first().role)
     }
 
     @Test

--- a/platform-desktop/src/test/kotlin/io/github/rygel/outerstellar/platform/swing/SyncViewModelAuthTest.kt
+++ b/platform-desktop/src/test/kotlin/io/github/rygel/outerstellar/platform/swing/SyncViewModelAuthTest.kt
@@ -5,6 +5,7 @@ import io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService
 import io.github.rygel.outerstellar.platform.model.AuthTokenResponse
 import io.github.rygel.outerstellar.platform.model.SessionExpiredException
 import io.github.rygel.outerstellar.platform.model.SyncException
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.swing.viewmodel.SyncViewModel
@@ -241,8 +242,8 @@ class SyncViewModelAuthTest {
     fun `loadUsers populates adminUsers list`() {
         val users =
             listOf(
-                UserSummary("1", "admin", "admin@test.com", "ADMIN", true),
-                UserSummary("2", "alice", "alice@test.com", "USER", true),
+                UserSummary("1", "admin", "admin@test.com", UserRole.ADMIN, true),
+                UserSummary("2", "alice", "alice@test.com", UserRole.USER, true),
             )
         every { syncService.listUsers() } returns users
 
@@ -260,7 +261,7 @@ class SyncViewModelAuthTest {
 
     @Test
     fun `toggleUserEnabled calls service and refreshes list`() {
-        val users = listOf(UserSummary("1", "alice", "alice@test.com", "USER", false))
+        val users = listOf(UserSummary("1", "alice", "alice@test.com", UserRole.USER, false))
         every { syncService.setUserEnabled("1", true) } just runs
         every { syncService.listUsers() } returns users
 

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepository.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRepository
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiApiKeyRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiApiKeyRepositoryTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
 import io.github.rygel.outerstellar.platform.model.ApiKey
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.Test

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiDeviceTokenRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiDeviceTokenRepositoryTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.DeviceToken
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiNotificationRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiNotificationRepositoryTest.kt
@@ -1,7 +1,7 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiOAuthRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiOAuthRepositoryTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.OAuthConnection
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiPasswordResetRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiPasswordResetRepositoryTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
 import io.github.rygel.outerstellar.platform.model.PasswordResetToken
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.Test

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiSessionRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiSessionRepositoryTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.Session
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepositoryTest.kt
@@ -1,7 +1,7 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.Test

--- a/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepository.kt
+++ b/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepository.kt
@@ -1,9 +1,9 @@
 package io.github.rygel.outerstellar.platform.persistence
 
 import io.github.rygel.outerstellar.platform.jooq.tables.references.PLT_USERS
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRepository
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset

--- a/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqApiKeyRepositoryTest.kt
+++ b/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqApiKeyRepositoryTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
 import io.github.rygel.outerstellar.platform.model.ApiKey
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.Test

--- a/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqDeviceTokenRepositoryTest.kt
+++ b/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqDeviceTokenRepositoryTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.DeviceToken
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqNotificationRepositoryTest.kt
+++ b/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqNotificationRepositoryTest.kt
@@ -1,7 +1,7 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqOAuthRepositoryTest.kt
+++ b/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqOAuthRepositoryTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.OAuthConnection
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqPasswordResetRepositoryTest.kt
+++ b/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqPasswordResetRepositoryTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
 import io.github.rygel.outerstellar.platform.model.PasswordResetToken
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.Test

--- a/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqSessionRepositoryTest.kt
+++ b/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqSessionRepositoryTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.Session
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID

--- a/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepositoryStatsTest.kt
+++ b/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepositoryStatsTest.kt
@@ -1,7 +1,7 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.UUID

--- a/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepositoryTest.kt
+++ b/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqUserRepositoryTest.kt
@@ -1,7 +1,7 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.time.Instant
 import java.util.UUID
 import kotlin.test.Test

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/CachingUserRepository.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/CachingUserRepository.kt
@@ -2,6 +2,7 @@ package io.github.rygel.outerstellar.platform.security
 
 import com.github.benmanes.caffeine.cache.Cache
 import com.github.benmanes.caffeine.cache.Caffeine
+import io.github.rygel.outerstellar.platform.model.UserRole
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/JwtService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/JwtService.kt
@@ -5,6 +5,7 @@ import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.exceptions.JWTVerificationException
 import com.github.benmanes.caffeine.cache.Caffeine
 import io.github.rygel.outerstellar.platform.JwtConfig
+import io.github.rygel.outerstellar.platform.model.UserRole
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/Models.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/Models.kt
@@ -1,13 +1,9 @@
 package io.github.rygel.outerstellar.platform.security
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import java.time.Instant
 import java.time.LocalDateTime
 import java.util.UUID
-
-enum class UserRole {
-    USER,
-    ADMIN,
-}
 
 data class User(
     val id: UUID,
@@ -84,7 +80,7 @@ interface PasswordResetRepository {
 data class DeviceToken(val id: Long, val userId: UUID, val platform: String, val token: String, val appBundle: String?)
 
 data class SecurityConfig(
-    val appBaseUrl: String = "http://localhost:8080",
+    val appBaseUrl: String = io.github.rygel.outerstellar.platform.AppConfig.DEFAULT_APP_BASE_URL,
     val sessionTimeoutSeconds: Long = 1800L,
     val maxFailedLoginAttempts: Int = 10,
     val lockoutDurationSeconds: Long = 900,

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/OAuthService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/OAuthService.kt
@@ -1,6 +1,7 @@
 package io.github.rygel.outerstellar.platform.security
 
 import io.github.rygel.outerstellar.platform.model.AuditEntry
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.persistence.AuditRepository
 import java.util.UUID
 import org.slf4j.LoggerFactory

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/PasswordResetService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/PasswordResetService.kt
@@ -15,7 +15,7 @@ class PasswordResetService(
     private val resetRepository: PasswordResetRepository? = null,
     private val auditRepository: AuditRepository? = null,
     private val emailService: io.github.rygel.outerstellar.platform.service.EmailService? = null,
-    private val appBaseUrl: String = "http://localhost:8080",
+    private val appBaseUrl: String = io.github.rygel.outerstellar.platform.AppConfig.DEFAULT_APP_BASE_URL,
 ) {
     private val logger = LoggerFactory.getLogger(PasswordResetService::class.java)
 

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/Permission.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/Permission.kt
@@ -1,5 +1,7 @@
 package io.github.rygel.outerstellar.platform.security
 
+import io.github.rygel.outerstellar.platform.model.UserRole
+
 /**
  * Wildcard permission following the `domain:action:instance` pattern.
  *

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityRules.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityRules.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.security
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import java.net.URLEncoder
 import org.http4k.core.HttpHandler
 import org.http4k.core.Response

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityService.kt
@@ -5,6 +5,7 @@ import io.github.rygel.outerstellar.platform.model.AuditEntry
 import io.github.rygel.outerstellar.platform.model.CreateApiKeyResponse
 import io.github.rygel.outerstellar.platform.model.InsufficientPermissionException
 import io.github.rygel.outerstellar.platform.model.UserNotFoundException
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.model.UsernameAlreadyExistsException
 import io.github.rygel.outerstellar.platform.model.WeakPasswordException
@@ -389,7 +390,7 @@ private fun User.toSummary() =
         id = id.toString(),
         username = username,
         email = email,
-        role = role.name,
+        role = role,
         enabled = enabled,
         failedLoginAttempts = failedLoginAttempts,
         lockedUntil = lockedUntil,

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthRealmTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthRealmTest.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.security
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/CachingUserRepositoryTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/CachingUserRepositoryTest.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.security
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/JwtServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/JwtServiceTest.kt
@@ -1,6 +1,7 @@
 package io.github.rygel.outerstellar.platform.security
 
 import io.github.rygel.outerstellar.platform.JwtConfig
+import io.github.rygel.outerstellar.platform.model.UserRole
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNull

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/OAuthServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/OAuthServiceTest.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.security
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.persistence.AuditRepository
 import io.mockk.every
 import io.mockk.mockk

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/PermissionTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/PermissionTest.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.security
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityRulesTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityRulesTest.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.security
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityServiceTest.kt
@@ -2,6 +2,7 @@ package io.github.rygel.outerstellar.platform.security
 
 import io.github.rygel.outerstellar.platform.model.ApiKey
 import io.github.rygel.outerstellar.platform.model.InsufficientPermissionException
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UsernameAlreadyExistsException
 import io.github.rygel.outerstellar.platform.model.WeakPasswordException
 import io.github.rygel.outerstellar.platform.persistence.AuditRepository

--- a/platform-seed/src/main/kotlin/io/github/rygel/outerstellar/platform/seed/SeedData.kt
+++ b/platform-seed/src/main/kotlin/io/github/rygel/outerstellar/platform/seed/SeedData.kt
@@ -3,12 +3,12 @@ package io.github.rygel.outerstellar.platform.seed
 import io.github.rygel.outerstellar.platform.di.coreModule
 import io.github.rygel.outerstellar.platform.di.persistenceModule
 import io.github.rygel.outerstellar.platform.infra.migrate
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.persistence.ContactRepository
 import io.github.rygel.outerstellar.platform.persistence.MessageRepository
 import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRepository
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.security.securityModule
 import java.util.UUID
 import javax.sql.DataSource

--- a/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/engine/DesktopAppConfig.kt
+++ b/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/engine/DesktopAppConfig.kt
@@ -4,7 +4,7 @@ import org.snakeyaml.engine.v2.api.Load
 import org.snakeyaml.engine.v2.api.LoadSettings
 
 data class DesktopAppConfig(
-    val serverBaseUrl: String = "http://localhost:8080",
+    val serverBaseUrl: String = io.github.rygel.outerstellar.platform.AppConfig.DEFAULT_APP_BASE_URL,
     val jdbcUrl: String = "jdbc:postgresql://localhost:5432/outerstellar",
     val jdbcUser: String = "outerstellar",
     val jdbcPassword: String = "outerstellar",
@@ -47,7 +47,13 @@ data class DesktopAppConfig(
         private fun buildFromYaml(yaml: Map<String, Any>?, env: Map<String, String>): DesktopAppConfig {
             if (yaml == null) return DesktopAppConfig()
             return DesktopAppConfig(
-                serverBaseUrl = yaml.str("serverBaseUrl", env, "SERVER_BASE_URL", "http://localhost:8080"),
+                serverBaseUrl =
+                    yaml.str(
+                        "serverBaseUrl",
+                        env,
+                        "SERVER_BASE_URL",
+                        io.github.rygel.outerstellar.platform.AppConfig.DEFAULT_APP_BASE_URL,
+                    ),
                 jdbcUrl = yaml.str("jdbcUrl", env, "JDBC_URL", "jdbc:postgresql://localhost:5432/outerstellar"),
                 jdbcUser = yaml.str("jdbcUser", env, "JDBC_USER", "outerstellar"),
                 jdbcPassword = yaml.str("jdbcPassword", env, "JDBC_PASSWORD", "outerstellar"),

--- a/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/engine/DesktopSyncEngine.kt
+++ b/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/engine/DesktopSyncEngine.kt
@@ -176,49 +176,27 @@ class DesktopSyncEngine(
         }
     }
 
-    fun loadUsers() {
-        try {
+    fun loadUsers() =
+        runGuarded("loadUsers") {
             val users = syncService.listUsers()
             updateState { it.copy(adminUsers = users) }
-        } catch (e: SessionExpiredException) {
-            handleSessionExpired(e)
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            logger.warn("Failed to load users", e)
-            fireError("loadUsers", e.message ?: "Unknown error")
         }
-    }
 
-    fun setUserEnabled(userId: String, enabled: Boolean): Result<Unit> {
-        return try {
+    fun setUserEnabled(userId: String, enabled: Boolean): Result<Unit> =
+        runGuardedResult("setUserEnabled") {
             syncService.setUserEnabled(userId, enabled)
             loadUsers()
             analytics.track(state.userName, "user_enabled_changed", mapOf("userId" to userId, "enabled" to enabled))
             Result.success(Unit)
-        } catch (e: SessionExpiredException) {
-            handleSessionExpired()
-            Result.failure(e)
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            logger.warn("Failed to set user enabled", e)
-            fireError("setUserEnabled", e.message ?: "Unknown error")
-            Result.failure(e)
         }
-    }
 
-    fun setUserRole(userId: String, role: String): Result<Unit> {
-        return try {
+    fun setUserRole(userId: String, role: String): Result<Unit> =
+        runGuardedResult("setUserRole") {
             syncService.setUserRole(userId, role)
             loadUsers()
             analytics.track(state.userName, "user_role_changed", mapOf("userId" to userId, "role" to role))
             Result.success(Unit)
-        } catch (e: SessionExpiredException) {
-            handleSessionExpired()
-            Result.failure(e)
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            logger.warn("Failed to set user role", e)
-            fireError("setUserRole", e.message ?: "Unknown error")
-            Result.failure(e)
         }
-    }
 
     fun requestPasswordReset(email: String): Result<Unit> {
         return try {
@@ -244,44 +222,26 @@ class DesktopSyncEngine(
         }
     }
 
-    fun loadNotifications() {
-        try {
+    fun loadNotifications() =
+        runGuarded("loadNotifications") {
             val notifications = syncService.listNotifications()
             updateState { it.copy(notifications = notifications) }
-        } catch (e: SessionExpiredException) {
-            handleSessionExpired(e)
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            logger.warn("Failed to load notifications", e)
-            fireError("loadNotifications", e.message ?: "Unknown error")
         }
-    }
 
-    fun markNotificationRead(notificationId: String) {
-        try {
+    fun markNotificationRead(notificationId: String) =
+        runGuarded("markNotificationRead") {
             syncService.markNotificationRead(notificationId)
             loadNotifications()
-        } catch (e: SessionExpiredException) {
-            handleSessionExpired(e)
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            logger.warn("Failed to mark notification read", e)
-            fireError("markNotificationRead", e.message ?: "Unknown error")
         }
-    }
 
-    fun markAllNotificationsRead() {
-        try {
+    fun markAllNotificationsRead() =
+        runGuarded("markAllNotificationsRead") {
             syncService.markAllNotificationsRead()
             loadNotifications()
-        } catch (e: SessionExpiredException) {
-            handleSessionExpired(e)
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            logger.warn("Failed to mark all notifications read", e)
-            fireError("markAllNotificationsRead", e.message ?: "Unknown error")
         }
-    }
 
-    fun loadProfile() {
-        try {
+    fun loadProfile() =
+        runGuarded("loadProfile") {
             val profile = syncService.fetchProfile()
             updateState {
                 it.copy(
@@ -292,13 +252,7 @@ class DesktopSyncEngine(
                     pushNotificationsEnabled = profile.pushNotificationsEnabled,
                 )
             }
-        } catch (e: SessionExpiredException) {
-            handleSessionExpired(e)
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            logger.warn("Failed to load profile", e)
-            fireError("loadProfile", e.message ?: "Unknown error")
         }
-    }
 
     fun updateProfile(email: String, username: String? = null, avatarUrl: String? = null): Result<Unit> {
         return try {
@@ -318,20 +272,12 @@ class DesktopSyncEngine(
         }
     }
 
-    fun updateNotificationPreferences(emailEnabled: Boolean, pushEnabled: Boolean): Result<Unit> {
-        return try {
+    fun updateNotificationPreferences(emailEnabled: Boolean, pushEnabled: Boolean): Result<Unit> =
+        runGuardedResult("updateNotificationPreferences") {
             syncService.updateNotificationPreferences(emailEnabled, pushEnabled)
             updateState { it.copy(emailNotificationsEnabled = emailEnabled, pushNotificationsEnabled = pushEnabled) }
             Result.success(Unit)
-        } catch (e: SessionExpiredException) {
-            handleSessionExpired()
-            Result.failure(e)
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            logger.warn("Failed to update notification preferences", e)
-            fireError("updateNotificationPreferences", e.message ?: "Unknown error")
-            Result.failure(e)
         }
-    }
 
     fun deleteAccount(): Result<Unit> {
         return try {
@@ -490,5 +436,29 @@ class DesktopSyncEngine(
         if (pulled > 0) parts.add("pulled $pulled")
         if (conflicts > 0) parts.add("$conflicts conflict(s)")
         return if (parts.isEmpty()) "Everything up to date" else "Synced: ${parts.joinToString(", ")}"
+    }
+
+    internal inline fun runGuarded(operation: String, block: () -> Unit) {
+        try {
+            block()
+        } catch (e: SessionExpiredException) {
+            handleSessionExpired(e)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            logger.warn("Failed to {}", operation, e)
+            fireError(operation, e.message ?: "Unknown error")
+        }
+    }
+
+    internal inline fun runGuardedResult(operation: String, block: () -> Result<Unit>): Result<Unit> {
+        return try {
+            block()
+        } catch (e: SessionExpiredException) {
+            handleSessionExpired(e)
+            Result.failure(e)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            logger.warn("Failed to {}", operation, e)
+            fireError(operation, e.message ?: "Unknown error")
+            Result.failure(e)
+        }
     }
 }

--- a/platform-sync-client/src/test/kotlin/io/github/rygel/outerstellar/platform/sync/engine/DesktopSyncEngineAdminTest.kt
+++ b/platform-sync-client/src/test/kotlin/io/github/rygel/outerstellar/platform/sync/engine/DesktopSyncEngineAdminTest.kt
@@ -3,6 +3,7 @@
 package io.github.rygel.outerstellar.platform.sync.engine
 
 import io.github.rygel.outerstellar.platform.model.SessionExpiredException
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.mockk.every
 import io.mockk.verify
@@ -15,7 +16,7 @@ internal class DesktopSyncEngineAdminTest : DesktopSyncEngineTestBase() {
 
     @Test
     fun `loadUsers success updates state`() {
-        val users = listOf(UserSummary("1", "alice", "a@b.c", "USER", true))
+        val users = listOf(UserSummary("1", "alice", "a@b.c", UserRole.USER, true))
         every { syncService.listUsers() } returns users
 
         engine.loadUsers()

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
@@ -2,6 +2,7 @@ package io.github.rygel.outerstellar.platform
 
 import io.github.rygel.outerstellar.platform.analytics.AnalyticsService
 import io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.persistence.MessageCache
 import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
 import io.github.rygel.outerstellar.platform.security.ApiKeyRealm
@@ -12,7 +13,6 @@ import io.github.rygel.outerstellar.platform.security.SecurityRules
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.SessionRealm
 import io.github.rygel.outerstellar.platform.security.UserRepository
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.web.AdminNavItem
 import io.github.rygel.outerstellar.platform.web.AuthApi

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AdminPageFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AdminPageFactory.kt
@@ -36,7 +36,7 @@ class AdminPageFactory(
                                 id = u.id,
                                 username = u.username,
                                 email = u.email,
-                                role = u.role,
+                                role = u.role.name,
                                 enabled = u.enabled,
                                 toggleEnabledUrl = ctx.url("/admin/users/${u.id}/toggle-enabled"),
                                 toggleRoleUrl = ctx.url("/admin/users/${u.id}/toggle-role"),

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminApi.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminApi.kt
@@ -4,10 +4,10 @@ import io.github.rygel.outerstellar.platform.model.InsufficientPermissionExcepti
 import io.github.rygel.outerstellar.platform.model.SetUserEnabledRequest
 import io.github.rygel.outerstellar.platform.model.SetUserRoleRequest
 import io.github.rygel.outerstellar.platform.model.UserNotFoundException
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.security.SecurityRules
 import io.github.rygel.outerstellar.platform.security.SecurityService
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import org.http4k.contract.ContractRoute
 import org.http4k.contract.bindContract

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminRoutes.kt
@@ -3,9 +3,9 @@ package io.github.rygel.outerstellar.platform.web
 import io.github.rygel.outerstellar.platform.export.CsvUtils
 import io.github.rygel.outerstellar.platform.infra.render
 import io.github.rygel.outerstellar.platform.model.InsufficientPermissionException
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.security.SecurityService
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import org.http4k.contract.bindContract
 import org.http4k.contract.div
@@ -103,7 +103,7 @@ class UserAdminRoutes(
                         val users = securityService.listUsers()
                         val target = users.find { it.id == userId }
                         if (target != null) {
-                            val newRole = if (target.role == "ADMIN") UserRole.USER else UserRole.ADMIN
+                            val newRole = if (target.role == UserRole.ADMIN) UserRole.USER else UserRole.ADMIN
                             securityService.setUserRole(admin.id, UUID.fromString(userId), newRole)
                         }
                         renderer.render(pageFactory.buildUserAdminPage(ctx))
@@ -129,7 +129,7 @@ class UserAdminRoutes(
             val sb = StringBuilder()
             sb.appendLine(CsvUtils.toCsvRow(listOf("Username", "Email", "Role", "Enabled")))
             users.forEach { u ->
-                sb.appendLine(CsvUtils.toCsvRow(listOf(u.username, u.email, u.role, u.enabled.toString())))
+                sb.appendLine(CsvUtils.toCsvRow(listOf(u.username, u.email, u.role.name, u.enabled.toString())))
             }
             return sb.toString()
         }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
@@ -3,12 +3,12 @@ package io.github.rygel.outerstellar.platform.web
 import io.github.rygel.outerstellar.i18n.I18nService
 import io.github.rygel.outerstellar.platform.I18nTextResolver
 import io.github.rygel.outerstellar.platform.TextResolver
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.JwtService
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.SessionLookup
 import io.github.rygel.outerstellar.platform.security.User
 import io.github.rygel.outerstellar.platform.security.UserRepository
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import org.http4k.core.Request

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityIntegrationTest.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.security
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.persistence.JooqUserRepository
 import io.github.rygel.outerstellar.platform.web.WebTest
 import io.github.rygel.outerstellar.platform.web.testPassword

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AdminExportIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AdminExportIntegrationTest.kt
@@ -1,10 +1,10 @@
 package io.github.rygel.outerstellar.platform.web
 
 import io.github.rygel.outerstellar.platform.model.AuditEntry
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -201,8 +201,8 @@ class AdminExportIntegrationTest : WebTest() {
     fun `usersAsCsv produces one data row per user`() {
         val users =
             listOf(
-                UserSummary("1", "alice", "alice@test.com", "USER", true),
-                UserSummary("2", "bob", "bob@test.com", "ADMIN", true),
+                UserSummary("1", "alice", "alice@test.com", UserRole.USER, true),
+                UserSummary("2", "bob", "bob@test.com", UserRole.ADMIN, true),
             )
         val csv = UserAdminRoutes.usersAsCsv(users)
         val lines = csv.trim().lines()
@@ -212,14 +212,14 @@ class AdminExportIntegrationTest : WebTest() {
 
     @Test
     fun `usersAsCsv escapes username containing a comma`() {
-        val users = listOf(UserSummary("1", "last, first", "e@test.com", "USER", true))
+        val users = listOf(UserSummary("1", "last, first", "e@test.com", UserRole.USER, true))
         val csv = UserAdminRoutes.usersAsCsv(users)
         assertTrue(csv.contains("\"last, first\""), "Comma in username should be quoted, got: $csv")
     }
 
     @Test
     fun `usersAsCsv escapes username containing a double-quote`() {
-        val users = listOf(UserSummary("1", "say \"hello\"", "e@test.com", "USER", true))
+        val users = listOf(UserSummary("1", "say \"hello\"", "e@test.com", UserRole.USER, true))
         val csv = UserAdminRoutes.usersAsCsv(users)
         // CSV escaping: " → "" inside quoted field
         assertTrue(csv.contains("\"\""), "Double-quotes in value should be escaped")

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AdminHtmlRoutesIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AdminHtmlRoutesIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyAuthIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyAuthIntegrationTest.kt
@@ -1,9 +1,9 @@
 package io.github.rygel.outerstellar.platform.web
 
 import io.github.rygel.outerstellar.platform.model.CreateApiKeyResponse
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyLifecycleIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyLifecycleIntegrationTest.kt
@@ -2,9 +2,9 @@ package io.github.rygel.outerstellar.platform.web
 
 import io.github.rygel.outerstellar.platform.model.ApiKeySummary
 import io.github.rygel.outerstellar.platform.model.CreateApiKeyResponse
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuditLogIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuditLogIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthHtmlFlowIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthHtmlFlowIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthProfileApiKeysIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthProfileApiKeysIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthenticationWorkflowTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthenticationWorkflowTest.kt
@@ -1,6 +1,6 @@
 package io.github.rygel.outerstellar.platform.web
 
-import io.github.rygel.outerstellar.platform.security.UserRole
+import io.github.rygel.outerstellar.platform.model.UserRole
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ChangePasswordWebIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ChangePasswordWebIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ComponentFragmentIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ComponentFragmentIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ConcurrentSyncIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ConcurrentSyncIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.sync.SyncPullResponse
 import java.util.UUID
 import java.util.concurrent.CopyOnWriteArrayList

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ContactDetailsSyncIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ContactDetailsSyncIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.sync.SyncPullContactResponse
 import io.github.rygel.outerstellar.platform.sync.SyncPushContactResponse
 import java.util.UUID

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ContactsSyncCrudIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ContactsSyncCrudIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.sync.SyncPullContactResponse
 import io.github.rygel.outerstellar.platform.sync.SyncPushContactResponse
 import java.util.UUID

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DarkModeToggleIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DarkModeToggleIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DevDashboardAccessIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DevDashboardAccessIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DeviceRegistrationApiIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/DeviceRegistrationApiIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/LoginReturnToIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/LoginReturnToIntegrationTest.kt
@@ -1,7 +1,7 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/LogoutIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/LogoutIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MessageSearchIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MessageSearchIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.sync.SyncPullResponse
 import io.github.rygel.outerstellar.platform.sync.SyncPushResponse
 import java.util.UUID

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PasswordResetFlowIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PasswordResetFlowIntegrationTest.kt
@@ -1,7 +1,7 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PerformanceBenchmarkTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PerformanceBenchmarkTest.kt
@@ -327,7 +327,7 @@ class PerformanceBenchmarkTest : WebTest() {
                 username = "prodperfuser",
                 email = "prodperf@example.com",
                 passwordHash = prodEncoder.encode("prodpass123!"),
-                role = io.github.rygel.outerstellar.platform.security.UserRole.USER,
+                role = io.github.rygel.outerstellar.platform.model.UserRole.USER,
             )
         )
 

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PlatformPageRenderingTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PlatformPageRenderingTest.kt
@@ -1,9 +1,9 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.persistence.JooqNotificationRepository
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.NotificationService
 import java.util.UUID
 import kotlin.test.Test

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ProfileApiIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ProfileApiIntegrationTest.kt
@@ -6,9 +6,9 @@ import io.github.rygel.outerstellar.platform.model.RegisterRequest
 import io.github.rygel.outerstellar.platform.model.UpdateNotificationPrefsRequest
 import io.github.rygel.outerstellar.platform.model.UpdateProfileRequest
 import io.github.rygel.outerstellar.platform.model.UserProfileResponse
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PushNotificationsIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PushNotificationsIntegrationTest.kt
@@ -1,9 +1,9 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.DeviceToken
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ApnsPushNotificationService
 import io.github.rygel.outerstellar.platform.service.ConsolePushNotificationService
 import io.github.rygel.outerstellar.platform.service.FcmPushNotificationService

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SecurityHeadersIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SecurityHeadersIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SessionSecurityIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SessionSecurityIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SessionTimeoutIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SessionTimeoutIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncApiIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncApiIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.sync.SyncPullContactResponse
 import io.github.rygel.outerstellar.platform.sync.SyncPullResponse
 import io.github.rygel.outerstellar.platform.sync.SyncPushContactResponse

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncConflictResolutionIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncConflictResolutionIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.sync.SyncPushResponse
 import java.util.UUID
 import kotlin.test.Test

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SyncIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.sync.SyncPullResponse
 import io.mockk.mockk

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementIntegrationTest.kt
@@ -6,10 +6,10 @@ import io.github.rygel.outerstellar.platform.model.LoginRequest
 import io.github.rygel.outerstellar.platform.model.RegisterRequest
 import io.github.rygel.outerstellar.platform.model.SetUserEnabledRequest
 import io.github.rygel.outerstellar.platform.model.SetUserRoleRequest
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -309,7 +309,7 @@ class UserManagementIntegrationTest : WebTest() {
 
         assertEquals("fieldcheck", user.username)
         assertEquals("fieldcheck", user.email)
-        assertEquals("USER", user.role)
+        assertEquals(UserRole.USER, user.role)
         assertTrue(user.enabled)
         assertTrue(user.id.isNotBlank())
     }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementWebUiIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementWebUiIntegrationTest.kt
@@ -3,9 +3,9 @@ package io.github.rygel.outerstellar.platform.web
 import io.github.rygel.outerstellar.platform.model.AuthTokenResponse
 import io.github.rygel.outerstellar.platform.model.LoginRequest
 import io.github.rygel.outerstellar.platform.model.RegisterRequest
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/WebSocketSyncIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/WebSocketSyncIntegrationTest.kt
@@ -1,8 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import io.github.rygel.outerstellar.platform.security.User
-import io.github.rygel.outerstellar.platform.security.UserRole
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.UUID


### PR DESCRIPTION
## Summary

- **UserRole enum centralized**: Moved from platform-security/Models.kt to platform-core/model/AuthModels.kt for cross-module access without circular deps. UserSummary.role changed from String to UserRole. ~54 files updated.
- **DesktopSyncEngine boilerplate extracted**: Added runGuarded/runGuardedResult inline helpers to eliminate repeated try/catch blocks. 8 methods refactored.
- **appBaseUrl default consolidated**: Added AppConfig.DEFAULT_APP_BASE_URL constant replacing hardcoded string across SecurityConfig, PasswordResetService, DesktopAppConfig.

## Test plan
- [x] Full mvn clean verify (excl. desktop) - 549 tests, 0 failures
- [x] All quality gates: SpotBugs, PMD, Checkstyle, Detekt
- [x] Desktop modules compile via mvn clean install -DskipTests