### PR TITLE
refactor: extract SSRF URL validation into UrlValidator

### DIFF
--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/UrlValidator.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/UrlValidator.kt
@@ -1,0 +1,46 @@
+package io.github.rygel.outerstellar.platform.service
+
+import java.net.URI
+
+object UrlValidator {
+    private const val MAX_URL_LENGTH = 2048
+    private val PRIVATE_HOST_PATTERNS =
+        listOf(
+            Regex("^localhost$"),
+            Regex("^127\\..*"),
+            Regex("^10\\..*"),
+            Regex("^172\\.(1[6-9]|2\\d|3[01])\\..*"),
+            Regex("^192\\.168\\..*"),
+            Regex("^0\\..*"),
+            Regex("^0\\.0\\.0\\.0$"),
+            Regex("^\\[::1]$"),
+            Regex("^\\[::]$"),
+            Regex("^\\[fe80:.*]$"),
+            Regex("^\\[fd00:.*]$"),
+            Regex("^\\[fc00:.*]$"),
+            Regex(".*\\.local$"),
+            Regex(".*\\.internal$"),
+        )
+
+    fun validate(url: String) {
+        val sanitized = url.trim()
+        if (!sanitized.startsWith("https://") && !sanitized.startsWith("http://")) {
+            throw IllegalArgumentException("URL must use http or https scheme")
+        }
+        if (sanitized.length > MAX_URL_LENGTH) {
+            throw IllegalArgumentException("URL exceeds maximum length of $MAX_URL_LENGTH characters")
+        }
+        val host =
+            try {
+                URI(sanitized).host?.lowercase()
+            } catch (e: Exception) {
+                throw IllegalArgumentException("URL could not be parsed: ${e.message}", e)
+            }
+        if (host == null) {
+            throw IllegalArgumentException("URL must have a valid host")
+        }
+        if (PRIVATE_HOST_PATTERNS.any { it.matches(host) }) {
+            throw IllegalArgumentException("URL must not point to private or internal addresses")
+        }
+    }
+}

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityService.kt
@@ -10,6 +10,7 @@ import io.github.rygel.outerstellar.platform.model.UserSummary
 import io.github.rygel.outerstellar.platform.model.UsernameAlreadyExistsException
 import io.github.rygel.outerstellar.platform.model.WeakPasswordException
 import io.github.rygel.outerstellar.platform.persistence.AuditRepository
+import io.github.rygel.outerstellar.platform.service.UrlValidator
 import java.time.Instant
 import java.util.UUID
 import org.slf4j.LoggerFactory
@@ -235,22 +236,7 @@ class SecurityService(
         if (newAvatarUrl != user.avatarUrl) {
             val sanitizedUrl = newAvatarUrl?.takeIf { it.isNotBlank() }
             if (sanitizedUrl != null) {
-                if (!sanitizedUrl.startsWith("https://") && !sanitizedUrl.startsWith("http://")) {
-                    throw IllegalArgumentException("Avatar URL must use http or https scheme")
-                }
-                if (sanitizedUrl.length > MAX_URL_LENGTH) {
-                    throw IllegalArgumentException("Avatar URL exceeds maximum length of $MAX_URL_LENGTH characters")
-                }
-                val host =
-                    try {
-                        java.net.URI(sanitizedUrl).host?.lowercase()
-                    } catch (e: Exception) {
-                        logger.warn("Failed to parse avatar URL for SSRF check: {}", e.message)
-                        null
-                    }
-                if (host != null && PRIVATE_HOST_PATTERNS.any { it.matches(host) }) {
-                    throw IllegalArgumentException("Avatar URL must not point to private or internal addresses")
-                }
+                UrlValidator.validate(sanitizedUrl)
             }
             userRepository.updateAvatarUrl(userId, sanitizedUrl)
         }
@@ -363,25 +349,7 @@ class SecurityService(
         private const val MAX_USERNAME_LENGTH = 50
         private const val SESSION_TOKEN_HEX_LENGTH = 48
         private const val MAX_PAGE_LIMIT = 1000
-        private const val MAX_URL_LENGTH = 2048
         private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
-        private val PRIVATE_HOST_PATTERNS =
-            listOf(
-                Regex("^localhost$"),
-                Regex("^127\\..*"),
-                Regex("^10\\..*"),
-                Regex("^172\\.(1[6-9]|2\\d|3[01])\\..*"),
-                Regex("^192\\.168\\..*"),
-                Regex("^0\\..*"),
-                Regex("^0\\.0\\.0\\.0$"),
-                Regex("^\\[::1]$"),
-                Regex("^\\[::]$"),
-                Regex("^\\[fe80:.*]$"),
-                Regex("^\\[fd00:.*]$"),
-                Regex("^\\[fc00:.*]$"),
-                Regex(".*\\.local$"),
-                Regex(".*\\.internal$"),
-            )
     }
 }
 


### PR DESCRIPTION
## Summary
- Extracted inline SSRF validation from `SecurityService.updateProfile()` into a reusable `UrlValidator` object in `platform-core`
- Validates: scheme (http/https), max length (2048), private host patterns (same regex set as before)
- Removed `MAX_URL_LENGTH` and `PRIVATE_HOST_PATTERNS` from `SecurityService.companion`
- Security fix: parse failures now throw instead of silently logging and bypassing SSRF checks

## Test plan
- [x] All tests pass
- [x] Full reactor mvn verify passes (SpotBugs, Detekt, PMD, CPD, Jacoco)