### PR TITLE
fix: resolve plugin Flyway migration issues (baseline skipping + discovery)

### DIFF
--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/DatabaseInfra.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/DatabaseInfra.kt
@@ -36,6 +36,7 @@ fun migratePlugin(dataSource: DataSource, location: String, historyTable: String
         .locations(location)
         .table(historyTable)
         .baselineOnMigrate(true)
+        .baselineVersion("0")
         .load()
         .migrate()
 }

--- a/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/DatabaseInfra.kt
+++ b/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/DatabaseInfra.kt
@@ -31,6 +31,7 @@ fun migratePlugin(dataSource: DataSource, location: String, historyTable: String
         .locations(location)
         .table(historyTable)
         .baselineOnMigrate(true)
+        .baselineVersion("0")
         .load()
         .migrate()
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/WebModule.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/WebModule.kt
@@ -2,6 +2,7 @@ package io.github.rygel.outerstellar.platform.di
 
 import io.github.rygel.outerstellar.i18n.I18nService
 import io.github.rygel.outerstellar.platform.AppConfig
+import io.github.rygel.outerstellar.platform.PluginMigrationSource
 import io.github.rygel.outerstellar.platform.analytics.AnalyticsService
 import io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService
 import io.github.rygel.outerstellar.platform.analytics.SegmentAnalyticsService
@@ -30,6 +31,9 @@ import org.http4k.template.TemplateRenderer
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
+/** Null-object for apps without a plugin — migrationLocation returns null so no plugin migrations run. */
+private object NoPluginMigrationSource : PluginMigrationSource
+
 val webModule
     get() = module {
         includes(adminWebModule)
@@ -46,6 +50,10 @@ val webModule
                 baseRenderer
             }
         }
+        // Bridge: PlatformPlugin extends PluginMigrationSource but Koin doesn't resolve parent types.
+        // Register explicitly so persistenceModule.getOrNull<PluginMigrationSource>() finds the plugin.
+        // Use a null-object (NoPluginMigrationSource) for apps without plugins.
+        single<PluginMigrationSource> { getOrNull<PlatformPlugin>() ?: NoPluginMigrationSource }
         single {
             WebPageFactory(
                 getOrNull(),


### PR DESCRIPTION
## Summary
Fixes two plugin migration bugs from issue #246 found during GraalVM native-image validation:

### Fix 1: baselineOnMigrate skips plugin V1 migration
- Added `baselineVersion("0")` to plugin Flyway config in both jOOQ and JDBI DatabaseInfra
- Previously used default baseline at version 1, which skipped the plugin'"'"'s V1__...sql because host tables already existed
- Now baselines at version 0, allowing V1+ to execute normally

### Fix 2: PluginMigrationSource not discovered via Koin
- PlatformPlugin extends PluginMigrationSource but Koin doesn'"'"'t resolve parent types
- Added bridge bean in WebModule: `single<PluginMigrationSource> { getOrNull<PlatformPlugin>() ?: NoPluginMigrationSource }`
- Null-object pattern (NoPluginMigrationSource) ensures no-plugin apps don'"'"'t crash
- Plugin apps no longer need the extra `single<PluginMigrationSource> { get<PlatformPlugin>() }` registration

## Test plan
- [x] All 552 tests pass
- [x] Full reactor mvn verify passes (SpotBugs, Detekt, PMD, CPD, Jacoco)