### PR TITLE
refactor: remove SecurityService delegation methods

### DIFF
--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
@@ -79,7 +79,6 @@ fun createSecurityComponents(
             emailService = emailService,
             oauthRepository = oauthRepository,
             config = securityConfig,
-            activityUpdater = asyncActivityUpdater,
         )
     val permissionResolver = RoleBasedPermissionResolver()
     val authRealms = listOf(SessionRealm(sessionService), ApiKeyRealm(securityService))

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityService.kt
@@ -3,7 +3,6 @@ package io.github.rygel.outerstellar.platform.security
 import io.github.rygel.outerstellar.platform.model.ApiKeySummary
 import io.github.rygel.outerstellar.platform.model.AuditEntry
 import io.github.rygel.outerstellar.platform.model.CreateApiKeyResponse
-import io.github.rygel.outerstellar.platform.model.TotpVerifyResponse
 import io.github.rygel.outerstellar.platform.model.User
 import io.github.rygel.outerstellar.platform.persistence.ApiKeyRepository
 import io.github.rygel.outerstellar.platform.persistence.AuditRepository
@@ -11,7 +10,6 @@ import io.github.rygel.outerstellar.platform.persistence.PasswordResetRepository
 import io.github.rygel.outerstellar.platform.persistence.SessionRepository
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import java.util.UUID
-import org.slf4j.LoggerFactory
 
 class SecurityService(
     private val userRepository: UserRepository,
@@ -23,26 +21,7 @@ class SecurityService(
     private val oauthRepository: OAuthRepository? = null,
     private val config: SecurityConfig = SecurityConfig(),
     private val sessionRepository: SessionRepository? = null,
-    private val activityUpdater: AsyncActivityUpdater? = null,
 ) {
-    private val logger = LoggerFactory.getLogger(SecurityService::class.java)
-
-    private val authService =
-        AuthService(
-            userRepository = userRepository,
-            passwordEncoder = passwordEncoder,
-            auditRepository = auditRepository,
-            config = config,
-        )
-
-    private val accountService =
-        AccountService(
-            userRepository = userRepository,
-            passwordEncoder = passwordEncoder,
-            sessionRepository = sessionRepository,
-            auditRepository = auditRepository,
-        )
-
     private val passwordResetService by lazy {
         PasswordResetService(
             userRepository = userRepository,
@@ -67,29 +46,6 @@ class SecurityService(
             auditRepository = auditRepository,
         )
     }
-
-    fun authenticate(username: String, password: String): AuthResult? = authService.authenticate(username, password)
-
-    fun register(username: String, password: String): User = authService.register(username, password)
-
-    fun changePassword(userId: UUID, currentPassword: String, newPassword: String) =
-        accountService.changePassword(userId, currentPassword, newPassword)
-
-    fun updateProfile(userId: UUID, newEmail: String, newUsername: String? = null, newAvatarUrl: String? = null) =
-        accountService.updateProfile(userId, newEmail, newUsername, newAvatarUrl)
-
-    fun deleteAccount(userId: UUID, currentPassword: String) = accountService.deleteAccount(userId, currentPassword)
-
-    fun updateNotificationPreferences(userId: UUID, emailEnabled: Boolean, pushEnabled: Boolean) =
-        accountService.updateNotificationPreferences(userId, emailEnabled, pushEnabled)
-
-    fun verifyTotp(partialToken: String, code: String, sessionService: SessionService): TotpVerifyResponse =
-        authService.verifyTotp(partialToken, code, sessionService)
-
-    fun enableTotp(userId: UUID, secret: String, backupCodes: String) =
-        authService.enableTotp(userId, secret, backupCodes)
-
-    fun disableTotp(userId: UUID) = authService.disableTotp(userId)
 
     fun requestPasswordReset(email: String): String? = passwordResetService.requestPasswordReset(email)
 

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityIntegrationTest.kt
@@ -16,14 +16,14 @@ class SecurityIntegrationTest : WebTest() {
 
     private lateinit var localUserRepository: JdbiUserRepository
     private lateinit var passwordEncoder: PasswordEncoder
-    private lateinit var securityService: SecurityService
+    private lateinit var authService: AuthService
 
     @BeforeEach
     fun setupTest() {
         localUserRepository = JdbiUserRepository(testJdbi)
-        passwordEncoder = BCryptPasswordEncoder(logRounds = 4) // Fast for tests
-        securityService =
-            SecurityService(
+        passwordEncoder = BCryptPasswordEncoder(logRounds = 4)
+        authService =
+            AuthService(
                 userRepository = localUserRepository,
                 passwordEncoder = passwordEncoder,
                 config = SecurityConfig(),
@@ -35,7 +35,6 @@ class SecurityIntegrationTest : WebTest() {
         val username = "testuser"
         val password = testPassword()
 
-        // 1. Register
         val newUser =
             User(
                 id = UUID.randomUUID(),
@@ -46,8 +45,7 @@ class SecurityIntegrationTest : WebTest() {
             )
         localUserRepository.save(newUser)
 
-        // 2. Authenticate
-        val result = securityService.authenticate(username, password)
+        val result = authService.authenticate(username, password)
 
         assertTrue(result is AuthResult.Authenticated, "Should authenticate successfully")
         val auth = result as AuthResult.Authenticated
@@ -70,14 +68,14 @@ class SecurityIntegrationTest : WebTest() {
             )
         )
 
-        val result = securityService.authenticate(username, "wrongpassword")
+        val result = authService.authenticate(username, "wrongpassword")
 
         assertNull(result)
     }
 
     @Test
     fun `should fail authentication for non-existent user`() {
-        val result = securityService.authenticate("ghost", "anypassword")
+        val result = authService.authenticate("ghost", "anypassword")
         assertNull(result)
     }
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ChangePasswordWebIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ChangePasswordWebIntegrationTest.kt
@@ -3,6 +3,7 @@ package io.github.rygel.outerstellar.platform.web
 import com.natpryce.hamkrest.assertion.assertThat
 import io.github.rygel.outerstellar.platform.model.User
 import io.github.rygel.outerstellar.platform.model.UserRole
+import io.github.rygel.outerstellar.platform.security.AuthService
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import java.util.UUID
 import kotlin.test.Test
@@ -36,6 +37,7 @@ class ChangePasswordWebIntegrationTest : WebTest() {
     private lateinit var app: HttpHandler
     private lateinit var testUser: User
     private lateinit var securityService: SecurityService
+    private lateinit var authService: AuthService
     private lateinit var testToken: String
 
     @BeforeEach
@@ -51,6 +53,7 @@ class ChangePasswordWebIntegrationTest : WebTest() {
         userRepository.save(testUser)
 
         securityService = createSecurityService()
+        authService = AuthService(userRepository, encoder, auditRepository)
 
         testToken = sessionSvc.createSession(testUser.id)
 
@@ -173,11 +176,11 @@ class ChangePasswordWebIntegrationTest : WebTest() {
         )
 
         // Verify old password no longer works
-        val oldAuth = securityService.authenticate(testUser.email, "OldPass123!")
+        val oldAuth = authService.authenticate(testUser.email, "OldPass123!")
         assertTrue(oldAuth == null, "Old password should no longer authenticate")
 
         // Verify new password works
-        val newAuth = securityService.authenticate(testUser.email, newPassword)
+        val newAuth = authService.authenticate(testUser.email, newPassword)
         assertNotNull(newAuth, "New password should authenticate successfully")
     }
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
@@ -1,6 +1,7 @@
 package io.github.rygel.outerstellar.platform.web
 
 import com.natpryce.hamkrest.assertion.assertThat
+import io.github.rygel.outerstellar.platform.security.AuthService
 import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.SecurityService
 import java.util.UUID
@@ -42,6 +43,7 @@ class OAuthIntegrationTest : WebTest() {
     private lateinit var app: HttpHandler
     private lateinit var localOAuthRepository: InMemoryOAuthRepository
     private lateinit var securityService: SecurityService
+    private lateinit var authService: AuthService
 
     @BeforeEach
     fun setupTest() {
@@ -56,6 +58,7 @@ class OAuthIntegrationTest : WebTest() {
                 auditRepository = auditRepository,
                 oauthRepository = localOAuthRepository,
             )
+        authService = AuthService(userRepository, encoder, auditRepository)
 
         app = buildApp(securityService = securityService)
     }
@@ -311,7 +314,7 @@ class OAuthIntegrationTest : WebTest() {
     @Test
     fun `findOrCreateOAuthUser generates unique username when base is already taken`() {
         // Create a user whose username will collide with the derived OAuth username
-        securityService.register("alice", testPassword())
+        authService.register("alice", testPassword())
 
         // Now sign in with Apple as alice@example.com → username 'alice' is taken → should be
         // alice2


### PR DESCRIPTION
Remove all delegation methods from SecurityService that forwarded to AuthService and AccountService. Callers already have direct access to those services through SecurityComponents.

SecurityService now only contains: API key management (ApiKeyService), OAuth (OAuthService), and password reset (PasswordResetService).

5 files changed, 16 insertions, 57 deletions (net -41 lines). 620 tests pass.

Generated with Claude Code