### PR TITLE
refactor(test): fix stale docs, Testcontainers reuse, auto-generate JteClassRegistry (closes #324)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -317,7 +317,7 @@ If you're in platform-web, extend `WebTest`. If you're in platform-persistence-j
 
 ### Never eagerly initialize expensive resources
 
-Use `by lazy` for DataSource, DSLContext, Jdbi handles, repositories, and any service that depends on them. Eager initialization in `@BeforeEach` creates unnecessary overhead when test classes only use a subset of resources.
+Use `by lazy` for DataSource, Jdbi handles, repositories, and any service that depends on them. Eager initialization in `@BeforeEach` creates unnecessary overhead when test classes only use a subset of resources.
 
 ### Never use `TemplateEngine.create(DirectoryCodeResolver(...))` in tests
 

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/di/PersistenceModule.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/di/PersistenceModule.kt
@@ -39,9 +39,8 @@ import org.jdbi.v3.core.Jdbi
 import org.koin.dsl.module
 
 /**
- * Persistence module backed by JDBI. Suitable for environments that do not use jOOQ code generation (e.g., lightweight
- * deployments, embedded databases). Wire this into your Koin app in place of the jOOQ module — never include both
- * `platform-persistence-jdbi` and `platform-persistence-jooq` at runtime.
+ * Persistence module backed by JDBI. Provides all repository implementations via Koin.
+ * Wire this into your Koin application to get DataSource, Jdbi, and repository bindings.
  */
 val persistenceModule
     get() = module {

--- a/platform-test-infrastructure/src/main/resources/.testcontainers.properties
+++ b/platform-test-infrastructure/src/main/resources/.testcontainers.properties
@@ -1,1 +1,0 @@
-testcontainers.reuse.enable=true

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteClassRegistry.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteClassRegistry.kt
@@ -15,15 +15,19 @@ import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.pl
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteHomePageGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteLayoutRouterGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteNotificationsPageGenerated
+import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JtePluginAdminDashboardGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteProfilePageGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteResetPasswordPageGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteSearchPageGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteSettingsPageGenerated
+import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteSettingsTabContentGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteTotpChallengeFormGenerated
+import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteTotpSetupFragmentGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteTrashPageGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.JteUserAdminPageGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.components.JteConflictResolveModalGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.components.JteContactFormGenerated
+import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.components.JteContactTrashListGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.components.JteMessageEditGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.components.JteMessageListGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.components.JteModalGenerated
@@ -33,6 +37,7 @@ import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.pl
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.components.JtePaginationGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.components.JtePollCardGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.components.JteSidebarSelectorGenerated
+import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.components.JteVoteFragmentGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.layouts.JteLayoutHeadGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.layouts.JteSidebarLayoutGenerated
 import gg.jte.generated.precompiled.outerstellar.io.github.rygel.outerstellar.platform.web.layouts.JteTopbarLayoutGenerated
@@ -53,10 +58,12 @@ object JteClassRegistry {
             JteHomePageGenerated::class.java,
             JteLayoutRouterGenerated::class.java,
             JteNotificationsPageGenerated::class.java,
+            JtePluginAdminDashboardGenerated::class.java,
             JteProfilePageGenerated::class.java,
             JteResetPasswordPageGenerated::class.java,
             JteSearchPageGenerated::class.java,
             JteSettingsPageGenerated::class.java,
+            JteSettingsTabContentGenerated::class.java,
             JteTrashPageGenerated::class.java,
             JteUserAdminPageGenerated::class.java,
         )
@@ -69,12 +76,14 @@ object JteClassRegistry {
             JteErrorHelpFragmentGenerated::class.java,
             JteFooterStatusFragmentGenerated::class.java,
             JteTotpChallengeFormGenerated::class.java,
+            JteTotpSetupFragmentGenerated::class.java,
         )
 
     private val componentClasses =
         listOf(
             JteConflictResolveModalGenerated::class.java,
             JteContactFormGenerated::class.java,
+            JteContactTrashListGenerated::class.java,
             JteMessageEditGenerated::class.java,
             JteMessageListGenerated::class.java,
             JteModalGenerated::class.java,
@@ -84,6 +93,7 @@ object JteClassRegistry {
             JtePaginationGenerated::class.java,
             JtePollCardGenerated::class.java,
             JteSidebarSelectorGenerated::class.java,
+            JteVoteFragmentGenerated::class.java,
         )
 
     private val layoutClasses =

--- a/scripts/generate-jte-class-registry.ps1
+++ b/scripts/generate-jte-class-registry.ps1
@@ -1,0 +1,143 @@
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$JteRoot = Join-Path $RepoRoot "platform-web/src/main/jte"
+$OutputFile = Join-Path $RepoRoot "platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteClassRegistry.kt"
+
+if (-not (Test-Path $JteRoot)) {
+    Write-Error "JTE root not found: $JteRoot"
+    exit 1
+}
+
+$templateFiles = Get-ChildItem -LiteralPath $JteRoot -Recurse -Filter "*.kte" | Sort-Object { $_.FullName }
+Write-Host "Found $($templateFiles.Count) .kte files"
+
+$entries = @()
+foreach ($file in $templateFiles) {
+    $relativePath = $file.FullName.Substring($JteRoot.Length + 1).Replace("\", "/")
+    $relativePathNoExt = $relativePath -replace '\.kte$', ''
+    $dirPart = ""
+    $lastSlash = $relativePathNoExt.LastIndexOf('/')
+    if ($lastSlash -ge 0) {
+        $dirPart = $relativePathNoExt.Substring(0, $lastSlash)
+    }
+    $baseName = if ($lastSlash -ge 0) { $relativePathNoExt.Substring($lastSlash + 1) } else { $relativePathNoExt }
+
+    $sanitizedBase = $baseName -replace '-', '' -replace '\.', ''
+    $className = "Jte${sanitizedBase}Generated"
+
+    $dirPartDots = $dirPart.Replace("/", ".")
+    if ($dirPart -eq "") {
+        $fqcn = "gg.jte.generated.precompiled.outerstellar.$className"
+    } else {
+        $fqcn = "gg.jte.generated.precompiled.outerstellar.$dirPartDots.$className"
+    }
+
+    $category = "page"
+    if ($relativePath -match '/layouts/') {
+        $category = "layout"
+    } elseif ($relativePath -match '/components/') {
+        $category = "component"
+    } elseif ($baseName -match '(Fragment|Form)$') {
+        $category = "fragment"
+    }
+
+    $entries += [PSCustomObject]@{
+        FQCN      = $fqcn
+        ClassName = $className
+        Category  = $category
+        SortKey   = $fqcn
+    }
+}
+
+$pages = $entries | Where-Object { $_.Category -eq "page" } | Sort-Object { $_.SortKey }
+$fragments = $entries | Where-Object { $_.Category -eq "fragment" } | Sort-Object { $_.SortKey }
+$components = $entries | Where-Object { $_.Category -eq "component" } | Sort-Object { $_.SortKey }
+$layouts = $entries | Where-Object { $_.Category -eq "layout" } | Sort-Object { $_.SortKey }
+
+$allImports = @()
+$allImports += $pages | ForEach-Object { "import $($_.FQCN)" }
+$allImports += $fragments | ForEach-Object { "import $($_.FQCN)" }
+$allImports += $components | ForEach-Object { "import $($_.FQCN)" }
+$allImports += $layouts | ForEach-Object { "import $($_.FQCN)" }
+$allImports += "import org.slf4j.LoggerFactory"
+$allImports = $allImports | Sort-Object { if ($_ -match "org\.slf4j") { "zzz" } else { $_ } }
+
+$lines = @()
+$lines += "package io.github.rygel.outerstellar.platform.infra"
+$lines += ""
+foreach ($imp in $allImports) {
+    $lines += $imp
+}
+$lines += ""
+$lines += "object JteClassRegistry {"
+$lines += "    private val logger = LoggerFactory.getLogger(JteClassRegistry::class.java)"
+$lines += ""
+$lines += "    private val pageClasses ="
+$lines += "        listOf("
+foreach ($entry in $pages) {
+    $lines += "            $($entry.ClassName)::class.java,"
+}
+$lines += "        )"
+$lines += ""
+$lines += "    private val fragmentClasses ="
+$lines += "        listOf("
+foreach ($entry in $fragments) {
+    $lines += "            $($entry.ClassName)::class.java,"
+}
+$lines += "        )"
+$lines += ""
+$lines += "    private val componentClasses ="
+$lines += "        listOf("
+foreach ($entry in $components) {
+    $lines += "            $($entry.ClassName)::class.java,"
+}
+$lines += "        )"
+$lines += ""
+$lines += "    private val layoutClasses ="
+$lines += "        listOf("
+foreach ($entry in $layouts) {
+    $lines += "            $($entry.ClassName)::class.java,"
+}
+$lines += "        )"
+$lines += ""
+$lines += "    val allClasses: List<Class<*>> = pageClasses + fragmentClasses + componentClasses + layoutClasses"
+$lines += ""
+$lines += "    private val classMap: Map<String, Class<*>> = allClasses.associateBy { it.name }"
+$lines += ""
+
+$verbatimBlock = @'
+    init {
+        logger.info("Initializing {} JTE template classes", allClasses.size)
+        for (cls in allClasses) {
+            try {
+                Class.forName(cls.name, true, cls.classLoader)
+            } catch (e: ClassNotFoundException) {
+                logger.warn("Failed to force-load JTE template class {}: {}", cls.name, e.message)
+            }
+        }
+    }
+
+    fun getTemplateClass(templateName: String): Class<*>? {
+        val templatePath = templateName.removeSuffix(".kte")
+        val slash = templatePath.lastIndexOf('/')
+        val packagePath = if (slash >= 0) templatePath.substring(0, slash).replace('/', '.') else ""
+        val baseName = if (slash >= 0) templatePath.substring(slash + 1) else templatePath
+        val className = "Jte${baseName.replace("-", "").replace(".", "")}Generated"
+        val fullName =
+            if (packagePath.isEmpty()) {
+                "gg.jte.generated.precompiled.outerstellar.$className"
+            } else {
+                "gg.jte.generated.precompiled.outerstellar.$packagePath.$className"
+            }
+        return classMap[fullName]
+    }
+}
+'@
+
+$lines += $verbatimBlock
+
+$lines | Out-File -FilePath $OutputFile -Encoding utf8NoBOM
+
+$total = $pages.Count + $fragments.Count + $components.Count + $layouts.Count
+Write-Host "Generated $OutputFile with $total entries ($($pages.Count) pages, $($fragments.Count) fragments, $($components.Count) components, $($layouts.Count) layouts)"


### PR DESCRIPTION
## Summary

Three high-priority test infrastructure fixes.

### Task 1: Fix stale doc references
- Removed `DSLContext` from `docs/testing.md` (jOOQ was removed in PR #333)
- Removed jOOQ references from `PersistenceModule.kt` KDoc

### Task 2: Fix Testcontainers container reuse
- Deleted `platform-test-infrastructure/src/main/resources/.testcontainers.properties` — Testcontainers ignores `reuse.enable` from classpath by design
- Added `testcontainers.reuse.enable=true` to `~/.testcontainers.properties` (the correct location)
- Container reuse now works — no more "Reuse was requested but the environment does not support the reuse of containers" warning

### Task 3: Auto-generate JteClassRegistry (closes #324)
- Created `scripts/generate-jte-class-registry.ps1` — scans `.kte` files and generates the registry
- Fixed 5 missing templates: PluginAdminDashboard, SettingsTabContent, TotpSetupFragment, ContactTrashList, VoteFragment
- Registry now has 41 entries (was 36), matching all `.kte` template files
- Categories (page/fragment/component/layout) determined by directory and naming conventions

## Test plan
- [x] Full reactor build: 612 web + 135 persistence tests, 0 failures
- [x] Compile passes (detekt, spotbugs, checkstyle all clean)
- [x] JteClassRegistry generated with 41 entries including all 5 previously missing templates
- [x] Testcontainers reuse enabled (user-level config)
