### PR TITLE
fix: make JTE development template paths configurable

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfra.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfra.kt
@@ -34,7 +34,9 @@ fun createRenderer(): TemplateRenderer {
     val templateEngine =
         if (!isProduction) {
             val applicationClassLoader = Thread.currentThread().contextClassLoader
-            val projectDirectory = Path.of(System.getProperty("user.dir"))
+            val sourceDir =
+                System.getProperty("jte.sourceDir") ?: System.getenv("JTE_SOURCE_DIR") ?: System.getProperty("user.dir")
+            val projectDirectory = Path.of(sourceDir)
             val sourceTemplates = projectDirectory.resolve(Path.of("web", "src", "main", "jte"))
             val generatedTemplateClasses = projectDirectory.resolve(Path.of("web", "target", "jte-classes"))
 

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -295,7 +295,7 @@ object Filters {
 
             val langCookie =
                 preferenceCookie(request.query("lang"), WebContext.LANG_COOKIE, cookieMaxAge, cookieSecure) {
-                    it in setOf("en", "fr")
+                    it in WebContext.SUPPORTED_LANGUAGES
                 }
             val themeCookie =
                 preferenceCookie(request.query("theme"), WebContext.THEME_COOKIE, cookieMaxAge, cookieSecure) { v ->
@@ -303,11 +303,11 @@ object Filters {
                 }
             val layoutCookie =
                 preferenceCookie(request.query("layout"), WebContext.LAYOUT_COOKIE, cookieMaxAge, cookieSecure) {
-                    it in setOf("nice", "cozy", "compact")
+                    it in WebContext.SUPPORTED_LAYOUTS
                 }
             val shellCookie =
                 preferenceCookie(request.query("shell"), WebContext.SHELL_COOKIE, cookieMaxAge, cookieSecure) {
-                    it in setOf("sidebar", "topbar")
+                    it in WebContext.SUPPORTED_SHELLS
                 }
 
             persistUserPreferences(contextUser, langCookie, themeCookie, layoutCookie, userRepository)

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
@@ -39,6 +39,10 @@ class WebContext(
         const val JWT_COOKIE = "app_jwt"
         const val CSRF_COOKIE = "_csrf"
 
+        val SUPPORTED_LANGUAGES = setOf("en", "fr")
+        val SUPPORTED_LAYOUTS = listOf("nice", "cozy", "compact")
+        val SUPPORTED_SHELLS = listOf("sidebar", "topbar")
+
         private val NO_INDEX_SECTIONS =
             setOf(
                 "/auth",
@@ -77,12 +81,12 @@ class WebContext(
 
     val layout: String by lazy {
         val value = request.query("layout") ?: request.cookie(LAYOUT_COOKIE)?.value ?: user?.layout ?: "nice"
-        if (listOf("nice", "cozy", "compact").any { it == value }) value else "nice"
+        if (value in SUPPORTED_LAYOUTS) value else "nice"
     }
 
     val shellStyle: String by lazy {
         val value = request.query("shell") ?: request.cookie(SHELL_COOKIE)?.value ?: "sidebar"
-        if (listOf("sidebar", "topbar").any { it == value }) value else "sidebar"
+        if (value in SUPPORTED_SHELLS) value else "sidebar"
     }
 
     val user: User? by lazy {

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebPageFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebPageFactory.kt
@@ -434,8 +434,9 @@ open class WebPageFactory(
             selectId = "layout-selector",
             selectName = "layout",
             options =
-                listOf("nice" to "web.layout.nice", "cozy" to "web.layout.cozy", "compact" to "web.layout.compact")
-                    .map { (id, key) -> ShellOption(id, i18n.translate(key), id, id == ctx.layout) },
+                WebContext.SUPPORTED_LAYOUTS.map { id ->
+                    ShellOption(id, i18n.translate("web.layout.$id"), id, id == ctx.layout)
+                },
             hiddenFields =
                 listOf(
                     HiddenField("pagePath", pagePath),


### PR DESCRIPTION
## Summary
Replace hardcoded `System.getProperty("user.dir")` with configurable fallback chain: `jte.sourceDir` system property → `JTE_SOURCE_DIR` env var → `user.dir`.

This allows running in dev mode from any working directory or in containers where the project root isn'"'"'t at `user.dir`.

## Test plan
- [x] All 552 tests pass