### PR TITLE
refactor: extract OutboxStatus enum to replace raw string constants

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -150,9 +150,9 @@ Architecture, security, and maintainability improvements identified during code 
   `setOf("en", "fr")`, `setOf("nice", "cozy", "compact")`, `setOf("sidebar", "topbar")` in `Filters.kt` should be configurable.
   — `platform-web/.../web/Filters.kt:281-296`
 
-- [ ] **Outbox status strings (`"PENDING"`, `"PROCESSED"`, `"FAILED"`) scattered**
-  Used as raw strings in `JooqOutboxRepository`, `MessageService`, and `DevDashboardRoutes`. Should be an enum or constants.
-  — Multiple files
+- [x] ~~**Outbox status strings (`"PENDING"`, `"PROCESSED"`, `"FAILED"`) scattered**~~
+  Fixed in PR #243 — extracted `OutboxStatus` enum in `OutboxRepository.kt`. All 19 usages across `MessageService`, `JooqOutboxRepository`, `JdbiOutboxRepository`, `DevDashboardRoutes`, and tests updated.
+  — `platform-core/.../persistence/OutboxRepository.kt`
 
 ---
 

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/OutboxRepository.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/OutboxRepository.kt
@@ -3,11 +3,17 @@ package io.github.rygel.outerstellar.platform.persistence
 import java.time.Instant
 import java.util.UUID
 
+enum class OutboxStatus {
+    PENDING,
+    PROCESSED,
+    FAILED,
+}
+
 data class OutboxEntry(
     val id: UUID,
     val payloadType: String,
     val payload: String,
-    val status: String,
+    val status: OutboxStatus,
     val createdAt: Instant = Instant.now(),
 )
 
@@ -20,7 +26,7 @@ interface OutboxRepository {
 
     fun markFailed(id: UUID, error: String)
 
-    fun getStats(): Map<String, Int>
+    fun getStats(): Map<OutboxStatus, Int>
 
     fun listFailed(): List<OutboxEntry>
 }

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
@@ -14,6 +14,7 @@ import io.github.rygel.outerstellar.platform.persistence.MessageRepository
 import io.github.rygel.outerstellar.platform.persistence.NoOpMessageCache
 import io.github.rygel.outerstellar.platform.persistence.OutboxEntry
 import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
+import io.github.rygel.outerstellar.platform.persistence.OutboxStatus
 import io.github.rygel.outerstellar.platform.persistence.TransactionManager
 import io.github.rygel.outerstellar.platform.sync.SyncConflict
 import io.github.rygel.outerstellar.platform.sync.SyncMessage
@@ -109,7 +110,7 @@ class MessageService(
                             id = UUID.randomUUID(),
                             payloadType = "MESSAGE_CREATED",
                             payload = msg.syncId,
-                            status = "PENDING",
+                            status = OutboxStatus.PENDING,
                         )
                     )
                     msg
@@ -224,7 +225,7 @@ class MessageService(
                         id = UUID.randomUUID(),
                         payloadType = "MESSAGE_DELETED",
                         payload = syncId,
-                        status = "PENDING",
+                        status = OutboxStatus.PENDING,
                     )
                 )
             }
@@ -259,7 +260,7 @@ class MessageService(
                             id = UUID.randomUUID(),
                             payloadType = "MESSAGE_UPDATED",
                             payload = up.syncId,
-                            status = "PENDING",
+                            status = OutboxStatus.PENDING,
                         )
                     )
                     up

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/OutboxProcessorTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/OutboxProcessorTest.kt
@@ -2,6 +2,7 @@ package io.github.rygel.outerstellar.platform.service
 
 import io.github.rygel.outerstellar.platform.persistence.OutboxEntry
 import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
+import io.github.rygel.outerstellar.platform.persistence.OutboxStatus
 import io.github.rygel.outerstellar.platform.persistence.TransactionManager
 import io.mockk.every
 import io.mockk.mockk
