### PR TITLE
fix(security): add per-account rate limiting to prevent brute-force via IP rotation

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiter.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiter.kt
@@ -17,6 +17,8 @@ private const val DEFAULT_WINDOW_MS = 60_000L
 private const val RESET_MAX_REQUESTS = 5
 private const val RESET_WINDOW_MS = 900_000L // 15 minutes
 private const val MAX_BUCKETS = 10_000L
+private const val ACCOUNT_MAX_REQUESTS = 20
+private const val ACCOUNT_WINDOW_MS = 900_000L // 15 minutes
 
 class TokenBucket(private val maxRequests: Int, private val windowMs: Long) {
     private val count = AtomicInteger(0)
@@ -57,10 +59,16 @@ fun rateLimitFilter(
             "/auth/components/reset-confirm",
         ),
 ): Filter {
-    val buckets =
+    val ipBuckets =
         Caffeine.newBuilder()
             .maximumSize(MAX_BUCKETS)
             .expireAfterWrite(RESET_WINDOW_MS * 2, TimeUnit.MILLISECONDS)
+            .build<String, TokenBucket>()
+
+    val accountBuckets =
+        Caffeine.newBuilder()
+            .maximumSize(MAX_BUCKETS)
+            .expireAfterWrite(ACCOUNT_WINDOW_MS * 2, TimeUnit.MILLISECONDS)
             .build<String, TokenBucket>()
 
     return Filter { next: HttpHandler ->
@@ -76,18 +84,56 @@ fun rateLimitFilter(
                 val effectiveMax = override?.maxRequests ?: maxRequests
                 val effectiveWindow = override?.windowMs ?: windowMs
 
-                val key = "$clientIp:$path"
-                val bucket = buckets.get(key) { TokenBucket(effectiveMax, effectiveWindow) }
+                val ipKey = "$clientIp:$path"
+                val ipBucket = ipBuckets.get(ipKey) { TokenBucket(effectiveMax, effectiveWindow) }
 
-                if (bucket.tryConsume()) {
-                    next(request)
-                } else {
+                if (!ipBucket.tryConsume()) {
                     logger.warn("Rate limit exceeded for {} on {}", clientIp, path)
-                    Response(Status.TOO_MANY_REQUESTS).body("Too many requests. Please try again later.")
+                    return@Filter Response(Status.TOO_MANY_REQUESTS).body("Too many requests. Please try again later.")
                 }
+
+                val account = extractAccountIdentifier(request)
+                if (account != null) {
+                    val accountKey = "account:$account"
+                    val accountBucket =
+                        accountBuckets.get(accountKey) { TokenBucket(ACCOUNT_MAX_REQUESTS, ACCOUNT_WINDOW_MS) }
+
+                    if (!accountBucket.tryConsume()) {
+                        logger.warn("Per-account rate limit exceeded for account {} on {}", account, path)
+                        return@Filter Response(Status.TOO_MANY_REQUESTS)
+                            .body("Too many login attempts for this account. Please try again later.")
+                    }
+                }
+
+                next(request)
             } else {
                 next(request)
             }
         }
     }
+}
+
+private fun extractAccountIdentifier(request: org.http4k.core.Request): String? {
+    val contentType = request.header("content-type").orEmpty()
+    val body = request.bodyString()
+    if (body.isBlank()) return null
+
+    return if (contentType.contains("json")) {
+        extractJsonValue(body, "username") ?: extractJsonValue(body, "email")
+    } else if (contentType.contains("form")) {
+        val params =
+            body.split("&").associate {
+                val parts = it.split("=", limit = 2)
+                if (parts.size == 2) parts[0] to java.net.URLDecoder.decode(parts[1], "UTF-8") else null to null
+            }
+        params["email"]?.trim()?.lowercase() ?: params["username"]?.trim()?.lowercase()
+    } else {
+        null
+    }
+}
+
+private fun extractJsonValue(json: String, key: String): String? {
+    val pattern = "\"$key\"\\s*:\\s*\"([^\"]+)\""
+    val match = Regex(pattern).find(json)
+    return match?.groupValues?.get(1)?.trim()?.lowercase()
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiterIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiterIntegrationTest.kt
@@ -108,4 +108,85 @@ class RateLimiterIntegrationTest : WebTest() {
             assertTrue(response.status != Status.TOO_MANY_REQUESTS, "Health endpoint should never be rate limited")
         }
     }
