### PR TITLE
perf: sync, search, and export optimizations (round 2)

### DIFF
--- a/docs/superpowers/plans/2026-05-16-performance-optimizations.md
+++ b/docs/superpowers/plans/2026-05-16-performance-optimizations.md
@@ -1,0 +1,552 @@
+# Performance Optimizations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate 7 performance bottlenecks: double session lookups, unbounded analytics threads, full-table admin scans, unwired cache config, linear JTE lookups, full-body ETag hashing, and missing search indexes.
+
+**Architecture:** Each task is independent — no task depends on another. Implement in order of risk (lowest first). Each task produces a self-contained commit.
+
+**Tech Stack:** Kotlin, Caffeine cache, jOOQ/JDBI, PostgreSQL pg_trgm, http4k, Koin DI
+
+---
+
+## Task 1: JteClassRegistry — O(1) Map Lookup
+
+**Files:**
+- Modify: `platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteClassRegistry.kt:92,117`
+
+- [ ] **Step 1: Build a Map from the existing `allClasses` list and use it in `getTemplateClass`**
+
+In `JteClassRegistry.kt`, after line 92 (`val allClasses: List<Class<*>> = ...`), add a map field. Then change line 117 from `.find {}` to map lookup.
+
+Replace line 92 with:
+```kotlin
+    val allClasses: List<Class<*>> = pageClasses + fragmentClasses + componentClasses + layoutClasses
+
+    private val classMap: Map<String, Class<*>> = allClasses.associateBy { it.name }
+```
+
+Replace line 117 (`return allClasses.find { it.name == fullName }`) with:
+```kotlin
+        return classMap[fullName]
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `mvn -pl platform-web compile -Ddetekt.skip=true -Dspotbugs.skip=true -Dspotless.check.skip=true`
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Run platform-web tests**
+
+Run: `mvn -pl platform-web test -Dexec.skip=true`
+
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```
+git add platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteClassRegistry.kt
+git commit -m "perf: replace linear scan with Map lookup in JteClassRegistry"
+```
+
+---
+
+## Task 2: Segment Analytics — Bounded Executor
+
+**Files:**
+- Modify: `platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/analytics/SegmentAnalyticsService.kt:85-96`
+
+- [ ] **Step 1: Replace per-event Thread with single-thread ExecutorService**
+
+Add imports at top (after existing imports):
+```kotlin
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+```
+
+Add a private executor field after line 23 (`private val authHeader = ...`):
+```kotlin
+    private val executor: ExecutorService = ThreadPoolExecutor(
+        1, 1, 0L, TimeUnit.MILLISECONDS, LinkedBlockingQueue(100),
+        { r -> Thread(r, "segment-analytics").also { it.isDaemon = true } },
+    ) { _, _ -> logger.warn("Segment analytics queue full — dropping event") }
+```
+
+Replace lines 85-96 (the Thread creation block inside `send()`) with:
+```kotlin
+            try {
+                executor.execute {
+                    try {
+                        client.send(request, HttpResponse.BodyHandlers.discarding())
+                    } catch (e: Exception) {
+                        logger.warn("Segment {} call failed: {}", endpoint, e.message)
+                    }
+                }
+            } catch (e: java.util.concurrent.RejectedExecutionException) {
+                logger.warn("Segment analytics event dropped: queue full")
+            }
+```
+
+- [ ] **Step 2: Verify build compiles**
+
+Run: `mvn -pl platform-core compile -Ddetekt.skip=true -Dspotbugs.skip=true -Dspotless.check.skip=true`
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Run platform-core tests**
+
+Run: `mvn -pl platform-core test`
+
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```
+git add platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/analytics/SegmentAnalyticsService.kt
+git commit -m "perf: replace per-event Thread with bounded single-thread executor in SegmentAnalytics"
+```
+
+---
+
+## Task 3: ETag Filter — Skip Dynamic HTML
+
+**Files:**
+- Modify: `platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt:59-81`
+
+- [ ] **Step 1: Add a content-type check to skip HTML and only ETag cacheable types**
+
+Replace the entire `etagCachingFilter` (lines 59-81) with:
+```kotlin
+val etagCachingFilter: Filter = Filter { next: HttpHandler ->
+    { request ->
+        val response = next(request)
+        val contentType = response.header("content-type") ?: ""
+        val isCacheable = contentType.contains("text/css") ||
+            contentType.contains("javascript") ||
+            contentType.contains("font/") ||
+            contentType.contains("image/")
+        if (
+            response.status == Status.OK && response.header("ETag") == null && isCacheable
+        ) {
+            val digest = MessageDigest.getInstance("SHA-256")
+            val bytes = response.body.stream.readBytes()
+            digest.update(bytes)
+            val hash = digest.digest().take(8).joinToString("") { "%02x".format(it) }
+            val etag = "\"$hash\""
+            val ifNoneMatch = request.header("If-None-Match")
+            if (ifNoneMatch == etag) {
+                Response(Status.NOT_MODIFIED)
+            } else {
+                response.body(Body(ByteBuffer.wrap(bytes))).header("ETag", etag)
+            }
+        } else {
+            response
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify build and tests**
+
+Run: `mvn -pl platform-web test -Dexec.skip=true`
+
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```
+git add platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+git commit -m "perf: skip ETag computation for dynamic HTML, only hash cacheable static assets"
+```
+
+---
+
+## Task 4: WebContext — Single Session Lookup
+
+**Files:**
+- Modify: `platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt:92-112`
+
+- [ ] **Step 1: Extract single session lookup, derive both user and sessionExpired from it**
+
+Replace lines 92-112 (`val user` and `val sessionExpired`) with:
+```kotlin
+    private val sessionLookup: SessionLookup? by lazy {
+        request.cookie(SESSION_COOKIE)?.value?.let { rawToken ->
+            securityService?.lookupSession(rawToken)
+        }
+    }
+
+    val user: User? by lazy {
+        when (sessionLookup) {
+            is SessionLookup.Active -> sessionLookup.user
+            else ->
+                request.cookie(JWT_COOKIE)?.value?.let { token ->
+                    jwtService?.extractClaims(token)?.let { (userId, _) ->
+                        userRepository?.findById(userId)?.takeIf { it.enabled }
+                    }
+                }
+        }
+    }
+
+    val sessionExpired: Boolean by lazy {
+        sessionLookup is SessionLookup.Expired
+    }
+```
+
+Key change: `sessionLookup` is resolved once. `user` derives from it (falling back to JWT if session is null). `sessionExpired` checks the same lookup result.
+
+- [ ] **Step 2: Verify build and tests**
+
+Run: `mvn -pl platform-web test -Dexec.skip=true`
+
+Expected: All tests pass
+
+- [ ] **Step 3: Commit**
+
+```
+git add platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/WebContext.kt
+git commit -m "perf: resolve session lookup once per request in WebContext"
+```
+
+---
+
+## Task 5: Admin Actions — Single User Lookup
+
+**Files:**
+- Modify: `platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityService.kt` (add method after line 151)
+- Modify: `platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminRoutes.kt:60-69,99-109`
+
+- [ ] **Step 1: Add `findUserSummary` to SecurityService**
+
+After line 151 (`fun countUsers(): Long = userRepository.countAll()`), add:
+```kotlin
+
+    fun findUserSummary(id: UUID): UserSummary? = userRepository.findById(id)?.toSummary()
+```
+
+- [ ] **Step 2: Update toggle-enabled route to use `findUserSummary`**
+
+In `UserAdminRoutes.kt`, replace lines 64-68:
+```kotlin
+                        val users = securityService.listUsers()
+                        val target = users.find { it.id == userId }
+                        if (target != null) {
+                            securityService.setUserEnabled(admin.id, UUID.fromString(userId), !target.enabled)
+                        }
+```
+with:
+```kotlin
+                        val target = securityService.findUserSummary(UUID.fromString(userId))
+                        if (target != null) {
+                            securityService.setUserEnabled(admin.id, UUID.fromString(userId), !target.enabled)
+                        }
+```
+
+- [ ] **Step 3: Update toggle-role route to use `findUserSummary`**
+
+Replace lines 103-107:
+```kotlin
+                        val users = securityService.listUsers()
+                        val target = users.find { it.id == userId }
+                        if (target != null) {
+                            val newRole = if (target.role == UserRole.ADMIN) UserRole.USER else UserRole.ADMIN
+                            securityService.setUserRole(admin.id, UUID.fromString(userId), newRole)
+                        }
+```
+with:
+```kotlin
+                        val target = securityService.findUserSummary(UUID.fromString(userId))
+                        if (target != null) {
+                            val newRole = if (target.role == UserRole.ADMIN) UserRole.USER else UserRole.ADMIN
+                            securityService.setUserRole(admin.id, UUID.fromString(userId), newRole)
+                        }
+```
+
+- [ ] **Step 4: Verify build and tests**
+
+Run: `mvn -pl platform-security,platform-web test -Dexec.skip=true`
+
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```
+git add platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityService.kt platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminRoutes.kt
+git commit -m "perf: replace listUsers with findUserSummary for admin toggle actions"
+```
+
+---
+
+## Task 6: CaffeineMessageCache — RuntimeConfig + Generation Invalidation
+
+**Files:**
+- Modify: `platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/MessageCache.kt` (interface)
+- Modify: `platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/CaffeineMessageCache.kt` (impl)
+- Modify: `platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/WebModule.kt:67`
+- Modify: `platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/CaffeineMessageCacheTest.kt`
+
+- [ ] **Step 1: Update MessageCache interface — rename `invalidateByPrefix` to `invalidateNamespace`**
+
+In `MessageCache.kt`, replace line 14:
+```kotlin
+    fun invalidateByPrefix(prefix: String) = invalidateAll()
+```
+with:
+```kotlin
+    fun invalidateNamespace(namespace: String) = invalidateAll()
+```
+
+- [ ] **Step 2: Update CaffeineMessageCache — accept config params, use generation counters**
+
+Replace the entire `CaffeineMessageCache.kt` with:
+```kotlin
+package io.github.rygel.outerstellar.platform.persistence
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+private const val DEFAULT_MAX_SIZE = 1000L
+private const val DEFAULT_TTL_MINUTES = 10L
+
+class CaffeineMessageCache(
+    maxSize: Long = DEFAULT_MAX_SIZE,
+    ttlMinutes: Long = DEFAULT_TTL_MINUTES,
+    meterRegistry: MeterRegistry? = null,
+) : MessageCache {
+    private val cache =
+        Caffeine.newBuilder()
+            .maximumSize(maxSize)
+            .expireAfterWrite(ttlMinutes, TimeUnit.MINUTES)
+            .recordStats()
+            .build<String, Any>()
+
+    private val generations = ConcurrentHashMap<String, AtomicLong>()
+
+    init {
+        if (meterRegistry != null) {
+            CaffeineCacheMetrics.monitor(meterRegistry, cache, "messageCache")
+        }
+    }
+
+    override fun get(key: String): Any? = cache.getIfPresent(key)
+
+    override fun put(key: String, value: Any) {
+        cache.put(key, value)
+    }
+
+    override fun getOrPut(key: String, loader: () -> Any): Any = cache.get(key) { loader() }
+
+    override fun invalidate(key: String) {
+        cache.invalidate(key)
+    }
+
+    override fun invalidateAll() {
+        cache.invalidateAll()
+    }
+
+    override fun invalidateNamespace(namespace: String) {
+        generations.computeIfAbsent(namespace) { AtomicLong(0) }.incrementAndGet()
+    }
+
+    fun generationKey(namespace: String, key: String): String {
+        val gen = generations.computeIfAbsent(namespace) { AtomicLong(0) }.get()
+        return "$namespace:$gen:$key"
+    }
+
+    override fun getStats(): Map<String, Any> {
+        val stats = cache.stats()
+        return mapOf(
+            "hitCount" to stats.hitCount(),
+            "missCount" to stats.missCount(),
+            "evictionCount" to stats.evictionCount(),
+            "evictionWeight" to stats.evictionWeight(),
+            "hitRate" to stats.hitRate(),
+            "missRate" to stats.missRate(),
+            "averageLoadPenalty" to stats.averageLoadPenalty(),
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Wire RuntimeConfig in WebModule**
+
+In `WebModule.kt`, replace line 67:
+```kotlin
+        single<MessageCache> { io.github.rygel.outerstellar.platform.persistence.CaffeineMessageCache() }
+```
+with:
+```kotlin
+        single<MessageCache> {
+            val runtime = get<AppConfig>().runtime
+            io.github.rygel.outerstellar.platform.persistence.CaffeineMessageCache(
+                maxSize = runtime.cacheMessageMaxSize.toLong(),
+                ttlMinutes = runtime.cacheMessageExpireMinutes.toLong(),
+            )
+        }
+```
+
+- [ ] **Step 4: Update all `invalidateByPrefix` callers to `invalidateNamespace`**
+
+In `platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt`, replace all 7 occurrences of `invalidateByPrefix` with `invalidateNamespace`:
+
+```
+cache.invalidateByPrefix("list:")  →  cache.invalidateNamespace("list")
+```
+
+Note: the prefix `"list:"` becomes namespace `"list"` (no trailing colon needed with generation counters).
+
+- [ ] **Step 5: Update MessageCacheTest mocks**
+
+In `platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageCacheTest.kt`, replace all occurrences:
+```
+cache.invalidateByPrefix("list:")  →  cache.invalidateNamespace("list")
+```
+
+- [ ] **Step 6: Update CaffeineMessageCacheTest**
+
+Replace `platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/CaffeineMessageCacheTest.kt` with:
+```kotlin
+package io.github.rygel.outerstellar.platform.persistence
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CaffeineMessageCacheTest {
+
+    private val cache = CaffeineMessageCache()
+
+    @Test
+    fun `invalidateNamespace bumps generation making old keys stale`() {
+        cache.put("list:0:all:null:10:0", "result-1")
+        cache.put("entity:abc-123", "message-1")
+
+        cache.invalidateNamespace("list")
+
+        assertNull(cache.get("list:0:all:null:10:0"))
+        assertEquals("message-1", cache.get("entity:abc-123"))
+    }
+
+    @Test
+    fun `invalidateNamespace with no prior keys is a no-op`() {
+        cache.put("entity:abc-123", "message-1")
+
+        cache.invalidateNamespace("list")
+
+        assertEquals("message-1", cache.get("entity:abc-123"))
+    }
+
+    @Test
+    fun `generationKey includes current generation`() {
+        assertEquals("list:0:query", cache.generationKey("list", "query"))
+        cache.invalidateNamespace("list")
+        assertEquals("list:1:query", cache.generationKey("list", "query"))
+    }
+
+    @Test
+    fun `constructor accepts custom size and TTL`() {
+        val custom = CaffeineMessageCache(maxSize = 50, ttlMinutes = 1)
+        custom.put("key", "value")
+        assertEquals("value", custom.get("key"))
+    }
+}
+```
+
+- [ ] **Step 7: Update test Stubs.kt if needed**
+
+Check `platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/Stubs.kt` for `invalidateByPrefix` and replace with `invalidateNamespace` if present.
+
+- [ ] **Step 8: Verify build and tests**
+
+Run: `mvn -pl platform-core,platform-web test -Dexec.skip=true`
+
+Expected: All tests pass
+
+- [ ] **Step 9: Commit**
+
+```
+git add platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/MessageCache.kt platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/CaffeineMessageCache.kt platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/WebModule.kt platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/CaffeineMessageCacheTest.kt platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageCacheTest.kt
+git commit -m "perf: wire RuntimeConfig into CaffeineMessageCache and use generation-based invalidation"
+```
+
+---
+
+## Task 7: Search Indexes — pg_trgm GIN
+
+**Files:**
+- Create: `platform-persistence-jooq/src/main/resources/db/migration/V10__add_trgm_search_indexes.sql`
+- Create: `platform-persistence-jdbi/src/main/resources/db/migration/V10__add_trgm_search_indexes.sql`
+
+- [ ] **Step 1: Create the Flyway migration**
+
+Create the file `platform-persistence-jooq/src/main/resources/db/migration/V10__add_trgm_search_indexes.sql` with:
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_plt_messages_content_trgm
+    ON plt_messages USING GIN (content gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_plt_contacts_name_trgm
+    ON plt_contacts USING GIN (name gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_plt_contacts_company_trgm
+    ON plt_contacts USING GIN (company gin_trgm_ops);
+```
+
+Copy the same file to `platform-persistence-jdbi/src/main/resources/db/migration/V10__add_trgm_search_indexes.sql`.
+
+- [ ] **Step 2: Verify build compiles and migration is picked up**
+
+Run: `mvn -pl platform-persistence-jooq,platform-persistence-jdbi compile`
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```
+git add platform-persistence-jooq/src/main/resources/db/migration/V10__add_trgm_search_indexes.sql platform-persistence-jdbi/src/main/resources/db/migration/V10__add_trgm_search_indexes.sql
+git commit -m "perf: add pg_trgm GIN indexes for message content and contact name/company search"
+```
+
+---
+
+## Final Verification
+
+After all 7 tasks are complete:
+
+- [ ] **Run full reactor verify**
+
+```bash
+mvn clean verify -T4 -pl platform-core,platform-security,platform-persistence-jooq,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
+```
+
+Expected: BUILD SUCCESS, 0 test failures, 0 quality gate violations
+
+- [ ] **Update TODO.md files — mark performance items as done**
+
+In `docs/TODO.md`, mark these as `[x]`:
+- Wire runtime cache settings into CaffeineMessageCache
+- Replace prefix-scan message cache invalidation
+- Resolve session state once per request
+- Precompute JTE template class lookup
+- Restrict dynamic ETag hashing
+- Use bounded executor for Segment analytics
+- Avoid loading all users for admin row actions
+- Add text-search indexes for %LIKE% search paths
+
+In root `TODO.md`, find and mark the matching performance items.
+
+- [ ] **Final commit**
+
+```
+git add docs/TODO.md TODO.md
+git commit -m "docs: mark completed performance optimization items"
+```

--- a/docs/superpowers/specs/2026-05-16-performance-optimizations-design.md
+++ b/docs/superpowers/specs/2026-05-16-performance-optimizations-design.md
@@ -1,0 +1,247 @@
+# Performance Optimizations — Design Spec
+
+**Date:** 2026-05-16
+**Status:** Draft
+**Scope:** 7 performance items across platform-core, platform-web, platform-persistence-jooq, platform-persistence-jdbi
+
+---
+
+## 1. WebContext — Single Session Lookup
+
+**Problem:** `WebContext.user` and `WebContext.sessionExpired` are independent `lazy` properties that each call `securityService.lookupSession(rawToken)`. When both are accessed during a request (common path: `sessionTimeout` filter checks `sessionExpired` then `user`), `lookupSession` fires twice — 2x DB reads + 2x DB writes per request.
+
+**Solution:** Extract a single `lazy` session lookup result that both properties derive from.
+
+```kotlin
+private val sessionLookup: SessionLookup? by lazy {
+    request.cookie(SESSION_COOKIE)?.value?.let { rawToken ->
+        securityService?.lookupSession(rawToken)
+    }
+}
+
+val user: User? by lazy {
+    sessionLookup.let { lookup ->
+        when (lookup) {
+            is SessionLookup.Active -> lookup.user
+            else -> null
+        }
+    }
+}
+
+val sessionExpired: Boolean by lazy {
+    sessionLookup is SessionLookup.Expired
+}
+```
+
+**Files:** `platform-web/.../web/WebContext.kt` (lines 92-112)
+
+**Risk:** Low. Same data, derived once. The JWT fallback path in `user` remains independent since JWT lookup is a different code path.
+
+---
+
+## 2. Segment Analytics — Bounded Executor
+
+**Problem:** `SegmentAnalyticsService.send()` spawns a new `Thread` per analytics event. Under load, this creates unbounded threads with no backpressure.
+
+**Solution:** Replace with a single-thread `ExecutorService` backed by a bounded queue with drop-oldest policy.
+
+```kotlin
+private val executor = Executors.newSingleThreadExecutor { r ->
+    Thread(r, "segment-analytics").also { it.isDaemon = true }
+}
+
+private val queue = LinkedBlockingQueue<Runnable>(100)
+```
+
+On queue full, drop the event and log at WARN. The executor reuses one thread for all events. On `close()`, call `executor.shutdown()` with a 5-second timeout.
+
+**Files:** `platform-core/.../analytics/SegmentAnalyticsService.kt` (lines 85-96)
+
+**Risk:** Low. Same fire-and-forget semantics. Drop policy is acceptable for analytics — losing an event is better than blocking a request thread.
+
+---
+
+## 3. Admin Actions — Single User Lookup
+
+**Problem:** `UserAdminRoutes` toggle-enabled and toggle-role routes call `securityService.listUsers()` (loads ALL users) then `.find { it.id == userId }` to read current state for toggling. `SecurityService.setUserEnabled`/`setUserRole` already call `findById` internally, making this a redundant full-table scan.
+
+**Solution:** Add `SecurityService.findUserSummary(id)` method, use it in toggle routes instead of `listUsers()`.
+
+```kotlin
+// SecurityService
+fun findUserSummary(id: UUID): UserSummary? {
+    return userRepository.findById(id)?.toSummary()
+}
+```
+
+```kotlin
+// UserAdminRoutes — toggle-enabled
+val target = securityService.findUserSummary(UUID.fromString(userId))
+if (target != null) {
+    securityService.setUserEnabled(admin.id, UUID.fromString(userId), !target.enabled)
+}
+```
+
+Same pattern for toggle-role.
+
+**Files:**
+- `platform-security/.../security/SecurityService.kt` (add method)
+- `platform-web/.../web/UserAdminRoutes.kt` (lines 60-69, 99-109)
+
+**Risk:** Low. `setUserEnabled`/`setUserRole` still do their own `findById` internally for validation — this is a redundant lookup but it's a single-row index hit, negligible cost. Removing the internal `findById` would require changing SecurityService's API contracts and is out of scope.
+
+---
+
+## 4. CaffeineMessageCache — RuntimeConfig Wiring + O(1) Invalidation
+
+**Problem:**
+- Cache uses hardcoded defaults (`maxSize=1000`, `ttl=10min`) ignoring `RuntimeConfig.cacheMessageMaxSize` / `cacheMessageExpireMinutes`.
+- `invalidateByPrefix()` does O(N) key scan via `cache.asMap().keys.filter { it.startsWith(prefix) }`.
+
+**Solution:**
+
+**4a. Wire RuntimeConfig:**
+Accept `maxSize` and `ttlMinutes` as constructor parameters, defaulting to current values. Wire in `WebModule`.
+
+```kotlin
+class CaffeineMessageCache(
+    maxSize: Long = DEFAULT_MAX_SIZE,
+    ttlMinutes: Long = DEFAULT_TTL_MINUTES,
+    meterRegistry: MeterRegistry? = null,
+)
+```
+
+```kotlin
+// WebModule
+single<MessageCache> {
+    val config = get<AppConfig>()
+    CaffeineMessageCache(
+        maxSize = config.runtime.cacheMessageMaxSize.toLong(),
+        ttlMinutes = config.runtime.cacheMessageExpireMinutes.toLong(),
+    )
+}
+```
+
+**4b. Version-key invalidation:**
+Replace prefix-scan with a `ConcurrentHashMap<String, AtomicLong>` that tracks generation counters per cache namespace (e.g., `"messages"`, `"contacts"`). Include the generation in cache keys. On invalidation, increment the counter — old keys naturally expire via Caffeine's TTL.
+
+```kotlin
+private val generations = ConcurrentHashMap<String, AtomicLong>()
+
+fun cacheKey(namespace: String, key: String): String {
+    val gen = generations.computeIfAbsent(namespace) { AtomicLong(0) }.get()
+    return "$namespace:$gen:$key"
+}
+
+override fun invalidateByPrefix(namespace: String) {
+    generations.computeIfAbsent(namespace) { AtomicLong(0) }.incrementAndGet()
+}
+```
+
+Callers that currently use `invalidateByPrefix("list:")` and `invalidateByPrefix("message:")` switch to the namespace model. Cache keys change from `"list:query:year:limit:offset"` to `"list:<gen>:query:year:limit:offset"`.
+
+**Files:**
+- `platform-core/.../persistence/CaffeineMessageCache.kt`
+- `platform-core/.../persistence/MessageCache.kt` (interface change: `invalidateByPrefix` → `invalidate` with namespace)
+- `platform-web/.../di/WebModule.kt`
+
+**Risk:** Medium. Interface change to `MessageCache` affects callers. The `invalidateByPrefix` callers in `MessageService` need updating. Existing cache entries are lost on deploy (acceptable — cache is transient).
+
+---
+
+## 5. JteClassRegistry — Map Lookup
+
+**Problem:** `getTemplateClass()` does O(N) linear scan over 34 classes on every production template render.
+
+**Solution:** Build a `Map<String, Class<*>>` once at init.
+
+```kotlin
+private val classMap: Map<String, Class<*>> =
+    allClasses.associateBy { it.name }
+
+fun getTemplateClass(templateName: String): Class<*>? {
+    // ... same name derivation logic ...
+    return classMap[fullName]
+}
+```
+
+**Files:** `platform-web/.../infra/JteClassRegistry.kt` (lines 92, 105-118)
+
+**Risk:** Minimal. Same behavior, O(1) instead of O(N). Map is built once at class load.
+
+---
+
+## 6. ETag Filter — Skip Dynamic HTML
+
+**Problem:** `etagCachingFilter` fully buffers every non-JSON 200 response body into a byte array, computes SHA-256, then wraps it back. This doubles memory for large HTML pages and adds latency. Dynamic HTML changes on every render (user data, timestamps), making ETags ineffective — clients never send `If-None-Match` for dynamic pages.
+
+**Solution:** Only compute ETags for responses with cacheable content types (CSS, JS, fonts, images). Skip HTML entirely.
+
+```kotlin
+private val CACHEABLE_TYPES = setOf(
+    "text/css",
+    "application/javascript",
+    "application/font-",
+    "font/",
+    "image/",
+)
+
+// In filter: skip if text/html or not in cacheable set
+if (contentType.contains("text/html") || !CACHEABLE_TYPES.any { contentType.startsWith(it) }) {
+    return response  // skip ETag for dynamic content
+}
+```
+
+This means dynamic HTML responses stream directly without buffering. Static assets (CSS/JS from the Tailwind build) still get ETags and benefit from `304 Not Modified`.
+
+**Files:** `platform-web/.../web/Filters.kt` (lines 59-81)
+
+**Risk:** Low. Static assets still get ETags. Dynamic HTML never benefited from them. No behavioral change for end users.
+
+---
+
+## 7. Search Indexes — pg_trgm GIN
+
+**Problem:** Message and contact search uses `%LIKE%` on `content`, `name`, `company` columns with no text indexes, forcing sequential scans.
+
+**Solution:** Add a Flyway migration enabling `pg_trgm` extension and creating GIN trigram indexes.
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_plt_messages_content_trgm
+    ON plt_messages USING GIN (content gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_plt_contacts_name_trgm
+    ON plt_contacts USING GIN (name gin_trgm_ops);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_plt_contacts_company_trgm
+    ON plt_contacts USING GIN (company gin_trgm_ops);
+```
+
+`CONCURRENTLY` avoids locking the table during index creation on existing data. The `%LIKE%` queries automatically use the trigram indexes — no SQL changes needed.
+
+**Files:**
+- New migration: `platform-persistence-jooq/src/main/resources/db/migration/V10__add_trgm_search_indexes.sql`
+- New migration: `platform-persistence-jdbi/src/main/resources/db/migration/V10__add_trgm_search_indexes.sql`
+
+**Risk:** Low. `pg_trgm` is a standard PostgreSQL extension. Index creation is concurrent (no table lock). Storage overhead is moderate (~2-3x column size for the index). No query changes. Regenerate jOOQ sources not needed (no schema column changes).
+
+---
+
+## Implementation Order
+
+1. JteClassRegistry (trivial, zero risk)
+2. Segment analytics executor (isolated, zero risk)
+3. ETag filter skip (isolated, zero risk)
+4. WebContext single lookup (core change, medium verification)
+5. Admin actions single lookup (simple, needs test updates)
+6. CaffeineMessageCache (interface change, needs careful wiring)
+7. Search indexes (migration, concurrent, needs jOOQ awareness)
+
+## Testing Strategy
+
+- **Unit tests:** WebContext session resolution, CaffeineMessageCache generation counters, SegmentAnalyticsService executor behavior
+- **Integration tests:** Admin toggle routes (verify they no longer call listUsers), MessageService cache invalidation
+- **Migration:** V10 runs in CI against PostgreSQL Testcontainers
+- **Full reactor verify** before push as per AGENTS.md

--- a/docs/superpowers/specs/2026-05-16-performance-optimizations-round2-design.md
+++ b/docs/superpowers/specs/2026-05-16-performance-optimizations-round2-design.md
@@ -1,0 +1,143 @@
+# Performance Optimizations Round 2 — Design Spec
+
+**Date:** 2026-05-16
+**Status:** Draft
+**Scope:** 6 remaining performance items across platform-core, platform-web, platform-sync-client, platform-desktop, platform-persistence-jooq, platform-persistence-jdbi
+
+---
+
+## 1. Debounce Desktop Search Reloads
+
+**Problem:** Typing in the search field fires a DB query on every keystroke (10 queries for "hello" — 5 for messages + 5 for contacts).
+
+**Solution:** Add a 300ms debounce `javax.swing.Timer` in `SyncViewModel.searchQuery` setter. Cancel pending timer on each keystroke; fire `loadMessages()` only after the user pauses. For JavaFX, use `PauseTransition(Duration.millis(300))`.
+
+**Files:**
+- `platform-desktop/.../swing/viewmodel/SyncViewModel.kt` (setter at lines 86-90)
+- `platform-desktop/.../swing/SwingSyncApp.kt` (DocumentListener at lines 490-504)
+- `platform-desktop-javafx/.../fx/controller/MessagesController.kt` (line 77)
+
+---
+
+## 2. Push Search Limits Closer to Providers
+
+**Problem:** Each search provider fetches up to `limit` results independently. With 2 providers and `limit=20`, up to 40 results are fetched and then half are discarded after merging.
+
+**Solution:**
+- Pass `ceil(limit / providers.size)` to each provider instead of full `limit`.
+- Add `listMessagesForSearch(query, limit)` to `MessageService` that skips the `countMessages()` query (search doesn't need total count). Internally calls `repository.listMessages()` directly.
+- Same for contacts: `listContactsForSearch(query, limit)`.
+
+**Files:**
+- `platform-core/.../service/MessageService.kt` (add search-optimized method)
+- `platform-core/.../service/ContactService.kt` (add search-optimized method)
+- `platform-web/.../search/MessageSearchProvider.kt` (use new method)
+- `platform-web/.../search/ContactSearchProvider.kt` (use new method)
+- `platform-web/.../web/SearchRoutes.kt` (divide limit)
+- `platform-web/.../web/SearchPageFactory.kt` (divide limit)
+
+---
+
+## 3. Bound Sync Pull and Dirty Push Batches
+
+**Problem:** `findChangesSince()` and `listDirtyMessages()` have no LIMIT — a device offline for days loads thousands of records in one query.
+
+**Solution:**
+- Add `limit: Int = 500` parameter to `findChangesSince()`, `listDirtyMessages()`, `listDirtyContacts()` in repository interfaces and implementations.
+- Add `hasMore: Boolean` to `SyncPullResponse`.
+- `getChangesSince()` queries with `limit + 1`, returns `hasMore = results.size > limit`, then drops the extra.
+- `SyncService` push loop pages through dirty items in batches of 500.
+- Default limit: 500 (configurable).
+
+**Files:**
+- `platform-core/.../persistence/MessageRepository.kt` (interface)
+- `platform-core/.../persistence/ContactRepository.kt` (interface)
+- `platform-core/.../service/MessageService.kt`
+- `platform-core/.../service/ContactService.kt`
+- `platform-core/.../sync/SyncPullResponse.kt` (add hasMore)
+- `platform-persistence-jooq/.../JooqMessageRepository.kt`
+- `platform-persistence-jooq/.../JooqContactRepository.kt`
+- `platform-persistence-jdbi/.../JdbiMessageRepository.kt`
+- `platform-persistence-jdbi/.../JdbiContactRepository.kt`
+- `platform-sync-client/.../sync/SyncService.kt`
+
+---
+
+## 4. Reduce Paired List/Count Pagination Queries
+
+**Problem:** Every paginated list view runs two SQL queries: `listMessages()` + `countMessages()` with identical WHERE clauses.
+
+**Solution:** Use `COUNT(*) OVER()` window function in the list query. PostgreSQL returns the total count inline with each row (computed once, not per row). Eliminate the separate `countMessages()` / `countContacts()` calls in `MessageService` and `ContactService`.
+
+In jOOQ: `dsl.select(asterisk(), count().over()).from(PLT_MESSAGES)...`
+In JDBI: `SELECT *, COUNT(*) OVER() AS total_count FROM plt_messages ...`
+
+The `listMessages()` return type changes to include total count. Service layer extracts it from the first row (or 0 for empty results).
+
+**Files:**
+- `platform-core/.../persistence/MessageRepository.kt` (add method or change return type)
+- `platform-core/.../persistence/ContactRepository.kt` (same)
+- `platform-core/.../service/MessageService.kt`
+- `platform-core/.../service/ContactService.kt`
+- `platform-persistence-jooq/.../JooqMessageRepository.kt`
+- `platform-persistence-jooq/.../JooqContactRepository.kt`
+- `platform-persistence-jdbi/.../JdbiMessageRepository.kt`
+- `platform-persistence-jdbi/.../JdbiContactRepository.kt`
+
+---
+
+## 5. Batch Sync Push Upserts
+
+**Problem:** Each pushed message requires 3 SQL roundtrips: SELECT (check exists) + INSERT/UPDATE + SELECT (return). For 100 messages, that's 300 queries.
+
+**Solution:** Add `batchUpsertSyncedMessages(List<SyncMessage>): List<StoredMessage>` to repository interfaces.
+
+**Strategy:**
+1. Collect all incoming `syncId`s
+2. Single SELECT to find which already exist: `WHERE sync_id IN (...)`
+3. Partition into inserts vs updates based on existence
+4. jOOQ: use `dsl.batchInsert()` / `dsl.batchUpdate()` for each set
+5. JDBI: use prepared statement `INSERT ... ON CONFLICT (sync_id) DO UPDATE SET ...` in a batch
+6. Single final SELECT to return all stored results
+
+**Files:**
+- `platform-core/.../persistence/MessageRepository.kt` (add batch method)
+- `platform-core/.../persistence/ContactRepository.kt` (add batch method)
+- `platform-core/.../service/MessageService.kt` (use batch in processPushRequest)
+- `platform-core/.../service/ContactService.kt` (use batch in processPushRequest)
+- `platform-persistence-jooq/.../JooqMessageRepository.kt`
+- `platform-persistence-jooq/.../JooqContactRepository.kt`
+- `platform-persistence-jdbi/.../JdbiMessageRepository.kt`
+- `platform-persistence-jdbi/.../JdbiContactRepository.kt`
+- `platform-sync-client/.../sync/SyncService.kt` (use batch on client side too)
+
+---
+
+## 6. Stream or Page CSV Exports
+
+**Problem:** CSV exports load entire datasets into memory (`Int.MAX_VALUE` for audit, `findAll()` for users). Large datasets cause heap pressure.
+
+**Solution:**
+- Replace in-memory `StringBuilder` with paged iteration.
+- Add `listUsersPaged(limit, offset)` and `getAuditLogPaged(limit, offset)` methods.
+- Export handlers loop over pages, appending to a `StringBuilder` per page but releasing each page for GC.
+- Cap audit export at 10,000 rows (configurable constant).
+- User/audit export uses `findPage()` which already exists.
+
+**Files:**
+- `platform-web/.../web/UserAdminRoutes.kt` (export handlers + companion CSV methods)
+- `platform-web/.../export/MessageExportProvider.kt`
+- `platform-web/.../export/ContactExportProvider.kt`
+- `platform-security/.../security/SecurityService.kt` (add paged export method)
+- `platform-core/.../export/ExportService.kt` (streaming support)
+
+---
+
+## Implementation Order
+
+1. Debounce desktop search (isolated, desktop module only)
+2. Push search limits (service + web, simple)
+3. Bound sync batches (interface change, medium)
+4. Reduce paired list/count (repository change, medium)
+5. Batch sync push upserts (complex, multi-repo)
+6. Stream/page CSV exports (medium, web routes)

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/model/Pagination.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/model/Pagination.kt
@@ -11,3 +11,5 @@ data class PaginationMetadata(val currentPage: Int, val pageSize: Int, val total
 }
 
 data class PagedResult<T>(val items: List<T>, val metadata: PaginationMetadata)
+
+data class PagedQueryResult<T>(val items: List<T>, val totalItems: Long)

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/ContactRepository.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/ContactRepository.kt
@@ -1,6 +1,7 @@
 package io.github.rygel.outerstellar.platform.persistence
 
 import io.github.rygel.outerstellar.platform.model.ContactSummary
+import io.github.rygel.outerstellar.platform.model.PagedQueryResult
 import io.github.rygel.outerstellar.platform.model.StoredContact
 import io.github.rygel.outerstellar.platform.sync.SyncContact
 
@@ -14,6 +15,13 @@ interface ContactRepository {
     ): List<ContactSummary>
 
     fun countContacts(query: String? = null, includeDeleted: Boolean = false): Long
+
+    fun listContactsWithTotal(
+        query: String? = null,
+        limit: Int = 100,
+        offset: Int = 0,
+        includeDeleted: Boolean = false,
+    ): PagedQueryResult<ContactSummary>
 
     fun listDirtyContacts(limit: Int = 500): List<StoredContact>
 

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/ContactRepository.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/ContactRepository.kt
@@ -53,6 +53,8 @@ interface ContactRepository {
 
     fun upsertSyncedContact(contact: SyncContact, dirty: Boolean): StoredContact
 
+    fun batchUpsertSyncedContacts(contacts: List<SyncContact>, dirty: Boolean): List<StoredContact>
+
     fun markClean(syncIds: Collection<String>)
 
     fun getLastSyncEpochMs(): Long

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/ContactRepository.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/ContactRepository.kt
@@ -15,11 +15,11 @@ interface ContactRepository {
 
     fun countContacts(query: String? = null, includeDeleted: Boolean = false): Long
 
-    fun listDirtyContacts(): List<StoredContact>
+    fun listDirtyContacts(limit: Int = 500): List<StoredContact>
 
     fun findBySyncId(syncId: String): StoredContact?
 
-    fun findChangesSince(updatedAtEpochMs: Long): List<StoredContact>
+    fun findChangesSince(updatedAtEpochMs: Long, limit: Int = 500): List<StoredContact>
 
     @Suppress("LongParameterList")
     fun createServerContact(

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/MessageRepository.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/MessageRepository.kt
@@ -16,7 +16,7 @@ interface MessageRepository {
 
     fun countMessages(query: String? = null, year: Int? = null, includeDeleted: Boolean = false): Long
 
-    fun listDirtyMessages(): List<StoredMessage>
+    fun listDirtyMessages(limit: Int = 500): List<StoredMessage>
 
     fun countDirtyMessages(): Long
 
@@ -28,7 +28,7 @@ interface MessageRepository {
 
     fun upsertSyncedMessage(message: SyncMessage, dirty: Boolean): StoredMessage
 
-    fun findChangesSince(since: Long): List<StoredMessage>
+    fun findChangesSince(since: Long, limit: Int = 500): List<StoredMessage>
 
     fun getLastSyncEpochMs(): Long
 

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/MessageRepository.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/MessageRepository.kt
@@ -1,6 +1,7 @@
 package io.github.rygel.outerstellar.platform.persistence
 
 import io.github.rygel.outerstellar.platform.model.MessageSummary
+import io.github.rygel.outerstellar.platform.model.PagedQueryResult
 import io.github.rygel.outerstellar.platform.model.StoredMessage
 import io.github.rygel.outerstellar.platform.sync.SyncMessage
 
@@ -15,6 +16,14 @@ interface MessageRepository {
     ): List<MessageSummary>
 
     fun countMessages(query: String? = null, year: Int? = null, includeDeleted: Boolean = false): Long
+
+    fun listMessagesWithTotal(
+        query: String? = null,
+        year: Int? = null,
+        limit: Int = 100,
+        offset: Int = 0,
+        includeDeleted: Boolean = false,
+    ): PagedQueryResult<MessageSummary>
 
     fun listDirtyMessages(limit: Int = 500): List<StoredMessage>
 

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/MessageRepository.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/MessageRepository.kt
@@ -37,6 +37,8 @@ interface MessageRepository {
 
     fun upsertSyncedMessage(message: SyncMessage, dirty: Boolean): StoredMessage
 
+    fun batchUpsertSyncedMessages(messages: List<SyncMessage>, dirty: Boolean): List<StoredMessage>
+
     fun findChangesSince(since: Long, limit: Int = 500): List<StoredMessage>
 
     fun getLastSyncEpochMs(): Long

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/ContactService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/ContactService.kt
@@ -164,35 +164,38 @@ class ContactService(
     fun processPushRequest(
         request: io.github.rygel.outerstellar.platform.sync.SyncPushContactRequest
     ): io.github.rygel.outerstellar.platform.sync.SyncPushContactResponse {
-        var applied = 0
         val conflicts = mutableListOf<io.github.rygel.outerstellar.platform.sync.SyncContactConflict>()
+        val toApply = mutableListOf<io.github.rygel.outerstellar.platform.sync.SyncContact>()
+
+        request.contacts.forEach { pushedContact ->
+            val existing = repository.findBySyncId(pushedContact.syncId)
+            if (existing != null && existing.updatedAtEpochMs > pushedContact.updatedAtEpochMs) {
+                conflicts.add(
+                    io.github.rygel.outerstellar.platform.sync.SyncContactConflict(
+                        syncId = pushedContact.syncId,
+                        reason = "Server has newer version",
+                        serverContact = existing.toSyncContact(),
+                    )
+                )
+            } else {
+                toApply.add(pushedContact)
+            }
+        }
 
         val process = {
-            request.contacts.forEach { pushedContact ->
-                val existing = repository.findBySyncId(pushedContact.syncId)
-                if (existing != null && existing.updatedAtEpochMs > pushedContact.updatedAtEpochMs) {
-                    conflicts.add(
-                        io.github.rygel.outerstellar.platform.sync.SyncContactConflict(
-                            syncId = pushedContact.syncId,
-                            reason = "Server has newer version",
-                            serverContact = existing.toSyncContact(),
-                        )
-                    )
-                } else {
-                    repository.upsertSyncedContact(pushedContact, false)
-                    applied++
-                }
+            if (toApply.isNotEmpty()) {
+                repository.batchUpsertSyncedContacts(toApply, false)
             }
         }
 
         transactionManager?.inTransaction(process) ?: process()
 
-        if (applied > 0 || conflicts.isNotEmpty()) {
+        if (toApply.isNotEmpty() || conflicts.isNotEmpty()) {
             eventPublisher.publishRefresh("contact-list-panel")
         }
 
         return io.github.rygel.outerstellar.platform.sync.SyncPushContactResponse(
-            appliedCount = applied,
+            appliedCount = toApply.size,
             conflicts = conflicts,
         )
     }

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/ContactService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/ContactService.kt
@@ -33,6 +33,10 @@ class ContactService(
         return repository.listContacts(query, limit, offset)
     }
 
+    fun searchContacts(query: String, limit: Int = 20): List<ContactSummary> {
+        return repository.listContacts(query, limit.coerceIn(1, MAX_PAGE_LIMIT), 0)
+    }
+
     fun countContacts(query: String? = null): Long {
         return repository.countContacts(query)
     }

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/ContactService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/ContactService.kt
@@ -19,6 +19,7 @@ class ContactService(
 
     companion object {
         private const val MAX_PAGE_LIMIT = 1000
+        private const val DEFAULT_SYNC_BATCH_SIZE = 500
         const val MAX_NAME_LENGTH = 200
         const val MAX_COMPANY_LENGTH = 200
         const val MAX_ADDRESS_LENGTH = 500
@@ -145,12 +146,18 @@ class ContactService(
         eventPublisher.publishRefresh("contact-list-panel")
     }
 
-    fun getChangesSince(updatedAtEpochMs: Long): io.github.rygel.outerstellar.platform.sync.SyncPullContactResponse {
-        val changes = repository.findChangesSince(updatedAtEpochMs)
+    fun getChangesSince(
+        updatedAtEpochMs: Long,
+        limit: Int = DEFAULT_SYNC_BATCH_SIZE,
+    ): io.github.rygel.outerstellar.platform.sync.SyncPullContactResponse {
+        val changes = repository.findChangesSince(updatedAtEpochMs, limit + 1)
+        val hasMore = changes.size > limit
+        val results = if (hasMore) changes.dropLast(1) else changes
         val serverTimestamp = System.currentTimeMillis()
         return io.github.rygel.outerstellar.platform.sync.SyncPullContactResponse(
-            contacts = changes.map { it.toSyncContact() },
+            contacts = results.map { it.toSyncContact() },
             serverTimestamp = serverTimestamp,
+            hasMore = hasMore,
         )
     }
 

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
@@ -55,11 +55,15 @@ class MessageService(
 
         @Suppress("UNCHECKED_CAST")
         return cache.getOrPut(cacheKey) {
-            val items = repository.listMessages(query, year, limit, offset)
-            val total = repository.countMessages(query, year)
+            val result = repository.listMessagesWithTotal(query, year, limit, offset)
             PagedResult(
-                items = items,
-                metadata = PaginationMetadata(currentPage = (offset / limit) + 1, pageSize = limit, totalItems = total),
+                items = result.items,
+                metadata =
+                    PaginationMetadata(
+                        currentPage = (offset / limit) + 1,
+                        pageSize = limit,
+                        totalItems = result.totalItems,
+                    ),
             )
         } as PagedResult<MessageSummary>
     }
@@ -74,12 +78,11 @@ class MessageService(
         limit: Int = 100,
         offset: Int = 0,
     ): PagedResult<MessageSummary> {
-        val items = repository.listMessages(query, year, limit, offset, includeDeleted = true)
-        val total = repository.countMessages(query, year, includeDeleted = true)
-
+        val result = repository.listMessagesWithTotal(query, year, limit, offset, includeDeleted = true)
         return PagedResult(
-            items = items,
-            metadata = PaginationMetadata(currentPage = (offset / limit) + 1, pageSize = limit, totalItems = total),
+            items = result.items,
+            metadata =
+                PaginationMetadata(currentPage = (offset / limit) + 1, pageSize = limit, totalItems = result.totalItems),
         )
     }
 

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
@@ -63,6 +63,10 @@ class MessageService(
         } as PagedResult<MessageSummary>
     }
 
+    fun searchMessages(query: String, limit: Int = 20): List<MessageSummary> {
+        return repository.listMessages(query, null, limit.coerceIn(1, MAX_PAGE_LIMIT), 0)
+    }
+
     fun listDeletedMessages(
         query: String? = null,
         year: Int? = null,

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
@@ -39,6 +39,7 @@ class MessageService(
 
     companion object {
         private const val MAX_PAGE_LIMIT = 1000
+        private const val DEFAULT_SYNC_BATCH_SIZE = 500
         const val MAX_AUTHOR_LENGTH = 100
         const val MAX_CONTENT_LENGTH = 500
     }
@@ -92,7 +93,8 @@ class MessageService(
         return message
     }
 
-    fun listDirtyMessages(): List<StoredMessage> = repository.listDirtyMessages()
+    fun listDirtyMessages(limit: Int = DEFAULT_SYNC_BATCH_SIZE): List<StoredMessage> =
+        repository.listDirtyMessages(limit)
 
     fun createServerMessage(author: String, content: String): StoredMessage {
         val errors = mutableListOf<String>()
@@ -165,9 +167,11 @@ class MessageService(
         return message
     }
 
-    fun getChangesSince(since: Long): SyncPullResponse {
-        val changes = repository.findChangesSince(since).map { it.toSyncMessage() }
-        return SyncPullResponse(messages = changes, serverTimestamp = System.currentTimeMillis())
+    fun getChangesSince(since: Long, limit: Int = DEFAULT_SYNC_BATCH_SIZE): SyncPullResponse {
+        val changes = repository.findChangesSince(since, limit + 1).map { it.toSyncMessage() }
+        val hasMore = changes.size > limit
+        val results = if (hasMore) changes.dropLast(1) else changes
+        return SyncPullResponse(messages = results, serverTimestamp = System.currentTimeMillis(), hasMore = hasMore)
     }
 
     fun processPushRequest(request: SyncPushRequest): SyncPushResponse {

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
@@ -181,7 +181,7 @@ class MessageService(
         SyncPushRequest.validate(request)
 
         val conflicts = mutableListOf<SyncConflict>()
-        var appliedCount = 0
+        val toApply = mutableListOf<SyncMessage>()
 
         request.messages.forEach { incoming ->
             val current =
@@ -193,9 +193,7 @@ class MessageService(
                 }
             when {
                 current == null || incoming.updatedAtEpochMs >= current.updatedAtEpochMs -> {
-                    val updated = repository.upsertSyncedMessage(incoming, dirty = false)
-                    cache.put("entity:${updated.syncId}", updated)
-                    appliedCount++
+                    toApply.add(incoming)
                 }
                 else -> {
                     repository.markConflict(incoming.syncId, incoming)
@@ -209,12 +207,19 @@ class MessageService(
             }
         }
 
-        if (appliedCount > 0 || conflicts.isNotEmpty()) {
+        val applied =
+            if (toApply.isNotEmpty()) {
+                val upserted = repository.batchUpsertSyncedMessages(toApply, dirty = false)
+                upserted.forEach { cache.put("entity:${it.syncId}", it) }
+                upserted.size
+            } else 0
+
+        if (applied > 0 || conflicts.isNotEmpty()) {
             cache.invalidateNamespace("list")
             eventPublisher.publishRefresh("message-list-panel")
         }
 
-        return SyncPushResponse(appliedCount = appliedCount, conflicts = conflicts)
+        return SyncPushResponse(appliedCount = applied, conflicts = conflicts)
     }
 
     fun restore(syncId: String) {

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/SyncModels.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/SyncModels.kt
@@ -43,7 +43,12 @@ data class SyncPushRequest(val messages: List<SyncMessage> = emptyList()) {
 
 @Serializable data class SyncPushResponse(val appliedCount: Int = 0, val conflicts: List<SyncConflict> = emptyList())
 
-@Serializable data class SyncPullResponse(val messages: List<SyncMessage> = emptyList(), val serverTimestamp: Long = 0)
+@Serializable
+data class SyncPullResponse(
+    val messages: List<SyncMessage> = emptyList(),
+    val serverTimestamp: Long = 0,
+    val hasMore: Boolean = false,
+)
 
 data class SyncStats(val pushedCount: Int = 0, val pulledCount: Int = 0, val conflictCount: Int = 0)
 
@@ -112,4 +117,8 @@ data class SyncContactConflict(val syncId: String, val reason: String, val serve
 data class SyncPushContactResponse(val appliedCount: Int = 0, val conflicts: List<SyncContactConflict> = emptyList())
 
 @Serializable
-data class SyncPullContactResponse(val contacts: List<SyncContact> = emptyList(), val serverTimestamp: Long = 0)
+data class SyncPullContactResponse(
+    val contacts: List<SyncContact> = emptyList(),
+    val serverTimestamp: Long = 0,
+    val hasMore: Boolean = false,
+)

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/ContactServiceTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/ContactServiceTest.kt
@@ -200,7 +200,7 @@ class ContactServiceTest {
 
         assertEquals(1, response.appliedCount)
         assertTrue(response.conflicts.isEmpty())
-        verify { repository.upsertSyncedContact(pushed, false) }
+        verify { repository.batchUpsertSyncedContacts(listOf(pushed), false) }
     }
 
     @Test

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/ContactServiceTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/ContactServiceTest.kt
@@ -172,7 +172,7 @@ class ContactServiceTest {
     @Test
     fun `getChangesSince returns contacts mapped to sync format`() {
         val contact = storedContact(syncId = "sync-1", updatedAtEpochMs = 500L)
-        every { repository.findChangesSince(300L) } returns listOf(contact)
+        every { repository.findChangesSince(300L, any()) } returns listOf(contact)
 
         val response = service.getChangesSince(300L)
 

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageCacheTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageCacheTest.kt
@@ -30,13 +30,13 @@ class MessageCacheTest {
             {
                 cache.get(firstArg()) ?: secondArg<() -> Any>()().also { cache.put(firstArg(), it) }
             }
-        every { repository.listMessages(any(), any(), any(), any()) } returns items
-        every { repository.countMessages(any(), any()) } returns 1L
+        every { repository.listMessagesWithTotal(any(), any(), any(), any(), any()) } returns
+            io.github.rygel.outerstellar.platform.model.PagedQueryResult(items, 1L)
 
         // First call - cache miss
         val firstResult = service.listMessages("test")
         assertEquals(results, firstResult)
-        verify { repository.listMessages("test", null, 100, 0) }
+        verify { repository.listMessagesWithTotal("test", null, 100, 0, false) }
         verify { cache.put("list:test:null:100:0", results) }
 
         // Second call - cache hit
@@ -44,7 +44,7 @@ class MessageCacheTest {
         val secondResult = service.listMessages("test")
         assertEquals(results, secondResult)
         // Verify repository was not called again
-        verify(exactly = 1) { repository.listMessages(any(), any(), any(), any()) }
+        verify(exactly = 1) { repository.listMessagesWithTotal(any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageServiceTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageServiceTest.kt
@@ -28,8 +28,8 @@ class MessageServiceTest {
         val items = listOf(summary)
         val paged = PagedResult(items, PaginationMetadata(1, 10, 1L))
 
-        every { repository.listMessages("test", null, 10, 0) } returns items
-        every { repository.countMessages("test", null) } returns 1L
+        every { repository.listMessagesWithTotal("test", null, 10, 0, false) } returns
+            io.github.rygel.outerstellar.platform.model.PagedQueryResult(items, 1L)
 
         val result = service.listMessages("test", limit = 10, offset = 0)
         assertEquals(paged, result)

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageServiceTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageServiceTest.kt
@@ -39,7 +39,7 @@ class MessageServiceTest {
     fun `listDirtyMessages returns dirty items from repository`() {
         val msg = StoredMessage("id-1", "author", "content", 1000L, true, false, 1L)
         val items = listOf(msg)
-        every { repository.listDirtyMessages() } returns items
+        every { repository.listDirtyMessages(any()) } returns items
 
         val result = service.listDirtyMessages()
         assertEquals(items, result)

--- a/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/viewmodel/SyncViewModel.kt
+++ b/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/viewmodel/SyncViewModel.kt
@@ -13,6 +13,7 @@ import io.github.rygel.outerstellar.platform.sync.engine.EngineState
 import io.github.rygel.outerstellar.platform.sync.engine.SyncEngine
 import java.util.concurrent.CopyOnWriteArrayList
 import javax.swing.SwingWorker
+import javax.swing.Timer
 
 @Suppress("TooManyFunctions")
 class SyncViewModel(
@@ -85,9 +86,18 @@ class SyncViewModel(
     var content: String = ""
     var searchQuery: String = ""
         set(value) {
+            if (field == value) return
             field = value
-            loadMessages()
+            searchDebounceTimer?.stop()
+            searchDebounceTimer =
+                Timer(300) { loadMessages() }
+                    .apply {
+                        isRepeats = false
+                        start()
+                    }
         }
+
+    private var searchDebounceTimer: Timer? = null
 
     val connectivityChecker: ConnectivityChecker? = null
 

--- a/platform-desktop/src/test/kotlin/io/github/rygel/outerstellar/platform/swing/SyncViewModelSearchTest.kt
+++ b/platform-desktop/src/test/kotlin/io/github/rygel/outerstellar/platform/swing/SyncViewModelSearchTest.kt
@@ -1,0 +1,66 @@
+package io.github.rygel.outerstellar.platform.swing
+
+import io.github.rygel.outerstellar.i18n.I18nService
+import io.github.rygel.outerstellar.platform.swing.viewmodel.SyncViewModel
+import io.github.rygel.outerstellar.platform.sync.engine.SyncEngine
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SyncViewModelSearchTest {
+    private val engine = mockk<SyncEngine>(relaxed = true)
+    private val i18n = mockk<I18nService>(relaxed = true)
+
+    @Test
+    fun `searchQuery debounces rapid keystrokes`() {
+        val latch = CountDownLatch(1)
+        every { engine.loadMessages() } answers
+            {
+                latch.countDown()
+                Unit
+            }
+        val viewModel = SyncViewModel(engine, i18n)
+        viewModel.searchQuery = "h"
+        viewModel.searchQuery = "he"
+        viewModel.searchQuery = "hel"
+        viewModel.searchQuery = "hell"
+        viewModel.searchQuery = "hello"
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        verify(exactly = 1) { engine.loadMessages() }
+    }
+
+    @Test
+    fun `searchQuery initial set triggers loadMessages`() {
+        val latch = CountDownLatch(1)
+        every { engine.loadMessages() } answers
+            {
+                latch.countDown()
+                Unit
+            }
+        val viewModel = SyncViewModel(engine, i18n)
+        viewModel.searchQuery = "test"
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        verify(exactly = 1) { engine.loadMessages() }
+    }
+
+    @Test
+    fun `searchQuery same value does not trigger additional loadMessages`() {
+        val latch = CountDownLatch(1)
+        every { engine.loadMessages() } answers
+            {
+                latch.countDown()
+                Unit
+            }
+        val viewModel = SyncViewModel(engine, i18n)
+        viewModel.searchQuery = "test"
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        viewModel.searchQuery = "test"
+        SwingUtilities.invokeAndWait {}
+        verify(exactly = 1) { engine.loadMessages() }
+    }
+}

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiContactRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiContactRepository.kt
@@ -223,6 +223,64 @@ class JdbiContactRepository(private val jdbi: Jdbi) : ContactRepository {
         return requireNotNull(findBySyncId(contact.syncId))
     }
 
+    override fun batchUpsertSyncedContacts(contacts: List<SyncContact>, dirty: Boolean): List<StoredContact> {
+        if (contacts.isEmpty()) return emptyList()
+
+        jdbi.useTransaction<Exception> { handle ->
+            val batch =
+                handle.prepareBatch(
+                    """
+                INSERT INTO plt_contacts (sync_id, name, company, company_address, department, updated_at_epoch_ms, dirty, deleted, version)
+                VALUES (:syncId, :name, :company, :companyAddress, :department, :updatedAtEpochMs, :dirty, :deleted, 1)
+                ON CONFLICT (sync_id) DO UPDATE SET
+                    name = EXCLUDED.name,
+                    company = EXCLUDED.company,
+                    company_address = EXCLUDED.company_address,
+                    department = EXCLUDED.department,
+                    updated_at_epoch_ms = EXCLUDED.updated_at_epoch_ms,
+                    dirty = EXCLUDED.dirty,
+                    deleted = EXCLUDED.deleted,
+                    version = plt_contacts.version + 1
+                """
+                )
+            contacts.forEach { c ->
+                batch
+                    .bind("syncId", c.syncId)
+                    .bind("name", c.name)
+                    .bind("company", c.company)
+                    .bind("companyAddress", c.companyAddress)
+                    .bind("department", c.department)
+                    .bind("updatedAtEpochMs", c.updatedAtEpochMs)
+                    .bind("dirty", dirty)
+                    .bind("deleted", c.deleted)
+                    .add()
+            }
+            batch.execute()
+
+            for (c in contacts) {
+                val contactId = getContactId(handle, c.syncId) ?: continue
+                insertCollections(handle, contactId, c.emails, c.phones, c.socialMedia)
+            }
+        }
+
+        return jdbi.withHandle<List<StoredContact>, Exception> { handle ->
+            handle
+                .createQuery(
+                    "SELECT id, sync_id, name, company, company_address, department, updated_at_epoch_ms, dirty, deleted, version, sync_conflict FROM plt_contacts WHERE sync_id IN (<ids>)"
+                )
+                .bindList("ids", contacts.map { it.syncId })
+                .map { rs, _ -> readContactRow(rs) }
+                .list()
+                .let { rows ->
+                    val ids = rows.map { it.id }
+                    val emailsByContact = loadEmailsForContacts(handle, ids)
+                    val phonesByContact = loadPhonesForContacts(handle, ids)
+                    val socialsByContact = loadSocialsForContacts(handle, ids)
+                    rows.map { mapContact(it, emailsByContact, phonesByContact, socialsByContact) }
+                }
+        }
+    }
+
     override fun markClean(syncIds: Collection<String>) {
         if (syncIds.isEmpty()) return
         jdbi.useHandle<Exception> { handle ->

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiContactRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiContactRepository.kt
@@ -2,6 +2,7 @@ package io.github.rygel.outerstellar.platform.persistence
 
 import io.github.rygel.outerstellar.platform.model.ContactSummary
 import io.github.rygel.outerstellar.platform.model.OptimisticLockException
+import io.github.rygel.outerstellar.platform.model.PagedQueryResult
 import io.github.rygel.outerstellar.platform.model.StoredContact
 import io.github.rygel.outerstellar.platform.sync.SyncContact
 import java.util.UUID
@@ -46,6 +47,47 @@ class JdbiContactRepository(private val jdbi: Jdbi) : ContactRepository {
             val q = handle.createQuery("SELECT COUNT(*) FROM plt_contacts WHERE $whereClause")
             bindings(q)
             q.mapTo(Long::class.java).one()
+        }
+    }
+
+    override fun listContactsWithTotal(
+        query: String?,
+        limit: Int,
+        offset: Int,
+        includeDeleted: Boolean,
+    ): PagedQueryResult<ContactSummary> {
+        return jdbi.withHandle<PagedQueryResult<ContactSummary>, Exception> { handle ->
+            val (whereClause, bindings) = buildFilterClause(query, includeDeleted)
+            val sql =
+                """
+                SELECT id, sync_id, name, company, company_address, department, updated_at_epoch_ms,
+                       dirty, deleted, version, sync_conflict, COUNT(*) OVER() AS total_count
+                FROM plt_contacts
+                WHERE $whereClause
+                ORDER BY name ASC
+                LIMIT :limit OFFSET :offset
+                """
+            val q = handle.createQuery(sql)
+            bindings(q)
+            val rows =
+                q.bind("limit", limit)
+                    .bind("offset", offset)
+                    .map { rs, _ ->
+                        val totalCount = rs.getLong("total_count")
+                        val contactRow = readContactRow(rs)
+                        contactRow to totalCount
+                    }
+                    .list()
+            val totalCount = rows.firstOrNull()?.second ?: 0L
+            val contactRows = rows.map { it.first }
+            val contactIds = contactRows.map { it.id }
+            val emailsByContact = loadEmailsForContacts(handle, contactIds)
+            val phonesByContact = loadPhonesForContacts(handle, contactIds)
+            val socialsByContact = loadSocialsForContacts(handle, contactIds)
+            val items = contactRows.map {
+                mapContact(it, emailsByContact, phonesByContact, socialsByContact).toSummary()
+            }
+            PagedQueryResult(items = items, totalItems = totalCount)
         }
     }
 

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiContactRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiContactRepository.kt
@@ -49,13 +49,14 @@ class JdbiContactRepository(private val jdbi: Jdbi) : ContactRepository {
         }
     }
 
-    override fun listDirtyContacts(): List<StoredContact> =
+    override fun listDirtyContacts(limit: Int): List<StoredContact> =
         jdbi.withHandle<List<StoredContact>, Exception> { handle ->
             val contacts =
                 handle
                     .createQuery(
-                        "                SELECT id, sync_id, name, company, company_address, department, updated_at_epoch_ms, dirty, deleted, version, sync_conflict FROM plt_contacts WHERE dirty = true"
+                        "                SELECT id, sync_id, name, company, company_address, department, updated_at_epoch_ms, dirty, deleted, version, sync_conflict FROM plt_contacts WHERE dirty = true LIMIT :limit"
                     )
+                    .bind("limit", limit)
                     .map { rs, _ -> readContactRow(rs) }
                     .list()
             val contactIds = contacts.map { it.id }
@@ -84,14 +85,15 @@ class JdbiContactRepository(private val jdbi: Jdbi) : ContactRepository {
         return mapContact(contact, emailsByContact, phonesByContact, socialsByContact)
     }
 
-    override fun findChangesSince(updatedAtEpochMs: Long): List<StoredContact> =
+    override fun findChangesSince(updatedAtEpochMs: Long, limit: Int): List<StoredContact> =
         jdbi.withHandle<List<StoredContact>, Exception> { handle ->
             val contacts =
                 handle
                     .createQuery(
-                        "                SELECT id, sync_id, name, company, company_address, department, updated_at_epoch_ms, dirty, deleted, version, sync_conflict FROM plt_contacts WHERE updated_at_epoch_ms > :since"
+                        "                SELECT id, sync_id, name, company, company_address, department, updated_at_epoch_ms, dirty, deleted, version, sync_conflict FROM plt_contacts WHERE updated_at_epoch_ms > :since LIMIT :limit"
                     )
                     .bind("since", updatedAtEpochMs)
+                    .bind("limit", limit)
                     .map { rs, _ -> readContactRow(rs) }
                     .list()
             val contactIds = contacts.map { it.id }

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiMessageRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiMessageRepository.kt
@@ -2,6 +2,7 @@ package io.github.rygel.outerstellar.platform.persistence
 
 import io.github.rygel.outerstellar.platform.model.MessageSummary
 import io.github.rygel.outerstellar.platform.model.OptimisticLockException
+import io.github.rygel.outerstellar.platform.model.PagedQueryResult
 import io.github.rygel.outerstellar.platform.model.StoredMessage
 import io.github.rygel.outerstellar.platform.sync.SyncMessage
 import java.time.ZoneOffset
@@ -46,6 +47,41 @@ class JdbiMessageRepository(private val jdbi: Jdbi) : MessageRepository {
             val q = handle.createQuery("SELECT COUNT(*) FROM plt_messages WHERE $whereClause")
             bindings(q)
             q.mapTo(Long::class.java).one()
+        }
+    }
+
+    override fun listMessagesWithTotal(
+        query: String?,
+        year: Int?,
+        limit: Int,
+        offset: Int,
+        includeDeleted: Boolean,
+    ): PagedQueryResult<MessageSummary> {
+        return jdbi.withHandle<PagedQueryResult<MessageSummary>, Exception> { handle ->
+            val (whereClause, bindings) = buildFilterClause(query, year, includeDeleted)
+            val sql =
+                """
+                SELECT sync_id, author, content, updated_at_epoch_ms, dirty, deleted, version, sync_conflict,
+                       COUNT(*) OVER() AS total_count
+                FROM plt_messages
+                WHERE $whereClause
+                ORDER BY updated_at_epoch_ms DESC, id DESC
+                LIMIT :limit OFFSET :offset
+                """
+            val q = handle.createQuery(sql)
+            bindings(q)
+            val rows =
+                q.bind("limit", limit)
+                    .bind("offset", offset)
+                    .map { rs, _ ->
+                        val totalCount = rs.getLong("total_count")
+                        val msg = mapMessage(rs)
+                        msg to totalCount
+                    }
+                    .list()
+            val totalCount = rows.firstOrNull()?.second ?: 0L
+            val items = rows.map { it.first }.map(StoredMessage::toSummary)
+            PagedQueryResult(items = items, totalItems = totalCount)
         }
     }
 

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiMessageRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiMessageRepository.kt
@@ -49,12 +49,13 @@ class JdbiMessageRepository(private val jdbi: Jdbi) : MessageRepository {
         }
     }
 
-    override fun listDirtyMessages(): List<StoredMessage> =
+    override fun listDirtyMessages(limit: Int): List<StoredMessage> =
         jdbi.withHandle<List<StoredMessage>, Exception> { handle ->
             handle
                 .createQuery(
-                    "SELECT sync_id, author, content, updated_at_epoch_ms, dirty, deleted, version, sync_conflict FROM plt_messages WHERE dirty = true AND deleted_at IS NULL"
+                    "SELECT sync_id, author, content, updated_at_epoch_ms, dirty, deleted, version, sync_conflict FROM plt_messages WHERE dirty = true AND deleted_at IS NULL LIMIT :limit"
                 )
+                .bind("limit", limit)
                 .map { rs, _ -> mapMessage(rs) }
                 .list()
         }
@@ -80,16 +81,18 @@ class JdbiMessageRepository(private val jdbi: Jdbi) : MessageRepository {
             .findOne()
             .orElse(null)
 
-    override fun findChangesSince(since: Long): List<StoredMessage> =
+    override fun findChangesSince(since: Long, limit: Int): List<StoredMessage> =
         jdbi.withHandle<List<StoredMessage>, Exception> { handle ->
             handle
                 .createQuery(
                     """
                     SELECT sync_id, author, content, updated_at_epoch_ms, dirty, deleted, version, sync_conflict FROM plt_messages
                     WHERE updated_at_epoch_ms > :since AND deleted_at IS NULL
+                    LIMIT :limit
                     """
                 )
                 .bind("since", since)
+                .bind("limit", limit)
                 .map { rs, _ -> mapMessage(rs) }
                 .list()
         }

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiMessageRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiMessageRepository.kt
@@ -180,6 +180,49 @@ class JdbiMessageRepository(private val jdbi: Jdbi) : MessageRepository {
         return requireNotNull(findBySyncId(message.syncId))
     }
 
+    override fun batchUpsertSyncedMessages(messages: List<SyncMessage>, dirty: Boolean): List<StoredMessage> {
+        if (messages.isEmpty()) return emptyList()
+
+        jdbi.useHandle<Exception> { handle ->
+            val batch =
+                handle.prepareBatch(
+                    """
+                INSERT INTO plt_messages (sync_id, author, content, updated_at_epoch_ms, dirty, deleted, version)
+                VALUES (:syncId, :author, :content, :updatedAtEpochMs, :dirty, :deleted, 1)
+                ON CONFLICT (sync_id) DO UPDATE SET
+                    author = EXCLUDED.author,
+                    content = EXCLUDED.content,
+                    updated_at_epoch_ms = EXCLUDED.updated_at_epoch_ms,
+                    dirty = EXCLUDED.dirty,
+                    deleted = EXCLUDED.deleted,
+                    version = plt_messages.version + 1
+                """
+                )
+            messages.forEach { msg ->
+                batch
+                    .bind("syncId", msg.syncId)
+                    .bind("author", msg.author)
+                    .bind("content", msg.content)
+                    .bind("updatedAtEpochMs", msg.updatedAtEpochMs)
+                    .bind("dirty", dirty)
+                    .bind("deleted", msg.deleted)
+                    .add()
+            }
+            batch.execute()
+        }
+
+        return jdbi.withHandle<List<StoredMessage>, Exception> { handle ->
+            val ids = messages.map { it.syncId }
+            handle
+                .createQuery(
+                    "SELECT sync_id, author, content, updated_at_epoch_ms, dirty, deleted, version, sync_conflict FROM plt_messages WHERE sync_id IN (<ids>)"
+                )
+                .bindList("ids", ids)
+                .map { rs, _ -> mapMessage(rs) }
+                .list()
+        }
+    }
+
     override fun markClean(syncIds: Collection<String>) {
         if (syncIds.isEmpty()) return
         jdbi.useHandle<Exception> { handle ->

--- a/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqContactRepository.kt
+++ b/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqContactRepository.kt
@@ -67,7 +67,7 @@ class JooqContactRepository(private val dsl: DSLContext) : ContactRepository {
         return dsl.fetchCount(PLT_CONTACTS, getFilterConditions(query, includeDeleted)).toLong()
     }
 
-    override fun listDirtyContacts(): List<StoredContact> =
+    override fun listDirtyContacts(limit: Int): List<StoredContact> =
         dsl.select(
                 PLT_CONTACTS.ID,
                 PLT_CONTACTS.SYNC_ID,
@@ -86,6 +86,7 @@ class JooqContactRepository(private val dsl: DSLContext) : ContactRepository {
             )
             .from(PLT_CONTACTS)
             .where(PLT_CONTACTS.DIRTY.eq(true))
+            .limit(limit)
             .fetch(::toStoredContact)
 
     override fun findBySyncId(syncId: String): StoredContact? =
@@ -109,7 +110,7 @@ class JooqContactRepository(private val dsl: DSLContext) : ContactRepository {
             .where(PLT_CONTACTS.SYNC_ID.eq(syncId))
             .fetchOne(::toStoredContact)
 
-    override fun findChangesSince(updatedAtEpochMs: Long): List<StoredContact> =
+    override fun findChangesSince(updatedAtEpochMs: Long, limit: Int): List<StoredContact> =
         dsl.select(
                 PLT_CONTACTS.ID,
                 PLT_CONTACTS.SYNC_ID,
@@ -128,6 +129,7 @@ class JooqContactRepository(private val dsl: DSLContext) : ContactRepository {
             )
             .from(PLT_CONTACTS)
             .where(PLT_CONTACTS.UPDATED_AT_EPOCH_MS.gt(updatedAtEpochMs))
+            .limit(limit)
             .fetch(::toStoredContact)
 
     override fun createServerContact(

--- a/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqContactRepository.kt
+++ b/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqContactRepository.kt
@@ -237,6 +237,97 @@ class JooqContactRepository(private val dsl: DSLContext) : ContactRepository {
         return requireNotNull(findBySyncId(contact.syncId))
     }
 
+    override fun batchUpsertSyncedContacts(contacts: List<SyncContact>, dirty: Boolean): List<StoredContact> {
+        if (contacts.isEmpty()) return emptyList()
+
+        val existingMap =
+            dsl.select(PLT_CONTACTS.SYNC_ID, PLT_CONTACTS.VERSION)
+                .from(PLT_CONTACTS)
+                .where(PLT_CONTACTS.SYNC_ID.`in`(contacts.map { it.syncId }))
+                .fetch()
+                .associate { it.get(PLT_CONTACTS.SYNC_ID) to (it.get(PLT_CONTACTS.VERSION) ?: 1L) }
+
+        val (toInsert, toUpdate) = contacts.partition { it.syncId !in existingMap }
+
+        dsl.transaction { config ->
+            val txDsl = using(config)
+
+            if (toInsert.isNotEmpty()) {
+                val insertSteps = toInsert.map { contact ->
+                    txDsl
+                        .insertInto(PLT_CONTACTS)
+                        .set(PLT_CONTACTS.SYNC_ID, contact.syncId)
+                        .set(PLT_CONTACTS.NAME, contact.name)
+                        .set(PLT_CONTACTS.COMPANY, contact.company)
+                        .set(PLT_CONTACTS.COMPANY_ADDRESS, contact.companyAddress)
+                        .set(PLT_CONTACTS.DEPARTMENT, contact.department)
+                        .set(PLT_CONTACTS.UPDATED_AT_EPOCH_MS, contact.updatedAtEpochMs)
+                        .set(PLT_CONTACTS.DIRTY, dirty)
+                        .set(PLT_CONTACTS.DELETED, contact.deleted)
+                        .set(PLT_CONTACTS.VERSION, 1L)
+                }
+                txDsl.batch(insertSteps).execute()
+
+                for (contact in toInsert) {
+                    val contactId =
+                        txDsl
+                            .select(PLT_CONTACTS.ID)
+                            .from(PLT_CONTACTS)
+                            .where(PLT_CONTACTS.SYNC_ID.eq(contact.syncId))
+                            .fetchOne(PLT_CONTACTS.ID) ?: continue
+                    insertCollections(txDsl, contactId, contact.emails, contact.phones, contact.socialMedia)
+                }
+            }
+
+            if (toUpdate.isNotEmpty()) {
+                val updateSteps = toUpdate.map { contact ->
+                    txDsl
+                        .update(PLT_CONTACTS)
+                        .set(PLT_CONTACTS.NAME, contact.name)
+                        .set(PLT_CONTACTS.COMPANY, contact.company)
+                        .set(PLT_CONTACTS.COMPANY_ADDRESS, contact.companyAddress)
+                        .set(PLT_CONTACTS.DEPARTMENT, contact.department)
+                        .set(PLT_CONTACTS.UPDATED_AT_EPOCH_MS, contact.updatedAtEpochMs)
+                        .set(PLT_CONTACTS.DIRTY, dirty)
+                        .set(PLT_CONTACTS.DELETED, contact.deleted)
+                        .set(PLT_CONTACTS.VERSION, (existingMap[contact.syncId] ?: 1L) + 1)
+                        .where(PLT_CONTACTS.SYNC_ID.eq(contact.syncId))
+                }
+                txDsl.batch(updateSteps).execute()
+
+                for (contact in toUpdate) {
+                    val contactId =
+                        txDsl
+                            .select(PLT_CONTACTS.ID)
+                            .from(PLT_CONTACTS)
+                            .where(PLT_CONTACTS.SYNC_ID.eq(contact.syncId))
+                            .fetchOne(PLT_CONTACTS.ID) ?: continue
+                    insertCollections(txDsl, contactId, contact.emails, contact.phones, contact.socialMedia)
+                }
+            }
+        }
+
+        return dsl.select(
+                PLT_CONTACTS.ID,
+                PLT_CONTACTS.SYNC_ID,
+                PLT_CONTACTS.NAME,
+                emailsField,
+                phonesField,
+                socialsField,
+                PLT_CONTACTS.COMPANY,
+                PLT_CONTACTS.COMPANY_ADDRESS,
+                PLT_CONTACTS.DEPARTMENT,
+                PLT_CONTACTS.UPDATED_AT_EPOCH_MS,
+                PLT_CONTACTS.DIRTY,
+                PLT_CONTACTS.DELETED,
+                PLT_CONTACTS.VERSION,
+                PLT_CONTACTS.SYNC_CONFLICT,
+            )
+            .from(PLT_CONTACTS)
+            .where(PLT_CONTACTS.SYNC_ID.`in`(contacts.map { it.syncId }))
+            .fetch(::toStoredContact)
+    }
+
     override fun markClean(syncIds: Collection<String>) {
         if (syncIds.isEmpty()) return
         dsl.update(PLT_CONTACTS).set(PLT_CONTACTS.DIRTY, false).where(PLT_CONTACTS.SYNC_ID.`in`(syncIds)).execute()

--- a/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqContactRepository.kt
+++ b/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqContactRepository.kt
@@ -7,6 +7,7 @@ import io.github.rygel.outerstellar.platform.jooq.tables.references.PLT_CONTACT_
 import io.github.rygel.outerstellar.platform.jooq.tables.references.PLT_SYNC_STATE
 import io.github.rygel.outerstellar.platform.model.ContactSummary
 import io.github.rygel.outerstellar.platform.model.OptimisticLockException
+import io.github.rygel.outerstellar.platform.model.PagedQueryResult
 import io.github.rygel.outerstellar.platform.model.StoredContact
 import io.github.rygel.outerstellar.platform.sync.SyncContact
 import java.util.UUID
@@ -65,6 +66,44 @@ class JooqContactRepository(private val dsl: DSLContext) : ContactRepository {
 
     override fun countContacts(query: String?, includeDeleted: Boolean): Long {
         return dsl.fetchCount(PLT_CONTACTS, getFilterConditions(query, includeDeleted)).toLong()
+    }
+
+    override fun listContactsWithTotal(
+        query: String?,
+        limit: Int,
+        offset: Int,
+        includeDeleted: Boolean,
+    ): PagedQueryResult<ContactSummary> {
+        val conditions = getFilterConditions(query, includeDeleted)
+        val countField = org.jooq.impl.DSL.count().over()
+        val results =
+            dsl.select(
+                    PLT_CONTACTS.ID,
+                    PLT_CONTACTS.SYNC_ID,
+                    PLT_CONTACTS.NAME,
+                    emailsField,
+                    phonesField,
+                    socialsField,
+                    PLT_CONTACTS.COMPANY,
+                    PLT_CONTACTS.COMPANY_ADDRESS,
+                    PLT_CONTACTS.DEPARTMENT,
+                    PLT_CONTACTS.UPDATED_AT_EPOCH_MS,
+                    PLT_CONTACTS.DIRTY,
+                    PLT_CONTACTS.DELETED,
+                    PLT_CONTACTS.VERSION,
+                    PLT_CONTACTS.SYNC_CONFLICT,
+                    countField,
+                )
+                .from(PLT_CONTACTS)
+                .where(conditions)
+                .orderBy(PLT_CONTACTS.NAME.asc())
+                .limit(limit)
+                .offset(offset)
+                .fetch()
+
+        val totalCount = results.firstOrNull()?.getValue(countField)?.toLong() ?: 0L
+        val items = results.map(::toStoredContact).map(StoredContact::toSummary)
+        return PagedQueryResult(items = items, totalItems = totalCount)
     }
 
     override fun listDirtyContacts(limit: Int): List<StoredContact> =

--- a/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqMessageRepository.kt
+++ b/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqMessageRepository.kt
@@ -78,7 +78,7 @@ class JooqMessageRepository(private val dsl: DSLContext) : MessageRepository {
         return countMessages(query, year, true)
     }
 
-    override fun listDirtyMessages(): List<StoredMessage> =
+    override fun listDirtyMessages(limit: Int): List<StoredMessage> =
         dsl.select(
                 PLT_MESSAGES.ID,
                 PLT_MESSAGES.SYNC_ID,
@@ -92,6 +92,7 @@ class JooqMessageRepository(private val dsl: DSLContext) : MessageRepository {
             )
             .from(PLT_MESSAGES)
             .where(PLT_MESSAGES.DIRTY.eq(true).and(PLT_MESSAGES.DELETED_AT.isNull))
+            .limit(limit)
             .fetch(::toStoredMessage)
 
     override fun countDirtyMessages(): Long =
@@ -116,7 +117,7 @@ class JooqMessageRepository(private val dsl: DSLContext) : MessageRepository {
             .where(PLT_MESSAGES.SYNC_ID.eq(syncId))
             .fetchOne(::toStoredMessage)
 
-    override fun findChangesSince(since: Long): List<StoredMessage> =
+    override fun findChangesSince(since: Long, limit: Int): List<StoredMessage> =
         dsl.select(
                 PLT_MESSAGES.ID,
                 PLT_MESSAGES.SYNC_ID,
@@ -130,6 +131,7 @@ class JooqMessageRepository(private val dsl: DSLContext) : MessageRepository {
             )
             .from(PLT_MESSAGES)
             .where(PLT_MESSAGES.UPDATED_AT_EPOCH_MS.gt(since).and(PLT_MESSAGES.DELETED_AT.isNull))
+            .limit(limit)
             .fetch(::toStoredMessage)
 
     override fun createServerMessage(author: String, content: String): StoredMessage =

--- a/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqMessageRepository.kt
+++ b/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqMessageRepository.kt
@@ -202,6 +202,62 @@ class JooqMessageRepository(private val dsl: DSLContext) : MessageRepository {
         return requireNotNull(findBySyncId(message.syncId))
     }
 
+    override fun batchUpsertSyncedMessages(messages: List<SyncMessage>, dirty: Boolean): List<StoredMessage> {
+        if (messages.isEmpty()) return emptyList()
+
+        val existingMap =
+            dsl.select(PLT_MESSAGES.SYNC_ID, PLT_MESSAGES.VERSION)
+                .from(PLT_MESSAGES)
+                .where(PLT_MESSAGES.SYNC_ID.`in`(messages.map { it.syncId }))
+                .fetch()
+                .associate { it.get(PLT_MESSAGES.SYNC_ID) to (it.get(PLT_MESSAGES.VERSION) ?: 1L) }
+
+        val (toInsert, toUpdate) = messages.partition { it.syncId !in existingMap }
+
+        if (toInsert.isNotEmpty()) {
+            val insertSteps = toInsert.map { msg ->
+                dsl.insertInto(PLT_MESSAGES)
+                    .set(PLT_MESSAGES.SYNC_ID, msg.syncId)
+                    .set(PLT_MESSAGES.AUTHOR, msg.author)
+                    .set(PLT_MESSAGES.CONTENT, msg.content)
+                    .set(PLT_MESSAGES.UPDATED_AT_EPOCH_MS, msg.updatedAtEpochMs)
+                    .set(PLT_MESSAGES.DIRTY, dirty)
+                    .set(PLT_MESSAGES.DELETED, msg.deleted)
+                    .set(PLT_MESSAGES.VERSION, 1L)
+            }
+            dsl.batch(insertSteps).execute()
+        }
+
+        if (toUpdate.isNotEmpty()) {
+            val updateSteps = toUpdate.map { msg ->
+                dsl.update(PLT_MESSAGES)
+                    .set(PLT_MESSAGES.AUTHOR, msg.author)
+                    .set(PLT_MESSAGES.CONTENT, msg.content)
+                    .set(PLT_MESSAGES.UPDATED_AT_EPOCH_MS, msg.updatedAtEpochMs)
+                    .set(PLT_MESSAGES.DIRTY, dirty)
+                    .set(PLT_MESSAGES.DELETED, msg.deleted)
+                    .set(PLT_MESSAGES.VERSION, (existingMap[msg.syncId] ?: 1L) + 1)
+                    .where(PLT_MESSAGES.SYNC_ID.eq(msg.syncId))
+            }
+            dsl.batch(updateSteps).execute()
+        }
+
+        return dsl.select(
+                PLT_MESSAGES.ID,
+                PLT_MESSAGES.SYNC_ID,
+                PLT_MESSAGES.AUTHOR,
+                PLT_MESSAGES.CONTENT,
+                PLT_MESSAGES.UPDATED_AT_EPOCH_MS,
+                PLT_MESSAGES.DIRTY,
+                PLT_MESSAGES.DELETED,
+                PLT_MESSAGES.VERSION,
+                PLT_MESSAGES.SYNC_CONFLICT,
+            )
+            .from(PLT_MESSAGES)
+            .where(PLT_MESSAGES.SYNC_ID.`in`(messages.map { it.syncId }))
+            .fetch(::toStoredMessage)
+    }
+
     override fun markClean(syncIds: Collection<String>) {
         if (syncIds.isEmpty()) {
             return

--- a/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqMessageRepository.kt
+++ b/platform-persistence-jooq/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JooqMessageRepository.kt
@@ -4,6 +4,7 @@ import io.github.rygel.outerstellar.platform.jooq.tables.references.PLT_MESSAGES
 import io.github.rygel.outerstellar.platform.jooq.tables.references.PLT_SYNC_STATE
 import io.github.rygel.outerstellar.platform.model.MessageSummary
 import io.github.rygel.outerstellar.platform.model.OptimisticLockException
+import io.github.rygel.outerstellar.platform.model.PagedQueryResult
 import io.github.rygel.outerstellar.platform.model.StoredMessage
 import io.github.rygel.outerstellar.platform.sync.SyncMessage
 import java.time.LocalDateTime
@@ -76,6 +77,40 @@ class JooqMessageRepository(private val dsl: DSLContext) : MessageRepository {
 
     fun countDeletedMessages(query: String?, year: Int?): Long {
         return countMessages(query, year, true)
+    }
+
+    override fun listMessagesWithTotal(
+        query: String?,
+        year: Int?,
+        limit: Int,
+        offset: Int,
+        includeDeleted: Boolean,
+    ): PagedQueryResult<MessageSummary> {
+        val conditions = getFilterConditions(query, year, includeDeleted)
+        val countField = org.jooq.impl.DSL.count().over()
+        val results =
+            dsl.select(
+                    PLT_MESSAGES.ID,
+                    PLT_MESSAGES.SYNC_ID,
+                    PLT_MESSAGES.AUTHOR,
+                    PLT_MESSAGES.CONTENT,
+                    PLT_MESSAGES.UPDATED_AT_EPOCH_MS,
+                    PLT_MESSAGES.DIRTY,
+                    PLT_MESSAGES.DELETED,
+                    PLT_MESSAGES.VERSION,
+                    PLT_MESSAGES.SYNC_CONFLICT,
+                    countField,
+                )
+                .from(PLT_MESSAGES)
+                .where(conditions)
+                .orderBy(PLT_MESSAGES.UPDATED_AT_EPOCH_MS.desc(), PLT_MESSAGES.ID.desc())
+                .limit(limit)
+                .offset(offset)
+                .fetch()
+
+        val totalCount = results.firstOrNull()?.getValue(countField)?.toLong() ?: 0L
+        val items = results.map(::toStoredMessage).map(StoredMessage::toSummary)
+        return PagedQueryResult(items = items, totalItems = totalCount)
     }
 
     override fun listDirtyMessages(limit: Int): List<StoredMessage> =

--- a/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/SyncService.kt
+++ b/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/SyncService.kt
@@ -228,24 +228,34 @@ class SyncService(
 
     override fun sync(): SyncStats {
         val lastSync = repository.getLastSyncEpochMs()
-        val pullRequest = Request(GET, "$baseUrl/api/v1/sync?since=$lastSync")
-        val authenticatedPullRequest =
-            apiToken?.let { pullRequest.header("Authorization", "Bearer $it") } ?: pullRequest
 
-        val pullResponse = client(authenticatedPullRequest)
-        if (pullResponse.status != Status.OK) {
-            throw SyncException("Pull failed: ${pullResponse.status}")
+        val allPulled = mutableListOf<SyncMessage>()
+        var pullHasMore = true
+        var pullSince = lastSync
+        var latestTimestamp = 0L
+
+        while (pullHasMore) {
+            val pullRequest = Request(GET, "$baseUrl/api/v1/sync?since=$pullSince")
+            val authenticatedPullRequest =
+                apiToken?.let { pullRequest.header("Authorization", "Bearer $it") } ?: pullRequest
+            val pullResponse = client(authenticatedPullRequest)
+            if (pullResponse.status != Status.OK) {
+                throw SyncException("Pull failed: ${pullResponse.status}")
+            }
+            val pullBody = pullResponseLens(pullResponse)
+            allPulled.addAll(pullBody.messages)
+            pullHasMore = pullBody.hasMore
+            latestTimestamp = pullBody.serverTimestamp
+            if (pullBody.messages.isNotEmpty()) {
+                pullSince = pullBody.messages.maxOf { it.updatedAtEpochMs }
+            }
         }
-
-        val pullBody = pullResponseLens(pullResponse)
 
         val dirtyMessages = repository.listDirtyMessages()
         val pushRequestData = SyncPushRequest(dirtyMessages.map { it.toSyncMessage() })
 
         val httpRequest = Request(POST, "$baseUrl/api/v1/sync").with(pushRequestLens of pushRequestData)
-
         val authPushRequest = apiToken?.let { httpRequest.header("Authorization", "Bearer $it") } ?: httpRequest
-
         val pushResponse = client(authPushRequest)
         if (pushResponse.status != Status.OK) {
             throw SyncException("Push failed: ${pushResponse.status}")
@@ -254,16 +264,16 @@ class SyncService(
         val pushBody = pushResponseLens(pushResponse)
 
         transactionManager.inTransaction {
-            pullBody.messages.forEach { repository.upsertSyncedMessage(it, false) }
+            allPulled.forEach { repository.upsertSyncedMessage(it, false) }
             pushBody.conflicts.forEach { conflict ->
                 conflict.serverMessage?.let { repository.upsertSyncedMessage(it, false) }
             }
-            repository.setLastSyncEpochMs(pullBody.serverTimestamp)
+            repository.setLastSyncEpochMs(latestTimestamp)
         }
 
         return SyncStats(
             pushedCount = pushBody.appliedCount,
-            pulledCount = pullBody.messages.size,
+            pulledCount = allPulled.size,
             conflictCount = pushBody.conflicts.size,
         )
     }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/export/ContactExportProvider.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/export/ContactExportProvider.kt
@@ -6,24 +6,51 @@ class ContactExportProvider(private val contactService: ContactService?) : Expor
     override val entityType: String = "contact"
     override val displayName: String = "Contacts"
 
-    private val contacts
-        get() = contactService?.listContacts(limit = 1000) ?: emptyList()
-
     override fun headers(): List<String> = listOf("Name", "Emails", "Phones", "Company", "Department")
 
     override fun exportCsv(): String = buildString {
         appendLine(CsvUtils.toCsvRow(headers()))
-        contacts.forEach { c ->
-            appendLine(
-                CsvUtils.toCsvRow(
-                    listOf(c.name, c.emails.joinToString("; "), c.phones.joinToString("; "), c.company, c.department)
+        if (contactService == null) return@buildString
+        var offset = 0
+        val pageSize = 500
+        do {
+            val page = contactService.listContacts(limit = pageSize, offset = offset)
+            page.forEach { c ->
+                appendLine(
+                    CsvUtils.toCsvRow(
+                        listOf(
+                            c.name,
+                            c.emails.joinToString("; "),
+                            c.phones.joinToString("; "),
+                            c.company,
+                            c.department,
+                        )
+                    )
                 )
-            )
-        }
+            }
+            offset += pageSize
+        } while (page.size == pageSize)
     }
 
-    override fun exportJson(): String =
-        contacts.joinToString(",\n", "[\n", "\n]") { c ->
-            """  {"name":"${c.name}","emails":["${c.emails.joinToString("\",\"")}"],"company":"${c.company}","department":"${c.department}"}"""
+    override fun exportJson(): String = buildString {
+        appendLine("[")
+        if (contactService == null) {
+            appendLine("]")
+            return@buildString
         }
+        val allItems = mutableListOf<String>()
+        var offset = 0
+        val pageSize = 500
+        do {
+            val page = contactService.listContacts(limit = pageSize, offset = offset)
+            page.forEach { c ->
+                allItems.add(
+                    """  {"name":"${c.name}","emails":["${c.emails.joinToString("\",\"")}"],"company":"${c.company}","department":"${c.department}"}"""
+                )
+            }
+            offset += pageSize
+        } while (page.size == pageSize)
+        appendLine(allItems.joinToString(",\n"))
+        appendLine("]")
+    }
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/export/MessageExportProvider.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/export/MessageExportProvider.kt
@@ -7,21 +7,42 @@ class MessageExportProvider(private val messageService: MessageService?) : Expor
     override val entityType: String = "message"
     override val displayName: String = "Messages"
 
-    private val messages
-        get() = messageService?.listMessages(limit = 1000)?.items ?: emptyList()
-
     override fun headers(): List<String> = listOf("Author", "Content", "Updated", "Dirty")
 
     override fun exportCsv(): String = buildString {
         appendLine(CsvUtils.toCsvRow(headers()))
-        messages.forEach { msg ->
-            val ts = Instant.ofEpochMilli(msg.updatedAtEpochMs).toString().take(10)
-            appendLine(CsvUtils.toCsvRow(listOf(msg.author, msg.content, ts, msg.dirty.toString())))
-        }
+        if (messageService == null) return@buildString
+        var offset = 0
+        val pageSize = 500
+        do {
+            val page = messageService.listMessages(limit = pageSize, offset = offset)
+            page.items.forEach { msg ->
+                val ts = Instant.ofEpochMilli(msg.updatedAtEpochMs).toString().take(10)
+                appendLine(CsvUtils.toCsvRow(listOf(msg.author, msg.content, ts, msg.dirty.toString())))
+            }
+            offset += pageSize
+        } while (page.items.size == pageSize)
     }
 
-    override fun exportJson(): String =
-        messages.joinToString(",\n", "[\n", "\n]") { msg ->
-            """  {"author":"${msg.author}","content":"${msg.content}","updated":${msg.updatedAtEpochMs},"dirty":${msg.dirty}}"""
+    override fun exportJson(): String = buildString {
+        appendLine("[")
+        if (messageService == null) {
+            appendLine("]")
+            return@buildString
         }
+        val allItems = mutableListOf<String>()
+        var offset = 0
+        val pageSize = 500
+        do {
+            val page = messageService.listMessages(limit = pageSize, offset = offset)
+            page.items.forEach { msg ->
+                allItems.add(
+                    """  {"author":"${msg.author}","content":"${msg.content}","updated":${msg.updatedAtEpochMs},"dirty":${msg.dirty}}"""
+                )
+            }
+            offset += pageSize
+        } while (page.items.size == pageSize)
+        appendLine(allItems.joinToString(",\n"))
+        appendLine("]")
+    }
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/search/ContactSearchProvider.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/search/ContactSearchProvider.kt
@@ -11,17 +11,15 @@ class ContactSearchProvider(private val contactService: ContactService?) : Searc
 
     override fun search(query: String, limit: Int): List<SearchResult> {
         if (query.isBlank() || contactService == null) return emptyList()
-        return contactService
-            .listContacts(query = query, limit = limit.coerceIn(1, MAX_SEARCH_LIMIT), offset = 0)
-            .map { c ->
-                SearchResult(
-                    id = c.syncId,
-                    title = c.name,
-                    subtitle = c.emails.firstOrNull() ?: c.company.ifBlank { c.department },
-                    url = "/contacts",
-                    type = "contact",
-                    score = if (c.name.contains(query, ignoreCase = true)) 1.0 else 0.7,
-                )
-            }
+        return contactService.searchContacts(query, limit.coerceIn(1, MAX_SEARCH_LIMIT)).map { c ->
+            SearchResult(
+                id = c.syncId,
+                title = c.name,
+                subtitle = c.emails.firstOrNull() ?: c.company.ifBlank { c.department },
+                url = "/contacts",
+                type = "contact",
+                score = if (c.name.contains(query, ignoreCase = true)) 1.0 else 0.7,
+            )
+        }
     }
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/search/MessageSearchProvider.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/search/MessageSearchProvider.kt
@@ -12,18 +12,15 @@ class MessageSearchProvider(private val messageService: MessageService?) : Searc
 
     override fun search(query: String, limit: Int): List<SearchResult> {
         if (query.isBlank() || messageService == null) return emptyList()
-        return messageService
-            .listMessages(query = query, limit = limit.coerceIn(1, MAX_SEARCH_LIMIT), offset = 0)
-            .items
-            .map { msg ->
-                SearchResult(
-                    id = msg.syncId,
-                    title = msg.author,
-                    subtitle = msg.content.take(MAX_PREVIEW_LENGTH),
-                    url = "/",
-                    type = "message",
-                    score = if (msg.content.contains(query, ignoreCase = true)) 1.0 else 0.8,
-                )
-            }
+        return messageService.searchMessages(query, limit.coerceIn(1, MAX_SEARCH_LIMIT)).map { msg ->
+            SearchResult(
+                id = msg.syncId,
+                title = msg.author,
+                subtitle = msg.content.take(MAX_PREVIEW_LENGTH),
+                url = "/",
+                type = "message",
+                score = if (msg.content.contains(query, ignoreCase = true)) 1.0 else 0.8,
+            )
+        }
     }
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/SearchPageFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/SearchPageFactory.kt
@@ -14,8 +14,9 @@ class SearchPageFactory {
             if (query.isBlank()) {
                 emptyList()
             } else {
+                val providerLimit = (kotlin.math.ceil(limit.toDouble() / providers.size)).toInt()
                 providers
-                    .flatMap { it.search(query, limit) }
+                    .flatMap { it.search(query, providerLimit) }
                     .sortedByDescending { it.score }
                     .take(limit)
                     .map { r ->

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/SearchRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/SearchRoutes.kt
@@ -47,7 +47,11 @@ class SearchRoutes(
                         if (query.isBlank()) {
                             emptyList()
                         } else {
-                            providers.flatMap { it.search(query, limit) }.sortedByDescending { it.score }.take(limit)
+                            val providerLimit = (kotlin.math.ceil(limit.toDouble() / providers.size)).toInt()
+                            providers
+                                .flatMap { it.search(query, providerLimit) }
+                                .sortedByDescending { it.score }
+                                .take(limit)
                         }
                     val json =
                         KotlinxSerialization.asJsonObject(

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/UserAdminRoutes.kt
@@ -20,6 +20,7 @@ import org.http4k.template.TemplateRenderer
 
 private const val DEFAULT_PAGE_LIMIT = 20
 private const val MAX_PAGE_LIMIT = 100
+private const val MAX_AUDIT_EXPORT_ROWS = 10_000
 
 class UserAdminRoutes(
     private val pageFactory: WebPageFactory,
@@ -46,11 +47,23 @@ class UserAdminRoutes(
                 } bindContract
                 GET to
                 { _: org.http4k.core.Request ->
-                    val users = securityService.listUsers()
+                    val sb = StringBuilder()
+                    sb.appendLine(CsvUtils.toCsvRow(listOf("Username", "Email", "Role", "Enabled")))
+                    var offset = 0
+                    val pageSize = 100
+                    do {
+                        val page = securityService.listUsers(pageSize, offset)
+                        page.forEach { u ->
+                            sb.appendLine(
+                                CsvUtils.toCsvRow(listOf(u.username, u.email, u.role.name, u.enabled.toString()))
+                            )
+                        }
+                        offset += pageSize
+                    } while (page.size == pageSize)
                     Response(Status.OK)
                         .header("Content-Type", "text/csv; charset=utf-8")
                         .header("Content-Disposition", "attachment; filename=\"users.csv\"")
-                        .body(usersAsCsv(users))
+                        .body(sb.toString())
                 },
             "/admin/users" / userIdPath / "toggle-enabled" meta
                 {
@@ -84,11 +97,34 @@ class UserAdminRoutes(
                 } bindContract
                 GET to
                 { _: org.http4k.core.Request ->
-                    val entries = securityService.getAuditLog(limit = Int.MAX_VALUE)
+                    val sb = StringBuilder()
+                    sb.appendLine(CsvUtils.toCsvRow(listOf("Timestamp", "Actor", "Action", "Target", "Detail")))
+                    var offset = 0
+                    val pageSize = 500
+                    val maxRows = MAX_AUDIT_EXPORT_ROWS
+                    var totalRows = 0
+                    do {
+                        val page = securityService.getAuditLog(pageSize, offset)
+                        page.forEach { e ->
+                            sb.appendLine(
+                                CsvUtils.toCsvRow(
+                                    listOf(
+                                        e.createdAt.toString(),
+                                        e.actorUsername ?: "",
+                                        e.action,
+                                        e.targetUsername ?: "",
+                                        e.detail ?: "",
+                                    )
+                                )
+                            )
+                        }
+                        totalRows += page.size
+                        offset += pageSize
+                    } while (page.size == pageSize && totalRows < maxRows)
                     Response(Status.OK)
                         .header("Content-Type", "text/csv; charset=utf-8")
                         .header("Content-Disposition", "attachment; filename=\"audit.csv\"")
-                        .body(auditAsCsv(entries))
+                        .body(sb.toString())
                 },
             "/admin/users" / userIdPath / "toggle-role" meta
                 {


### PR DESCRIPTION
## Summary
- **Debounce desktop search**: 300ms `javax.swing.Timer` on `SyncViewModel.searchQuery` — avoids per-keystroke DB queries
- **Divide search limits across providers**: Each provider gets `ceil(limit/providers)` instead of full `limit`; added `searchMessages()`/`searchContacts()` to skip count queries
- **Bound sync batches**: `findChangesSince()` and `listDirtyMessages()` now accept `limit` param (default 500); `SyncPullResponse`/`SyncPullContactResponse` include `hasMore` for paging; client loops on `hasMore`
- **COUNT(*) OVER() for pagination**: New `listMessagesWithTotal()`/`listContactsWithTotal()` methods replace paired `listMessages()` + `countMessages()` SQL queries with single `COUNT(*) OVER()` window function query
- **Batch sync push upserts**: New `batchUpsertSyncedMessages()`/`batchUpsertSyncedContacts()` methods — single SELECT for existence check, batch INSERT/UPDATE, single final SELECT (reduces 3N roundtrips to ~4)
- **Paged CSV exports**: User/audit/message/contact exports now iterate in pages (100-500 rows) instead of loading entire datasets into memory; audit export capped at 10,000 rows

## Test plan
- [x] Full reactor `mvn clean verify` passes (detekt, SpotBugs, PMD, Surefire)
- [x] New `SyncViewModelSearchTest` validates debounce behavior
- [x] Existing integration tests pass: SyncApi, SyncConflictResolution, ConcurrentSync, ContactsSyncCrud, AdminExport, MessageSearch
- [x] Both jOOQ and JDBI repository implementations updated and tested