### PR TITLE
docs: move backlog from AGENTS.md to TODO.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,34 +301,6 @@ Full test architecture and patterns: **[docs/testing.md](docs/testing.md)**.
 - Never create your own PostgreSQL container — extend `WebTest` or `JdbiTest`.
 - Never use `testJdbi.open()` — it leaks connections. Use `testJdbi.withHandle { }` or `testJdbi.useHandle<Exception> { }`.
 
-## Project Status (as of May 2026)
-
-### Core features
-- Web app with auth, messages, contacts, notifications, search, admin, settings
-- Desktop Swing client with two-way sync
-- Plugin system (PlatformPlugin interface)
-- SEO: Open Graph, Twitter Card, JSON-LD, sitemap, robots.txt, canonical, hreflang
-- Accessibility: aria-hidden, aria-live, skip-to-content
-
-### Recently completed (PR #239-261)
-- AppContext refactoring, Security hardening (CORS, CSP, session, audit, SSRF)
-- Per-account rate limiting
-- WebPageFactory split into 10 domain factories
-- fragments-seo-core integration
-- Responsive layout (auto-close nav, touch CSS)
-- App.kt refactoring (OptionalServices extraction)
-- SyncWindowMenu + SyncWindowNav extraction
-- 18 performance/runtime items (configurable knobs, startup timing, fetch optimization, indexes, adaptive outbox)
-
-### Open items
-- Generic `catch (Exception)` boilerplate in DesktopSyncEngine
-- DesktopSyncEngine interface for testability
-- TOTP two-factor authentication
-- Unified Settings page with tabs
-- Search SPI (SearchProvider interface)
-- Export SPI (CSV/JSON export)
-- Jazzer fuzz tests
-
 ## http4k contract routing rules
 
 These are hard-won rules from actual failures. Violating them produces compile errors or wrong runtime behavior.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,30 @@
+# TODO
+
+## Backlog
+
+- [ ] Generic `catch (Exception)` boilerplate in DesktopSyncEngine
+- [ ] DesktopSyncEngine interface for testability
+- [ ] TOTP two-factor authentication
+- [ ] Unified Settings page with tabs
+- [ ] Search SPI (SearchProvider interface)
+- [ ] Export SPI (CSV/JSON export)
+- [ ] Jazzer fuzz tests
+- [ ] SecurityService can shrink further — callers could bypass delegation and use AuthService/AccountService directly, leaving SecurityService as just API key + OAuth + password reset
+
+## Completed
+
+- [x] AppContext refactoring, Security hardening (CORS, CSP, session, audit, SSRF) (PR #239-261)
+- [x] Per-account rate limiting
+- [x] WebPageFactory split into 10 domain factories
+- [x] fragments-seo-core integration
+- [x] Responsive layout (auto-close nav, touch CSS)
+- [x] App.kt refactoring (OptionalServices extraction)
+- [x] SyncWindowMenu + SyncWindowNav extraction
+- [x] 18 performance/runtime items (configurable knobs, startup timing, fetch optimization, indexes, adaptive outbox)
+- [x] Remove Koin from server runtime, unified Dockerfile.build, native-image hardening (PR #351)
+- [x] Banner SPI — BannerProvider interface, server-side banner rendering (PR #352)
+- [x] Decompose SecurityService into SessionService + UserAdminService (PR #353)
+- [x] Split WebContext into RequestContext + ShellRenderer (PR #354)
+- [x] Remove WebContext facade, use RequestContext + ShellRenderer directly (PR #355)
+- [x] Remove SecurityService session delegation, callers use SessionService directly (PR #355)
+- [x] Extract AuthService + AccountService from SecurityService (PR #357)


### PR DESCRIPTION
Move backlog items from AGENTS.md to docs/TODO.md. AGENTS.md now contains only guardrails and rules.

Generated with Claude Code