+
+    @Test
+    fun `per-account rate limit triggers when same username is tried from many IPs`() {
+        val username = "target-user-${UUID.randomUUID()}"
+        repeat(20) { i ->
+            val ip = "10.99.0.${i + 1}"
+            app(
+                Request(POST, "/api/v1/auth/login")
+                    .header("content-type", "application/json")
+                    .header("X-Forwarded-For", ip)
+                    .body("""{"username":"$username","password":"wrong"}""")
+            )
+        }
+
+        val response =
+            app(
+                Request(POST, "/api/v1/auth/login")
+                    .header("content-type", "application/json")
+                    .header("X-Forwarded-For", "10.99.0.100")
+                    .body("""{"username":"$username","password":"wrong"}""")
+            )
+        assertEquals(
+            Status.TOO_MANY_REQUESTS,
+            response.status,
+            "21st request for same account from different IP should be rate limited",
+        )
+    }
+
+    @Test
+    fun `different usernames from same IP use separate account buckets`() {
+        val ip = "10.88.${(1..254).random()}.${(1..254).random()}"
+        val targetAccount = "target-${UUID.randomUUID()}"
+
+        repeat(9) { i ->
+            app(
+                Request(POST, "/api/v1/auth/login")
+                    .header("content-type", "application/json")
+                    .header("X-Forwarded-For", ip)
+                    .body("""{"username":"filler-$i","password":"wrong"}""")
+            )
+        }
+
+        val response =
+            app(
+                Request(POST, "/api/v1/auth/login")
+                    .header("content-type", "application/json")
+                    .header("X-Forwarded-For", ip)
+                    .body("""{"username":"$targetAccount","password":"wrong"}""")
+            )
+        assertTrue(
+            response.status != Status.TOO_MANY_REQUESTS,
+            "Different usernames should have separate account buckets (10 requests from one IP, all within per-IP limit), got: ${response.status}",
+        )
+    }
+
+    @Test
+    fun `per-account rate limit works with form-encoded email`() {
+        val email = "target-${UUID.randomUUID()}@test.com"
+        repeat(20) { i ->
+            val ip = "10.77.0.${i + 1}"
+            app(
+                Request(POST, "/auth/components/result")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("X-Forwarded-For", ip)
+                    .body("mode=sign-in&email=${java.net.URLEncoder.encode(email, "UTF-8")}&password=wrong")
+            )
+        }
+
+        val response =
+            app(
+                Request(POST, "/auth/components/result")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .header("X-Forwarded-For", "10.77.0.100")
+                    .body("mode=sign-in&email=${java.net.URLEncoder.encode(email, "UTF-8")}&password=wrong")
+            )
+        assertEquals(
+            Status.TOO_MANY_REQUESTS,
+            response.status,
+            "Per-account limit should apply to form-encoded email too",
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Add per-account token bucket rate limiting (20 requests / 15 min) alongside existing per-IP rate limiting
- Extract account identifier from JSON body (`username`/`email` via regex) or form-encoded body (`email`/`username` param)
- Prevents brute-force attacks that rotate source IPs to bypass per-IP limits

## Test plan
- [x] Per-account limit triggers when same username is tried from 21+ different IPs
- [x] Different usernames from same IP use separate account buckets (not blocked by each other)
- [x] Per-account limit works with form-encoded email (not just JSON)
- [x] All 8 RateLimiterIntegrationTest tests pass