### PR TITLE
feat(seo): hreflang, preload, robots.txt, heading hierarchy, theme-color, lazy avatar

### DIFF
--- a/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/NotificationsPage.kte
+++ b/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/NotificationsPage.kte
@@ -6,7 +6,7 @@
     <div class="max-w-3xl mx-auto">
         <div class="flex items-center justify-between mb-6">
             <div>
-                <h2 class="mt-0">${model.data.title}</h2>
+                <h1 class="mt-0">${model.data.title}</h1>
                 <p class="opacity-60 text-sm mt-1">${model.data.description}</p>
             </div>
             @if(model.data.unreadCount > 0)

--- a/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/PluginAdminDashboard.kte
+++ b/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/PluginAdminDashboard.kte
@@ -4,7 +4,7 @@
 
 @template.io.github.rygel.outerstellar.platform.web.LayoutRouter(shell = model.shell, content = @`
 <div class="p-6">
-    <h2 class="text-2xl font-bold mb-6">Plugin Dashboard</h2>
+    <h1 class="text-2xl font-bold mb-6">Plugin Dashboard</h1>
     <div class="grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-4">
         @for(card in model.data.cards)
         <div class="card bg-base-200 border border-base-300">

--- a/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/ProfilePage.kte
+++ b/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/ProfilePage.kte
@@ -7,11 +7,12 @@
 
         <%-- ── Section 1: Profile Info ─────────────────────────────────────── --%>
         <section class="card bg-base-200 border border-base-300">
-            <h2 style="margin-top:0;">${model.data.title}</h2>
+            <h1 style="margin-top:0;">${model.data.title}</h1>
 
             <div style="display:flex; align-items:center; gap:1.25rem; margin-bottom:1.25rem;">
                 <img src="${model.data.avatarUrl}"
                      alt="${model.data.avatarAlt}"
+                     loading="lazy"
                      style="width:72px; height:72px; border-radius:50%; object-fit:cover; border:2px solid var(--color-border, #333);">
                 <div>
                     <div style="font-weight:600; font-size:1.05rem;">${model.data.username}</div>

--- a/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/layouts/LayoutHead.kte
+++ b/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/layouts/LayoutHead.kte
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="${shell.csrfToken}">
+    <meta name="theme-color" content="#0f172a">
     <title>${shell.pageTitle} - ${shell.appTitle}</title>
     @if(shell.pageDescription.isNotBlank())
     <meta name="description" content="${shell.pageDescription}">
@@ -15,6 +16,14 @@
     @if(shell.noIndex)
     <meta name="robots" content="noindex, nofollow">
     @endif
+    @if(!shell.noIndex && shell.canonicalUrl.isNotBlank())
+        @for(locale in shell.supportedLocales)
+    <link rel="alternate" hreflang="${locale}" href="${shell.canonicalUrl}?lang=${locale}">
+        @endfor
+    <link rel="alternate" hreflang="x-default" href="${shell.canonicalUrl}?lang=en">
+    @endif
+    <link rel="preload" href="/site.css?v=${shell.version}" as="style">
+    <link rel="preload" href="/vendor/remixicon/remixicon.woff2" as="font" type="font/woff2" crossorigin>
     <link href="/vendor/remixicon/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="/site.css?v=${shell.version}">
     <script defer src="/vendor/htmx.min.js"></script>

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
@@ -456,9 +456,34 @@ private fun buildBaseApp(
     }
     coreRoutes += "/health" bind GET to { buildHealthResponse(userRepository) }
     coreRoutes += "/metrics" bind GET to metricsHandler
+    coreRoutes += "/robots.txt" bind GET to { buildRobotsTxtResponse() }
 
     return routes(coreRoutes)
 }
+
+private fun buildRobotsTxtResponse(): Response =
+    Response(Status.OK)
+        .header("content-type", "text/plain; charset=utf-8")
+        .body(
+            """
+            User-agent: *
+            Allow: /
+            Allow: /contacts
+            Allow: /search
+            Disallow: /api/
+            Disallow: /admin/
+            Disallow: /ws/
+            Disallow: /auth/
+            Disallow: /errors/
+            Disallow: /components/
+            Disallow: /messages/
+            Disallow: /notifications/
+            Disallow: /settings/
+
+            Sitemap: /sitemap.xml
+            """
+                .trimIndent() + "\n"
+        )
 
 @Suppress("TooGenericExceptionCaught", "SwallowedException")
 private fun buildHealthResponse(userRepository: UserRepository): Response {

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ViewModels.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ViewModels.kt
@@ -45,6 +45,8 @@ data class ShellView(
     val pageDescription: String = "",
     val canonicalUrl: String = "",
     val noIndex: Boolean = false,
+    val supportedLocales: List<String> = listOf("en"),
+    val appBaseUrl: String = "",
 ) {
     fun text(key: String, vararg args: Any?): String = textResolver?.resolve(key, *args) ?: key
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
@@ -290,6 +290,8 @@ class WebContext(
                     .orEmpty(),
             canonicalUrl = if (appBaseUrl.isNotBlank()) "$appBaseUrl$currentPath" else "",
             noIndex = activeSection in NO_INDEX_SECTIONS,
+            supportedLocales = listOf("en", "fr"),
+            appBaseUrl = appBaseUrl,
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add `hreflang` alternate links for `en`/`fr` (with `x-default`) on indexable pages
- Add `<link rel="preload">` for `site.css` and `remixicon.woff2`
- Add `/robots.txt` route (disallow `/api/`, `/admin/`, `/ws/`, `/auth/`, etc.)
- Fix heading hierarchy — change `<h2>` to `<h1>` in ProfilePage, NotificationsPage, PluginAdminDashboard
- Add `<meta name="theme-color">` for mobile browsers
- Add `loading="lazy"` to Gravatar avatar image in ProfilePage
- Note: `font-display: swap` was already present in remixicon.css

## Test plan
- [x] All 552 tests pass (`mvn clean verify -T4`)
- [x] hreflang only emitted on non-noindex pages with canonical URL
- [x] robots.txt served at `/robots.txt` with correct `text/plain` content type
- [x] Preload hints use correct `as` attributes (`style`, `font`)