### PR TITLE
fix(config): rename VERSION env var to APP_VERSION for footer version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,7 @@ All configuration is read from `application.yaml` (or `application-{profile}.yam
 
 | YAML Key | Env Var | Default | Description |
 |---|---|---|---|
+| `version` | `APP_VERSION` | `dev` | Application version shown in footer |
 | `port` | `PORT` | 8080 | HTTP server port |
 | `jdbcUrl` | `JDBC_URL` | `jdbc:postgresql://localhost:5432/outerstellar` | Database URL |
 | `jdbcUser` | `JDBC_USER` | `outerstellar` | Database user |

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
@@ -133,7 +133,7 @@ data class AppConfig(
                 logger.warn("JDBC_URL is blank — database connection will fail at runtime")
             }
             return AppConfig(
-                version = yaml.str("version", env, "VERSION", "dev"),
+                version = yaml.str("version", env, "APP_VERSION", "dev"),
                 port = port,
                 jdbcUrl = jdbcUrl,
                 jdbcUser = yaml.str("jdbcUser", env, "JDBC_USER", "outerstellar"),

--- a/platform-desktop-javafx/src/test/kotlin/io/github/rygel/outerstellar/platform/fx/app/FxAppConfigTest.kt
+++ b/platform-desktop-javafx/src/test/kotlin/io/github/rygel/outerstellar/platform/fx/app/FxAppConfigTest.kt
@@ -44,7 +44,7 @@ class FxAppConfigTest {
                 "JDBC_USER" to "admin",
                 "JDBC_PASSWORD" to "secret",
                 "DEV_MODE" to "true",
-                "VERSION" to "2.0.0",
+                "APP_VERSION" to "2.0.0",
             )
         val config = FxAppConfig.fromEnvironment(env)
         assertThat(config.serverBaseUrl).isEqualTo("https://prod.example.com")

--- a/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/engine/DesktopAppConfig.kt
+++ b/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/engine/DesktopAppConfig.kt
@@ -57,7 +57,7 @@ data class DesktopAppConfig(
                 jdbcUrl = yaml.str("jdbcUrl", env, "JDBC_URL", "jdbc:postgresql://localhost:5432/outerstellar"),
                 jdbcUser = yaml.str("jdbcUser", env, "JDBC_USER", "outerstellar"),
                 jdbcPassword = yaml.str("jdbcPassword", env, "JDBC_PASSWORD", "outerstellar"),
-                version = yaml.str("version", env, "VERSION", "1.0.0"),
+                version = yaml.str("version", env, "APP_VERSION", "1.0.0"),
                 updateUrl = yaml.str("updateUrl", env, "UPDATE_URL", ""),
                 devMode = yaml.bool("devMode", env, "DEV_MODE", false),
                 devUsername = yaml.str("devUsername", env, "DEV_USERNAME", ""),


### PR DESCRIPTION
## Summary

Closes #345

The footer version plumbing already works end-to-end: `AppConfig.version` → `stateFilter(appVersion=config.version)` → `WebContext.appVersion` → footer rendering.

The only issue was the generic env var name `VERSION` which could collide with other tools. Renamed to `APP_VERSION` for clarity and consistency across all config modules.

### Changes
- Rename env var from `VERSION` to `APP_VERSION` in `AppConfig.fromEnvironment()`
- Rename env var from `VERSION` to `APP_VERSION` in `DesktopAppConfig` for consistency
- Update `FxAppConfigTest` to use new env var name
- Document `version` / `APP_VERSION` in AGENTS.md config reference

### Usage
Set version via any of:
- `version: 1.6.2` in `application.yaml`
- `APP_VERSION=1.6.2` environment variable
- `-Dversion=1.6.2` system property

## Test plan
- [x] platform-core tests pass (121 tests)
- [x] platform-sync-client tests pass (96 tests)