@@ -15,7 +16,13 @@ class OutboxProcessorTest {
     private val outboxRepository = mockk<OutboxRepository>(relaxed = true)
 
     private fun entry(id: UUID = UUID.randomUUID()) =
-        OutboxEntry(id = id, payloadType = "test.Event", payload = "{}", status = "pending", createdAt = Instant.now())
+        OutboxEntry(
+            id = id,
+            payloadType = "test.Event",
+            payload = "{}",
+            status = OutboxStatus.PENDING,
+            createdAt = Instant.now(),
+        )
 
     @Test
     fun `processPending does nothing when no pending entries`() {

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiOutboxRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiOutboxRepository.kt
@@ -13,7 +13,7 @@ class JdbiOutboxRepository(private val jdbi: Jdbi) : OutboxRepository {
                 .createUpdate(
                     """
                     INSERT INTO plt_outbox (id, payload_type, payload, status)
-                    VALUES (:id, :payloadType, :payload, 'PENDING')
+                    VALUES (:id, :payloadType, :payload, '${OutboxStatus.PENDING.name}')
                     """
                 )
                 .bind("id", entry.id)
@@ -29,7 +29,7 @@ class JdbiOutboxRepository(private val jdbi: Jdbi) : OutboxRepository {
                 .createQuery(
                     """
                     SELECT id, payload_type, payload, status, created_at FROM plt_outbox
-                    WHERE status = 'PENDING'
+                    WHERE status = '${OutboxStatus.PENDING.name}'
                     ORDER BY created_at ASC
                     LIMIT :limit
                     """
@@ -40,7 +40,7 @@ class JdbiOutboxRepository(private val jdbi: Jdbi) : OutboxRepository {
                         id = rs.getObject("id", UUID::class.java),
                         payloadType = rs.getString("payload_type"),
                         payload = rs.getString("payload"),
-                        status = rs.getString("status"),
+                        status = OutboxStatus.valueOf(rs.getString("status")),
                         createdAt = rs.getTimestamp("created_at").toInstant(),
                     )
                 }
@@ -53,7 +53,7 @@ class JdbiOutboxRepository(private val jdbi: Jdbi) : OutboxRepository {
             handle
                 .createUpdate(
                     """
-                    UPDATE plt_outbox SET status = 'PROCESSED', processed_at = :processedAt
+                    UPDATE plt_outbox SET status = '${OutboxStatus.PROCESSED.name}', processed_at = :processedAt
                     WHERE id = :id
                     """
                 )
@@ -66,18 +66,20 @@ class JdbiOutboxRepository(private val jdbi: Jdbi) : OutboxRepository {
     override fun markFailed(id: UUID, error: String) {
         jdbi.useHandle<Exception> { handle ->
             handle
-                .createUpdate("UPDATE plt_outbox SET status = 'FAILED', last_error = :error WHERE id = :id")
+                .createUpdate(
+                    "UPDATE plt_outbox SET status = '${OutboxStatus.FAILED.name}', last_error = :error WHERE id = :id"
+                )
                 .bind("id", id)
                 .bind("error", error)
                 .execute()
         }
     }
 
-    override fun getStats(): Map<String, Int> {
-        return jdbi.withHandle<Map<String, Int>, Exception> { handle ->
+    override fun getStats(): Map<OutboxStatus, Int> {
+        return jdbi.withHandle<Map<OutboxStatus, Int>, Exception> { handle ->
             handle
                 .createQuery("SELECT status, COUNT(*) AS cnt FROM plt_outbox GROUP BY status")
-                .map { rs, _ -> rs.getString("status") to rs.getInt("cnt") }
+                .map { rs, _ -> OutboxStatus.valueOf(rs.getString("status")) to rs.getInt("cnt") }
                 .list()
                 .toMap()
         }
@@ -89,7 +91,7 @@ class JdbiOutboxRepository(private val jdbi: Jdbi) : OutboxRepository {
                 .createQuery(
                     """
                     SELECT id, payload_type, payload, status, created_at FROM plt_outbox
-                    WHERE status = 'FAILED'
+                    WHERE status = '${OutboxStatus.FAILED.name}'
                     ORDER BY created_at DESC
                     """
                 )
@@ -98,7 +100,7 @@ class JdbiOutboxRepository(private val jdbi: Jdbi) : OutboxRepository {
                         id = rs.getObject("id", UUID::class.java),
                         payloadType = rs.getString("payload_type"),
                         payload = rs.getString("payload"),
-                        status = rs.getString("status"),
+                        status = OutboxStatus.valueOf(rs.getString("status")),
                         createdAt = rs.getTimestamp("created_at").toInstant(),
                     )
                 }

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiOutboxRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiOutboxRepositoryTest.kt
@@ -10,7 +10,7 @@ class JdbiOutboxRepositoryTest : JdbiTest() {
     private val repo by lazy { JdbiOutboxRepository(jdbi) }
 
     private fun entry(payloadType: String = "TestEvent", payload: String = "{}") =
-        OutboxEntry(id = UUID.randomUUID(), payloadType = payloadType, payload = payload, status = "PENDING")
+        OutboxEntry(id = UUID.randomUUID(), payloadType = payloadType, payload = payload, status = OutboxStatus.PENDING)
 
     @Test
     fun `save and listPending round-trips`() {
@@ -20,7 +20,7 @@ class JdbiOutboxRepositoryTest : JdbiTest() {
         assertEquals(1, pending.size)
         assertEquals("UserCreated", pending[0].payloadType)
         assertEquals("""{"id":"abc"}""", pending[0].payload)
-        assertEquals("PENDING", pending[0].status)
+        assertEquals(OutboxStatus.PENDING, pending[0].status)
     }
 
     @Test
@@ -59,7 +59,7 @@ class JdbiOutboxRepositoryTest : JdbiTest() {
         assertTrue(repo.listPending(10).isEmpty())
         val failed = repo.listFailed()
         assertEquals(1, failed.size)
-        assertEquals("FAILED", failed[0].status)
+        assertEquals(OutboxStatus.FAILED, failed[0].status)
     }
 
     @Test
@@ -70,8 +70,8 @@ class JdbiOutboxRepositoryTest : JdbiTest() {
         repo.save(e3)
         repo.markProcessed(e3.id)
         val stats = repo.getStats()
-        assertEquals(2, stats["PENDING"])
-        assertEquals(1, stats["PROCESSED"])
+        assertEquals(2, stats[OutboxStatus.PENDING])
+        assertEquals(1, stats[OutboxStatus.PROCESSED])
     }
 
     @Test

--- a/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqOutboxRepository.kt
+++ b/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqOutboxRepository.kt
@@ -11,13 +11,13 @@ class JooqOutboxRepository(private val dsl: DSLContext) : OutboxRepository {
             .set(PLT_OUTBOX.ID, entry.id)
             .set(PLT_OUTBOX.PAYLOAD_TYPE, entry.payloadType)
             .set(PLT_OUTBOX.PAYLOAD, entry.payload)
-            .set(PLT_OUTBOX.STATUS, "PENDING")
+            .set(PLT_OUTBOX.STATUS, OutboxStatus.PENDING.name)
             .execute()
     }
 
     override fun listPending(limit: Int): List<OutboxEntry> {
         return dsl.selectFrom(PLT_OUTBOX)
-            .where(PLT_OUTBOX.STATUS.eq("PENDING"))
+            .where(PLT_OUTBOX.STATUS.eq(OutboxStatus.PENDING.name))
             .orderBy(PLT_OUTBOX.CREATED_AT.asc())
             .limit(limit)
             .fetch { record ->
@@ -25,7 +25,7 @@ class JooqOutboxRepository(private val dsl: DSLContext) : OutboxRepository {
                     id = record.id!!,
                     payloadType = record.payloadType!!,
                     payload = record.payload!!,
-                    status = record.status!!,
+                    status = OutboxStatus.valueOf(record.status!!),
                     createdAt = record.createdAt!!.toInstant(java.time.ZoneOffset.UTC),
                 )
             }
@@ -33,7 +33,7 @@ class JooqOutboxRepository(private val dsl: DSLContext) : OutboxRepository {
 
     override fun markProcessed(id: UUID) {
         dsl.update(PLT_OUTBOX)
-            .set(PLT_OUTBOX.STATUS, "PROCESSED")
+            .set(PLT_OUTBOX.STATUS, OutboxStatus.PROCESSED.name)
             .set(PLT_OUTBOX.PROCESSED_AT, java.time.LocalDateTime.now(java.time.ZoneOffset.UTC))
             .where(PLT_OUTBOX.ID.eq(id))
             .execute()
@@ -41,29 +41,29 @@ class JooqOutboxRepository(private val dsl: DSLContext) : OutboxRepository {
 
     override fun markFailed(id: UUID, error: String) {
         dsl.update(PLT_OUTBOX)
-            .set(PLT_OUTBOX.STATUS, "FAILED")
+            .set(PLT_OUTBOX.STATUS, OutboxStatus.FAILED.name)
             .set(PLT_OUTBOX.LAST_ERROR, error)
             .where(PLT_OUTBOX.ID.eq(id))
             .execute()
     }
 
-    override fun getStats(): Map<String, Int> {
+    override fun getStats(): Map<OutboxStatus, Int> {
         val results =
             dsl.select(PLT_OUTBOX.STATUS, org.jooq.impl.DSL.count()).from(PLT_OUTBOX).groupBy(PLT_OUTBOX.STATUS).fetch()
 
-        return results.associate { it.value1()!! to it.value2() }
+        return results.associate { OutboxStatus.valueOf(it.value1()!!) to it.value2() }
     }
 
     override fun listFailed(): List<OutboxEntry> {
         return dsl.selectFrom(PLT_OUTBOX)
-            .where(PLT_OUTBOX.STATUS.eq("FAILED"))
+            .where(PLT_OUTBOX.STATUS.eq(OutboxStatus.FAILED.name))
             .orderBy(PLT_OUTBOX.CREATED_AT.desc())
             .fetch { record ->
                 OutboxEntry(
                     id = record.id!!,
                     payloadType = record.payloadType!!,
                     payload = record.payload!!,
-                    status = record.status!!,
+                    status = OutboxStatus.valueOf(record.status!!),
                     createdAt = record.createdAt!!.toInstant(java.time.ZoneOffset.UTC),
                 )
             }

--- a/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqOutboxRepositoryTest.kt
+++ b/platform-persistence-jooq/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqOutboxRepositoryTest.kt
@@ -10,7 +10,7 @@ class JooqOutboxRepositoryTest : JooqTest() {
     private val repo by lazy { JooqOutboxRepository(dsl) }
 
     private fun entry(payloadType: String = "TestEvent", payload: String = "{}") =
-        OutboxEntry(id = UUID.randomUUID(), payloadType = payloadType, payload = payload, status = "PENDING")
+        OutboxEntry(id = UUID.randomUUID(), payloadType = payloadType, payload = payload, status = OutboxStatus.PENDING)
 
     @Test
     fun `save and listPending round-trips`() {
@@ -20,7 +20,7 @@ class JooqOutboxRepositoryTest : JooqTest() {
         assertEquals(1, pending.size)
         assertEquals("UserCreated", pending[0].payloadType)
         assertEquals("""{"id":"abc"}""", pending[0].payload)
-        assertEquals("PENDING", pending[0].status)
+        assertEquals(OutboxStatus.PENDING, pending[0].status)
     }
 
     @Test
@@ -59,7 +59,7 @@ class JooqOutboxRepositoryTest : JooqTest() {
         assertTrue(repo.listPending(10).isEmpty())
         val failed = repo.listFailed()
         assertEquals(1, failed.size)
-        assertEquals("FAILED", failed[0].status)
+        assertEquals(OutboxStatus.FAILED, failed[0].status)
     }
 
     @Test
@@ -70,8 +70,8 @@ class JooqOutboxRepositoryTest : JooqTest() {
         repo.save(e3)
         repo.markProcessed(e3.id)
         val stats = repo.getStats()
-        assertEquals(2, stats["PENDING"])
-        assertEquals(1, stats["PROCESSED"])
+        assertEquals(2, stats[OutboxStatus.PENDING])
+        assertEquals(1, stats[OutboxStatus.PROCESSED])
     }
 
     @Test

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/DevDashboardRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/DevDashboardRoutes.kt
@@ -3,6 +3,7 @@ package io.github.rygel.outerstellar.platform.web
 import io.github.rygel.outerstellar.platform.infra.render
 import io.github.rygel.outerstellar.platform.persistence.MessageCache
 import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
+import io.github.rygel.outerstellar.platform.persistence.OutboxStatus
 import org.http4k.contract.bindContract
 import org.http4k.contract.meta
 import org.http4k.core.Method.GET
@@ -34,9 +35,9 @@ class DevDashboardRoutes(
                                 cacheStats = cache.getStats(),
                                 outboxStats =
                                     OutboxStatsViewModel(
-                                        pending = outboxStats["PENDING"] ?: 0,
-                                        processed = outboxStats["PROCESSED"] ?: 0,
-                                        failed = outboxStats["FAILED"] ?: 0,
+                                        pending = outboxStats[OutboxStatus.PENDING] ?: 0,
+                                        processed = outboxStats[OutboxStatus.PROCESSED] ?: 0,
+                                        failed = outboxStats[OutboxStatus.FAILED] ?: 0,
                                     ),
                                 telemetryStatus = "Enabled",
                             )

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/Stubs.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/Stubs.kt
@@ -3,6 +3,7 @@ package io.github.rygel.outerstellar.platform.web
 import io.github.rygel.outerstellar.platform.persistence.MessageCache
 import io.github.rygel.outerstellar.platform.persistence.OutboxEntry
 import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
+import io.github.rygel.outerstellar.platform.persistence.OutboxStatus
 import io.github.rygel.outerstellar.platform.security.DeviceToken
 import io.github.rygel.outerstellar.platform.security.DeviceTokenRepository
 import io.github.rygel.outerstellar.platform.security.OAuthConnection
@@ -27,7 +28,7 @@ class StubOutboxRepository : OutboxRepository {
         // Stub implementation
     }
 
-    override fun getStats(): Map<String, Int> = emptyMap()
+    override fun getStats(): Map<OutboxStatus, Int> = emptyMap()
 
     override fun listFailed(): List<OutboxEntry> = emptyList()
 }


### PR DESCRIPTION
## Summary
- Extracted `OutboxStatus` enum (`PENDING`, `PROCESSED`, `FAILED`) to `OutboxRepository.kt`
- Changed `OutboxEntry.status` type from `String` to `OutboxStatus`
- Changed `OutboxRepository.getStats()` return type from `Map<String, Int>` to `Map<OutboxStatus, Int>`
- Updated all 19 usages across 5 modules — no behavior change, strictly a type safety improvement

## Test plan
- [x] All 552 tests pass
- [x] Full reactor `mvn verify` passes (SpotBugs, Detekt, PMD, CPD, Jacoco)