### PR TITLE
refactor: architecture deepening — App.kt decoupling, AuthRoutes decomposition, auth guard consolidation

### DIFF
--- a/docs/superpowers/plans/2026-05-25-architecture-deepening.md
+++ b/docs/superpowers/plans/2026-05-25-architecture-deepening.md
@@ -1,0 +1,452 @@
+# Architecture Deepening: App.kt Decoupling + AuthRoutes Decomposition + Auth Guard Consolidation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce App.kt coupling (25 params → ~6), decompose AuthRoutes (487 lines → 4 focused classes), and consolidate 25+ scattered auth guards into a single filter.
+
+**Architecture:** Replace `app()`'s 25 individual parameters with the 4 existing component group objects (`PersistenceComponents`, `SecurityComponents`, `CoreComponents`, `WebComponents`). Split AuthRoutes into 4 route classes along domain boundaries. Apply `SecurityRules.authenticated` as a default filter on the UI route set, removing inline null-check guards.
+
+**Tech Stack:** Kotlin, http4k, JDBI, JTE
+
+---
+
+## File Structure
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `platform-web/src/main/kotlin/.../App.kt` | Replace 25-param `app()` with component-group params, delete `AppContext`/`OptionalServices`/`AuthServices`, add authenticated filter on UI routes |
+| `platform-web/src/main/kotlin/.../ServerComponents.kt` | Simplify to pass component groups instead of unwrapping |
+| `platform-web/src/main/kotlin/.../WebTest.kt` | Update `createApp()` to use new signature |
+
+### Created files
+
+| File | Content |
+|------|---------|
+| `platform-web/src/main/kotlin/.../PasswordRoutes.kt` | Password change + reset routes (extracted from AuthRoutes) |
+| `platform-web/src/main/kotlin/.../ProfileRoutes.kt` | Profile edit + notification prefs + account delete routes (extracted from AuthRoutes) |
+| `platform-web/src/main/kotlin/.../ApiKeyRoutes.kt` | API key CRUD routes (extracted from AuthRoutes) |
+
+### Deleted code
+
+| What | Lines removed |
+|------|--------------|
+| `OptionalServices` inner class (App.kt:86-98) | 13 lines |
+| `AuthServices` inner class (App.kt:100-106) | 7 lines |
+| `AppContext` inner class (App.kt:108-185) | 78 lines |
+| Inline auth guards from HomeRoutes, ContactsRoutes, ComponentRoutes, NotificationRoutes | ~125 lines |
+
+---
+
+## Task 1: Refactor `app()` to accept component groups
+
+**Files:**
+- Modify: `platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt`
+- Modify: `platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/ServerComponents.kt`
+- Modify: `platform-web/src/main/kotlin/.../WebTest.kt`
+- Test: All existing platform-web tests must pass
+
+This is the foundation task. Everything else builds on it.
+
+- [ ] **Step 1: Replace `app()` signature**
+
+Replace the 25-parameter `app()` function (lines 188-215) with:
+
+```kotlin
+@Suppress("DEPRECATION")
+fun app(
+    config: AppConfig,
+    persistence: io.github.rygel.outerstellar.platform.di.PersistenceComponents,
+    security: io.github.rygel.outerstellar.platform.security.SecurityComponents,
+    core: io.github.rygel.outerstellar.platform.di.CoreComponents,
+    web: io.github.rygel.outerstellar.platform.di.WebComponents,
+    plugin: io.github.rygel.outerstellar.platform.web.PlatformPlugin? = null,
+): PolyHandler
+```
+
+Delete the `OptionalServices`, `AuthServices`, and `AppContext` inner classes (lines 86-185). Replace the body of `app()` to extract what it needs from the component groups directly:
+
+```kotlin
+fun app(
+    config: AppConfig,
+    persistence: PersistenceComponents,
+    security: SecurityComponents,
+    core: CoreComponents,
+    web: WebComponents,
+    plugin: PlatformPlugin? = null,
+): PolyHandler {
+    logger.info("Initializing Outerstellar application")
+    val httpHandler = assembleHttpHandler(config, persistence, security, core, web, plugin)
+    val wsHandler = web.syncWebSocket?.let { websockets("/ws/sync" wsBind it.handler) }
+    return PolyHandler(httpHandler, wsHandler)
+}
+```
+
+- [ ] **Step 2: Rewrite `assembleHttpHandler` and all builder functions**
+
+Replace the `AppContext`-taking private functions with versions that take explicit parameters or component groups. The key mapping from old `ctx.*` to new component group access:
+
+| Old (`ctx.*`) | New |
+|---|---|
+| `ctx.config` | `config` (parameter) |
+| `ctx.messageService` | `core.messageService` |
+| `ctx.contactService` | `core.contactService` |
+| `ctx.authServices.auth` | `security.authService` |
+| `ctx.authServices.account` | `security.accountService` |
+| `ctx.authServices.apiKeyService` | `security.apiKeyService` |
+| `ctx.authServices.passwordResetService` | `security.passwordResetService` |
+| `ctx.authServices.oauthService` | `security.oauthService` |
+| `ctx.sessionService` | `security.sessionService` |
+| `ctx.userAdminService` | `security.userAdminService` |
+| `ctx.userRepository` | `persistence.userRepository` |
+| `ctx.outboxRepository` | `persistence.outboxRepository` |
+| `ctx.cache` | `web.messageCache` |
+| `ctx.jteRenderer` | `web.templateRenderer` |
+| `ctx.pageFactory` | `web.pageFactory` |
+| `ctx.analytics` | `web.analyticsService` |
+| `ctx.notificationService` | `web.notificationService` |
+| `ctx.jwtService` | `security.jwtService` |
+| `ctx.deviceTokenRepository` | `persistence.deviceTokenRepository` |
+| `ctx.syncWebSocket` | `web.syncWebSocket` |
+| `ctx.totpService` | `security.totpService` |
+| `ctx.voteService` | `web.voteService` |
+| `ctx.pollService` | `web.pollService` |
+| `ctx.plugin` | `plugin` (parameter) |
+| `ctx.appLabel` | `plugin?.appLabel ?: "Outerstellar"` |
+| `ctx.excludedRoutes` | `plugin?.excludeDefaultRoutes ?: emptySet()` |
+
+Each private function (`buildApiRoutes`, `buildUiRoutes`, `buildAdminRoutes`, `buildComponentRoutes`, `buildBaseApp`, `buildFilterChain`) changes its signature from `(ctx: AppContext)` to taking the component groups it needs.
+
+- [ ] **Step 3: Update `ServerComponents.kt`**
+
+The `app()` call (lines 72-98) simplifies to:
+
+```kotlin
+val polyHandler = app(
+    config = config,
+    persistence = persistence,
+    security = security,
+    core = core,
+    web = web,
+    plugin = plugin,
+)
+```
+
+Note: Remove the `CaffeineMessageCache` creation in `createCoreComponents` call (lines 47-51) — the cache is already created in `createWebComponents`. The `core` module should use `web.messageCache` or receive it from the web layer. Check if `CoreComponents` needs the cache or if only `WebComponents` does. If only WebComponents needs it, remove it from the `createCoreComponents` call and pass it separately.
+
+Actually, looking more carefully: `createCoreComponents` takes `messageCache` as a parameter to construct `MessageService`. And `createWebComponents` also creates a `CaffeineMessageCache`. So the cache is created twice — once in `ServerComponents` for `CoreComponents`, and once inside `WebFactory`. Fix this by having `ServerComponents` create the cache once and pass it to both.
+
+- [ ] **Step 4: Update `WebTest.kt`**
+
+The `createApp()` method (around line 145) currently calls `app()` with positional parameters. Update it to construct component groups and pass them:
+
+```kotlin
+return app(
+    config = config,
+    persistence = PersistenceComponents(
+        dataSource = /* unused in test, can be mock */,
+        jdbi = testJdbi,
+        messageRepository = messageRepository,
+        contactRepository = contactRepository,
+        userRepository = resolvedUserRepo,
+        outboxRepository = outbox,
+        transactionManager = txManager,
+        auditRepository = auditRepository,
+        passwordResetRepository = passwordResetRepository,
+        apiKeyRepository = apiKeyRepository,
+        oAuthRepository = oAuthRepository,
+        deviceTokenRepository = overrides.deviceTokenRepository ?: deviceTokenRepository,
+        sessionRepository = sessionRepository,
+        voteRepository = voteRepository,
+        pollRepository = pollRepository,
+        notificationRepository = notificationRepository,
+    ),
+    security = SecurityComponents(
+        jwtService = jwtService,
+        asyncActivityUpdater = /* ... */,
+        authService = authService,
+        accountService = accountService,
+        apiKeyService = apiKeyService,
+        passwordResetService = passwordResetService,
+        oauthService = oauthService,
+        authRealms = listOf(SessionRealm(sessionSvc), ApiKeyRealm(apiKeyService)),
+        totpService = TOTPService(),
+        sessionService = sessionSvc,
+        userAdminService = userAdminService,
+    ),
+    core = CoreComponents(
+        messageService = messageService,
+        contactService = resolvedContactService,
+        outboxProcessor = OutboxProcessor(outboxRepository = outbox, transactionManager = txManager),
+        eventPublisher = NoOpEventPublisher,
+        emailService = NoOpEmailService(),
+        pushNotificationService = ConsolePushNotificationService,
+    ),
+    web = WebComponents(
+        templateRenderer = renderer,
+        pageFactory = pageFactory,
+        messageCache = resolvedMessageCache,
+        analyticsService = NoOpAnalyticsService(),
+        emailService = NoOpEmailService(),
+        i18nService = I18nService.create("messages"),
+        syncWebSocket = null,
+        eventPublisher = NoOpEventPublisher,
+        voteService = overrides.pollService?.let { VoteService(voteRepository, messageRepository) } ?: voteService,
+        pollService = overrides.pollService ?: pollService,
+        notificationService = overrides.notificationService ?: notificationService,
+        adminPageFactory = AdminPageFactory(apiKeyService, overrides.notificationService ?: notificationService, userAdminService),
+        adminStatsService = AdminStatsService(resolvedUserRepo),
+        pluginMigrationSource = NoOpPluginMigrationSource,
+    ),
+    plugin = plugin,
+).http!!
+```
+
+This is the most tedious part — matching each test's current positional args to the new structure. Alternatively, `WebTest` could call the individual `create*Components()` factory functions with the test repos. Evaluate which approach is cleaner.
+
+- [ ] **Step 5: Compile and fix errors**
+
+Run: `mvn -pl platform-web compile -am -Ddetekt.skip=true -Dspotbugs.skip=true -Dspotless.check.skip=true`
+
+Expected: Compile passes. Fix any type mismatches where component groups expose different types than the old `app()` expected.
+
+- [ ] **Step 6: Run tests**
+
+Run: `mvn -pl platform-web -am test -Dexec.skip=true`
+
+Expected: All existing tests pass with no behavior changes. This is a pure structural refactor — no test assertions should change.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: replace app() 25-param signature with component groups
+
+Replace OptionalServices/AuthServices/AppContext inner classes with
+direct use of PersistenceComponents, SecurityComponents, CoreComponents,
+and WebComponents. No behavior change — pure structural refactor."
+```
+
+---
+
+## Task 2: Decompose AuthRoutes into domain-focused classes
+
+**Files:**
+- Modify: `platform-web/src/main/kotlin/.../AuthRoutes.kt` (slim to login/register/recover only)
+- Create: `platform-web/src/main/kotlin/.../PasswordRoutes.kt`
+- Create: `platform-web/src/main/kotlin/.../ProfileRoutes.kt`
+- Create: `platform/kotlin/.../ApiKeyRoutes.kt`
+- Modify: `platform-web/src/main/kotlin/.../App.kt` (register new route classes in `buildUiRoutes`)
+
+- [ ] **Step 1: Create `PasswordRoutes.kt`**
+
+Extract from AuthRoutes:
+- `GET /auth/change-password` (lines 173-186)
+- `POST /auth/components/change-password` (lines 187-232)
+- `GET /auth/reset/{token}` (lines 233-244)
+- `POST /auth/components/reset-confirm` (lines 245-303)
+
+Constructor: `(pageFactory: WebPageFactory, renderer: TemplateRenderer, accountService: AccountService, passwordResetService: PasswordResetService)` — 4 params.
+
+This class must implement `ServerRoutes` and return `routes` as `List<ContractRoute>`.
+
+The auth guard on `/auth/change-password` GET (`if (ctx.user == null)` redirect) stays for now — it will be removed in Task 3 when the authenticated filter is applied. Mark it with a TODO comment.
+
+- [ ] **Step 2: Create `ProfileRoutes.kt`**
+
+Extract from AuthRoutes:
+- `GET /auth/profile` (lines 304-317)
+- `POST /auth/components/profile-update` (lines 318-360)
+- `POST /auth/notification-preferences` (lines 361-384)
+- `POST /auth/account/delete` (lines 385-416)
+
+Constructor: `(pageFactory: WebPageFactory, renderer: TemplateRenderer, accountService: AccountService, sessionCookieSecure: Boolean)` — 4 params.
+
+The auth guards stay for now (removed in Task 3).
+
+- [ ] **Step 3: Create `ApiKeyRoutes.kt`**
+
+Extract from AuthRoutes:
+- `GET /auth/api-keys` (lines 417-430)
+- `POST /auth/api-keys/create` (lines 431-458)
+- `POST /auth/api-keys/{id}/delete` (lines 459-476)
+
+Constructor: `(pageFactory: WebPageFactory, renderer: TemplateRenderer, apiKeyService: ApiKeyService)` — 3 params.
+
+- [ ] **Step 4: Slim `AuthRoutes.kt`**
+
+Remove the extracted routes. The remaining `AuthRoutes` contains:
+- `GET /auth` (landing page)
+- `GET /auth/components/forms/{mode}` (form fragment)
+- `POST /auth/components/result` (login/register/recover handler)
+- `safeReturnTo()` helper
+
+Constructor params drop from 10 to 7: `pageFactory`, `renderer`, `authService`, `sessionService`, `passwordResetService`, `analytics`, `appConfig`. (Drop `apiKeyService` and `accountService` — they moved to the new classes.)
+
+- [ ] **Step 5: Register new route classes in App.kt `buildUiRoutes`**
+
+In the `buildUiRoutes` function, replace the single `AuthRoutes(...)` creation with:
+
+```kotlin
+routes += AuthRoutes(pageFactory, jteRenderer, security.authService, security.sessionService,
+    security.passwordResetService, web.analyticsService, config).routes
+routes += PasswordRoutes(pageFactory, jteRenderer, security.accountService,
+    security.passwordResetService).routes
+routes += ProfileRoutes(pageFactory, jteRenderer, security.accountService,
+    config.sessionCookieSecure).routes
+routes += ApiKeyRoutes(pageFactory, jteRenderer, security.apiKeyService).routes
+```
+
+- [ ] **Step 6: Compile and fix errors**
+
+Run: `mvn -pl platform-web compile -am -Ddetekt.skip=true -Dspotbugs.skip=true -Dspotless.check.skip=true`
+
+- [ ] **Step 7: Run tests**
+
+Run: `mvn -pl platform-web -am test -Dexec.skip=true`
+
+All existing auth-related tests (ChangePasswordWebIntegrationTest, OAuthIntegrationTest, UserManagementIntegrationTest, SessionSecurityIntegrationTest) must pass without changes — the route URLs haven't changed, only the classes that handle them.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: decompose AuthRoutes into domain-focused route classes
+
+Extract PasswordRoutes, ProfileRoutes, and ApiKeyRoutes from AuthRoutes.
+AuthRoutes now handles only the public auth flow (login/register/recover).
+No behavior change."
+```
+
+---
+
+## Task 3: Consolidate auth guards into `SecurityRules.authenticated` filter
+
+**Files:**
+- Modify: `platform-web/src/main/kotlin/.../App.kt` (wrap UI routes with authenticated filter)
+- Modify: `platform-web/src/main/kotlin/.../HomeRoutes.kt` (remove inline guards)
+- Modify: `platform-web/src/main/kotlin/.../ContactsRoutes.kt` (remove inline guards)
+- Modify: `platform-web/src/main/kotlin/.../ComponentRoutes.kt` (remove inline guards from protected routes)
+- Modify: `platform-web/src/main/kotlin/.../NotificationRoutes.kt` (remove inline guards)
+- Modify: `platform-web/src/main/kotlin/.../SettingsRoutes.kt` (remove inline guards)
+- Modify: `platform-web/src/main/kotlin/.../PasswordRoutes.kt` (remove inline guard on change-password)
+- Modify: `platform-web/src/main/kotlin/.../ProfileRoutes.kt` (remove inline guards)
+- Modify: `platform-web/src/main/kotlin/.../ApiKeyRoutes.kt` (remove inline guards)
+
+- [ ] **Step 1: Add `SecurityRules.authenticated` filter wrapper in App.kt**
+
+In `buildUiRoutes`, wrap the authenticated routes with the filter. The public routes (`/auth` and sub-paths) must sit outside the filter.
+
+Strategy: Split the UI contract into two contracts:
+1. **Public UI contract** — `/auth` landing, `/auth/components/forms`, `/auth/components/result`, `/auth/reset/{token}`, `/auth/components/reset-confirm`, OAuth routes, error routes
+2. **Authenticated UI contract** — Everything else, wrapped with `SecurityRules.authenticated`
+
+Actually, a simpler approach: apply the filter at the `buildBaseApp` level. Instead of adding `uiRoutes` directly to `appRoutes`, wrap them:
+
+```kotlin
+val authenticatedUiRoutes = Filter { next ->
+    SecurityRules.authenticated(next)
+}.then(uiRoutes)
+appRoutes += authenticatedUiRoutes
+```
+
+But this would also protect the public auth routes (`/auth/*`). The filter needs to skip those.
+
+Better approach: `SecurityRules.authenticated` redirects unauthenticated users to `/auth?returnTo=...`. The `/auth` routes already handle unauthenticated users (they're the login page). So even if the filter wraps them, the redirect just loops back to `/auth` — but the `/auth/components/result` POST handler needs to work without auth (it processes login forms).
+
+Cleanest approach: Keep the public routes in a separate contract that is NOT wrapped with the filter:
+
+In `buildBaseApp`, instead of:
+```kotlin
+val appRoutes = mutableListOf(uiRoutes, componentRoutes)
+```
+
+Do:
+```kotlin
+val authenticatedFilter = Filter { next -> SecurityRules.authenticated(next) }
+val appRoutes = mutableListOf(
+    publicAuthRoutes,      // /auth/* — no filter
+    authenticatedFilter.then(protectedUiRoutes),  // everything else
+    authenticatedFilter.then(componentRoutes),
+)
+```
+
+This requires splitting `buildUiRoutes` into `buildPublicUiRoutes` and `buildProtectedUiRoutes`.
+
+- [ ] **Step 2: Remove inline guards from route handlers**
+
+For each route file, remove the pattern:
+```kotlin
+val ctx = request.requestContext
+val shellRenderer = request.shellRenderer
+if (ctx.user == null) {
+    return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
+}
+```
+
+Replace with direct usage. After the filter is applied, `request.requestContext.user` is guaranteed non-null inside protected routes. Handlers can use `val user = request.requestContext.user!!` or `val user = SecurityRules.USER_KEY(request)!!`.
+
+HomeRoutes: Remove guard from all 8 protected routes.
+ContactsRoutes: Remove guard from all 8 routes.
+ComponentRoutes: Remove guard from 4 protected routes (message-list, vote routes). Leave the 4 public routes (theme/lang/layout selectors) as-is — they don't have guards.
+NotificationRoutes: Remove guards.
+SettingsRoutes: Remove guards.
+PasswordRoutes: Remove guard on `/auth/change-password` GET.
+ProfileRoutes: Remove guards on all 4 routes.
+ApiKeyRoutes: Remove guards on all 3 routes.
+
+Note: Some handlers check `ctx.user` and return `Response(Status.UNAUTHORIZED)` instead of redirecting (e.g., the POST handlers for change-password, profile-update, notification-preferences, account-delete, api-keys). These should also be removed — the filter handles the redirect before the handler is reached.
+
+- [ ] **Step 3: Verify `shellRenderer` still works**
+
+The inline guards reference `shellRenderer` for the redirect URL. After removing the guard, some handlers may no longer need `shellRenderer` at all. Check each handler and remove unused `val shellRenderer = request.shellRenderer` declarations.
+
+Handlers that still use `shellRenderer` for i18n (e.g., `shellRenderer.i18n.translate(...)`) or URL generation must keep it.
+
+- [ ] **Step 4: Compile**
+
+Run: `mvn -pl platform-web compile -am -Ddetekt.skip=true -Dspotbugs.skip=true -Dspotless.check.skip=true`
+
+- [ ] **Step 5: Run tests**
+
+Run: `mvn -pl platform-web -am test -Dexec.skip=true`
+
+Tests that verify unauthenticated redirect behavior must still pass. The redirect now comes from the filter, not the handler, but the end result (302 to `/auth`) is the same. The `returnTo` parameter will now be included (improvement over the old behavior).
+
+Check `SessionSecurityIntegrationTest` carefully — it tests redirect behavior for unauthenticated users on `/`, `/contacts`, `/admin/users`, `/auth/change-password`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "refactor: consolidate auth guards into SecurityRules.authenticated filter
+
+Apply SecurityRules.authenticated as a default filter on all protected UI
+routes. Remove ~125 lines of duplicated inline null-check guards across
+HomeRoutes, ContactsRoutes, ComponentRoutes, NotificationRoutes,
+SettingsRoutes, PasswordRoutes, ProfileRoutes, and ApiKeyRoutes.
+
+Public routes (/auth/*, /health, static assets) are excluded from the filter.
+Unauthenticated users now get proper returnTo parameter on redirect."
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- App.kt coupling reduction: Task 1 ✓
+- AuthRoutes decomposition: Task 2 ✓
+- Auth guard consolidation: Task 3 ✓
+- Component groups as seam: Task 1 ✓
+
+**2. Placeholder scan:**
+- No TBD, TODO (except the intentional one in Task 2 Step 1 that says the guard will be removed in Task 3)
+- All code steps show actual implementation patterns
+- Exact file paths provided
+
+**3. Type consistency:**
+- `PersistenceComponents`, `SecurityComponents`, `CoreComponents`, `WebComponents` are all existing data classes with the correct field names
+- The field names used in the mapping table (Task 1 Step 2) match the actual class definitions verified by reading the source files
+- Route class constructors use the correct service types from the component groups

--- a/docs/superpowers/plans/2026-05-25-reachability-metadata-resources.md
+++ b/docs/superpowers/plans/2026-05-25-reachability-metadata-resources.md
@@ -1,0 +1,365 @@
+# Reachability Metadata Resource Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `NativeResourceDriftTest` auto-fix the `resources` section of `reachability-metadata.json` when drift is detected, eliminating the manual generation script.
+
+**Architecture:** Replace 6 individual drift test methods with a single unified test that scans project resources from the source tree, combines them with a constant list of dependency resources, and compares against the current metadata. On drift, the test rewrites the resources section in-place and fails with a commit prompt. The reflection section (168 entries) is untouched. The manual generation script is deleted.
+
+**Tech Stack:** Kotlin, JUnit 5, Jackson (ObjectMapper), GraalVM reachability metadata JSON
+
+**Design spec:** `docs/superpowers/specs/2026-05-25-reachability-metadata-resources-design.md`
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `platform-web/src/test/kotlin/.../nativeimage/NativeResourceDriftTest.kt` | **Rewrite** | Scanner + auto-fix test |
+| `platform-web/src/main/resources/META-INF/.../reachability-metadata.json` | **Auto-updated** | Metadata file (resources section rewritten by test) |
+| `scripts/generate-reachability-resources.ps1` | **Delete** | Superseded by the test |
+| `docs/aot-native-image.md` | **Modify** | Update workflow documentation |
+
+### Resource entry split
+
+The `resources` section contains two categories of entries:
+
+**Project resources** (scanned from source tree — 33 entries):
+- Flyway migrations (12 SQL files + directory + index)
+- i18n bundles (`messages*.properties`)
+- Config files (`application.yaml`, `application-*.yaml`)
+- Static web assets (CSS, JS, fonts, HTML under `static/`)
+- Logback config (`logback.xml`)
+
+**Dependency resources** (constant in test class — 20 entries):
+- 16 glob-only entries from third-party JARs (META-INF/services, logback version props, flyway internals, postgres driver config, prometheus, http4k mime types)
+- 2 module+glob entries (java.logging)
+- 1 module+glob entry (jdk.jfr)
+- 1 bundle entry (sun.util.logging.resources.logging)
+
+**Stale entries removed** (4 entries currently in metadata that should not be):
+- `logback-test.xml` — test-scoped, not on production classpath
+- `themes.json` — only exists in platform-desktop, not a platform-web dependency
+- `themes/default.json` — does not exist anywhere on filesystem
+- `themes/dark.json` — does not exist anywhere on filesystem
+
+---
+
+### Task 1: Rewrite NativeResourceDriftTest
+
+**Files:**
+- Rewrite: `platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/nativeimage/NativeResourceDriftTest.kt`
+
+- [ ] **Step 1: Write the new test**
+
+Replace the entire file with the following code. This replaces 6 individual test methods with a single unified test that scans project resources, compares against metadata, and auto-fixes on drift.
+
+```kotlin
+package io.github.rygel.outerstellar.platform.nativeimage
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.node.ArrayNode
+import java.io.File
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class NativeResourceDriftTest {
+
+    private val metadataFile = File(
+        "src/main/resources/META-INF/native-image/" +
+            "io.github.rygel/outerstellar-platform-web/reachability-metadata.json"
+    )
+
+    private val mapper = ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT)
+
+    private val dependencyGlobs = listOf(
+        "META-INF/org/http4k/core/mime.types",
+        "META-INF/services/ch.qos.logback.classic.spi.Configurator",
+        "META-INF/services/io.opentelemetry.context.ContextStorageProvider",
+        "META-INF/services/java.net.spi.InetAddressResolverProvider",
+        "META-INF/services/java.net.spi.URLStreamHandlerProvider",
+        "META-INF/services/java.nio.channels.spi.SelectorProvider",
+        "META-INF/services/java.sql.Driver",
+        "META-INF/services/java.time.zone.ZoneRulesProvider",
+        "META-INF/services/javax.xml.parsers.SAXParserFactory",
+        "META-INF/services/org.flywaydb.core.extensibility.Plugin",
+        "META-INF/services/org.slf4j.spi.SLF4JServiceProvider",
+        "ch/qos/logback/classic/logback-classic-version.properties",
+        "ch/qos/logback/core/logback-core-version.properties",
+        "org/flywaydb/core/internal/version.txt",
+        "org/postgresql/driverconfig.properties",
+        "prometheus.properties",
+    )
+
+    private fun scanProjectGlobs(): Set<String> {
+        val globs = sortedSetOf<String>()
+        scanMigrations(globs)
+        scanI18nBundles(globs)
+        scanConfigFiles(globs)
+        scanStaticAssets(globs)
+        scanLogback(globs)
+        return globs
+    }
+
+    private fun scanMigrations(globs: MutableSet<String>) {
+        globs.add("db/migration")
+        globs.add("db/migration/migrations.index")
+        val dir = File("../platform-persistence-jdbi/src/main/resources/db/migration")
+        assertTrue(dir.isDirectory, "Migration directory must exist")
+        dir.listFiles()
+            ?.filter { it.name.endsWith(".sql") && it.name.startsWith("V") }
+            ?.forEach { globs.add("db/migration/${it.name}") }
+    }
+
+    private fun scanI18nBundles(globs: MutableSet<String>) {
+        val dir = File("../platform-core/src/main/resources")
+        assertTrue(dir.isDirectory, "platform-core resources must exist")
+        dir.listFiles()
+            ?.filter { it.name.matches(Regex("messages.*\\.properties")) }
+            ?.forEach { globs.add(it.name) }
+    }
+
+    private fun scanConfigFiles(globs: MutableSet<String>) {
+        globs.add("application.yaml")
+        globs.add("application-*.yaml")
+    }
+
+    private fun scanStaticAssets(globs: MutableSet<String>) {
+        val staticDir = File("src/main/resources/static")
+        if (!staticDir.isDirectory) return
+        scanDirectory(staticDir, "static", globs)
+    }
+
+    private fun scanDirectory(dir: File, prefix: String, globs: MutableSet<String>) {
+        dir.listFiles()?.sortedBy { it.name }?.forEach { file ->
+            val path = "$prefix/${file.name}"
+            if (file.isDirectory) {
+                scanDirectory(file, path, globs)
+            } else {
+                globs.add(path)
+            }
+        }
+    }
+
+    private fun scanLogback(globs: MutableSet<String>) {
+        if (File("../platform-core/src/main/resources/logback.xml").isFile) {
+            globs.add("logback.xml")
+        }
+    }
+
+    private fun buildExpectedResources(): ArrayNode {
+        val resources = mapper.createArrayNode()
+
+        for (glob in scanProjectGlobs()) {
+            resources.add(mapper.createObjectNode().put("glob", glob))
+        }
+
+        for (glob in dependencyGlobs.sorted()) {
+            resources.add(mapper.createObjectNode().put("glob", glob))
+        }
+
+        resources.add(
+            mapper.createObjectNode()
+                .put("module", "java.logging")
+                .put("glob", "sun/util/logging/resources/logging_en.properties")
+        )
+        resources.add(
+            mapper.createObjectNode()
+                .put("module", "java.logging")
+                .put("glob", "sun/util/logging/resources/logging_en_GB.properties")
+        )
+        resources.add(
+            mapper.createObjectNode()
+                .put("module", "jdk.jfr")
+                .put("glob", "jdk/jfr/internal/types/metadata.bin")
+        )
+        resources.add(
+            mapper.createObjectNode()
+                .put("bundle", "sun.util.logging.resources.logging")
+        )
+
+        return resources
+    }
+
+    @Test
+    fun `resources section matches classpath`() {
+        assertTrue(metadataFile.isFile, "reachability-metadata.json must exist")
+
+        val expected = buildExpectedResources()
+        val tree = mapper.readTree(metadataFile)
+        val current = tree["resources"]
+        assertTrue(current != null && current.isArray, "resources array must exist")
+
+        val expectedSet = expected.map { it.toString() }.toSet()
+        val currentSet = current.map { it.toString() }.toSet()
+
+        if (expectedSet != currentSet) {
+            val fixed =
+                mapper.readTree(metadataFile) as com.fasterxml.jackson.databind.ObjectNode
+            fixed.set<ArrayNode>("resources", expected)
+            mapper.writeValue(metadataFile, fixed)
+            assertTrue(
+                false,
+                "Resource entries regenerated — review diff and commit"
+            )
+        }
+    }
+}
+```
+
+Key design decisions in this code:
+
+1. **`dependencyGlobs`** — 16 glob-only entries from third-party JARs. These are stable and only change with dependency upgrades. Maintained as a constant list.
+
+2. **`scanProjectGlobs()`** — Scans the source tree across 3 modules: `platform-persistence-jdbi` (migrations), `platform-core` (i18n, logback), and `platform-web` (static assets). Config files use wildcard patterns rather than scanning individual files.
+
+3. **`buildExpectedResources()`** — Constructs the complete expected resources array in a fixed order: project globs (sorted) → dependency globs (sorted) → module+glob entries → bundle entries. This order is deterministic.
+
+4. **Comparison via `toString()`** — Each `JsonNode` entry is serialized to its compact string representation for set comparison. This handles different entry shapes (glob-only, module+glob, bundle) uniformly.
+
+5. **Auto-fix via `mapper.writeValue()`** — On drift, rewrites the entire JSON file. The reflection section is preserved (read and written back unchanged) but may be reformatted by Jackson's pretty printer. This is a one-time cosmetic change — subsequent runs produce no diff.
+
+- [ ] **Step 2: Compile the test**
+
+Run:
+```powershell
+mvn -pl platform-web compile test-compile -am "-Ddetekt.skip=true" "-Dspotbugs.skip=true" "-Dspotless.check.skip=true" "-Dexec.skip=true"
+```
+
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit the test rewrite**
+
+```bash
+git add platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/nativeimage/NativeResourceDriftTest.kt
+git commit -m "refactor: unify NativeResourceDriftTest with auto-fix
+
+Replace 6 individual drift test methods with a single unified test
+that scans project resources from source tree and auto-fixes the
+resources section of reachability-metadata.json when drift is detected."
+```
+
+---
+
+### Task 2: Run the drift test to auto-fix metadata
+
+**Files:**
+- Auto-updated: `platform-web/src/main/resources/META-INF/native-image/io.github.rygel/outerstellar-platform-web/reachability-metadata.json`
+
+- [ ] **Step 1: Run the drift test (first pass — should auto-fix)**
+
+Run:
+```powershell
+mvn -pl platform-web test -Dtest=NativeResourceDriftTest -am "-Dexec.skip=true"
+```
+
+Expected: Test FAILS with message "Resource entries regenerated — review diff and commit". The metadata file is updated in-place:
+- Stale entries removed: `themes.json`, `themes/default.json`, `themes/dark.json`, `logback-test.xml`
+- Resource ordering normalized (alphabetical within each group)
+- Reflection section preserved but may be reformatted by Jackson's pretty printer
+
+- [ ] **Step 2: Review the auto-fixed metadata**
+
+Run:
+```powershell
+git diff platform-web/src/main/resources/META-INF/native-image/
+```
+
+Verify:
+1. **No entries added or removed from the reflection section** — only cosmetic formatting changes are acceptable
+2. **Resource entries reordered** — project globs first (sorted alphabetically), then dependency globs (sorted), then special entries
+3. **Stale entries gone** — `themes.json`, `themes/default.json`, `themes/dark.json`, `logback-test.xml` no longer present
+4. **All expected entries present** — 33 project + 16 dependency globs + 4 special entries = 53 total
+
+If Jackson reformatted the reflection section, verify the entry count is unchanged (168 reflection entries).
+
+- [ ] **Step 3: Run the test again (second pass — should pass)**
+
+Run:
+```powershell
+mvn -pl platform-web test -Dtest=NativeResourceDriftTest -am "-Dexec.skip=true"
+```
+
+Expected: Test PASSES (resources now match expected). This confirms the auto-fix produced valid output.
+
+- [ ] **Step 4: Commit the auto-fixed metadata**
+
+```bash
+git add platform-web/src/main/resources/META-INF/native-image/io.github.rygel/outerstellar-platform-web/reachability-metadata.json
+git commit -m "chore: auto-fix reachability metadata resource entries
+
+Removed stale entries (themes/default.json, themes/dark.json,
+logback-test.xml, themes.json). Resource ordering normalized."
+```
+
+---
+
+### Task 3: Delete generation script and update docs
+
+**Files:**
+- Delete: `scripts/generate-reachability-resources.ps1`
+- Modify: `docs/aot-native-image.md` (Drift Prevention section, lines 401-418; When to Update section, lines 412-419)
+
+- [ ] **Step 1: Delete the generation script**
+
+```bash
+git rm scripts/generate-reachability-resources.ps1
+```
+
+- [ ] **Step 2: Update the Drift Prevention section in docs/aot-native-image.md**
+
+Replace lines 403-418 (from "The metadata must stay" through "- Adding new i18n resource bundles") with:
+
+```markdown
+The metadata must stay in sync with actual classpath files. Two mechanisms prevent drift:
+
+1. **Auto-fixing drift test** — `NativeResourceDriftTest` scans project resources from the source tree and compares them against the `resources` section of `reachability-metadata.json`. When drift is detected (missing or stale entries), the test **rewrites the resources section automatically** and fails with a commit prompt. Run the test again to confirm the fix.
+
+2. **Runtime self-check** — `NativeStartupCheck` runs on native-image startup and verifies critical resources are accessible. It fails fast with actionable error messages if anything is missing.
+
+The test covers: Flyway migrations, i18n bundles, application config YAML, static web assets, and logback config. Dependency resources (from third-party JARs) are maintained as a constant in the test class. Reflection entries (168) are hand-maintained and stable.
+
+### When to Update
+
+Update the metadata when:
+
+- Adding new Flyway migrations (the drift test auto-fixes on next run)
+- Adding new dependencies that use reflection (run the tracing agent to detect them)
+- Changing logging configuration (Logback classes may differ)
+- Adding new i18n resource bundles (the drift test auto-fixes on next run)
+- Adding new static web assets (the drift test auto-fixes on next run)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/generate-reachability-resources.ps1 docs/aot-native-image.md
+git commit -m "docs: update drift prevention docs, delete generation script
+
+The NativeResourceDriftTest now auto-fixes the resources section.
+The manual generation script is no longer needed."
+```
+
+---
+
+### Task 4: Full reactor verify
+
+- [ ] **Step 1: Run full reactor verify (non-desktop modules)**
+
+Run:
+```powershell
+mvn clean verify -T4 -pl platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
+```
+
+Expected: BUILD SUCCESS. All tests pass including `NativeResourceDriftTest`.
+
+- [ ] **Step 2: Verify git status is clean**
+
+Run:
+```powershell
+git status
+```
+
+Expected: working tree clean (all changes committed in previous tasks)

--- a/docs/superpowers/specs/2026-05-25-reachability-metadata-resources-design.md
+++ b/docs/superpowers/specs/2026-05-25-reachability-metadata-resources-design.md
@@ -1,0 +1,69 @@
+# Auto-Generate Reachability Metadata Resources
+
+**Issue:** #325
+**Date:** 2026-05-25
+**Status:** Approved
+
+## Problem
+
+`reachability-metadata.json` has 57 resource entries maintained by hand. A generation script exists (`scripts/generate-reachability-resources.ps1`) but only covers a subset of resource types and prints to stdout for manual copy-paste. Contributors forget to run it, and the drift test catches the mismatch after the fact.
+
+## Decision
+
+Make `NativeResourceDriftTest` the source of truth for resource entries. When it detects drift, it rewrites the `resources` section of `reachability-metadata.json` automatically and fails with a commit prompt.
+
+Reflection entries (168) remain hand-maintained — they only change with dependency upgrades and are stable.
+
+## Design
+
+### Resource scanner
+
+Add a `scanExpectedResources()` method to `NativeResourceDriftTest` that discovers all resource entries from the source tree:
+
+| Resource type | Source path | Pattern |
+|---|---|---|
+| Flyway migrations | `platform-persistence-jdbi/src/main/resources/db/migration/` | `db/migration/V*.sql` |
+| Migration index | same | `db/migration/migrations.index` |
+| Migration directories | same | `db/migration/` |
+| i18n bundles | `platform-core/src/main/resources/` | `messages*.properties` |
+| Config files | `platform-web/src/main/resources/` | `application*.yaml` |
+| Logback config | `platform-web/src/main/resources/` | `logback.xml` |
+| Static CSS | `platform-web/src/main/resources/static/` | `static/site.css` |
+| Static JS | `platform-web/src/main/resources/static/` | `static/platform.js` |
+| Vendor assets | `platform-web/src/main/resources/static/vendor/remixicon/` | `static/vendor/remixicon/remixicon.*` (eot, svg, ttf, woff, woff2, css) |
+| META-INF/services | all modules `src/main/resources/META-INF/services/` | `META-INF/services/*` |
+| Themes | `platform-core/src/main/resources/` | `themes.json`, `themes/*.json` |
+
+The scanner produces a sorted list of `{ "glob": "..." }` entries.
+
+### Auto-fix behavior
+
+The existing test methods are refactored into a single `resources match classpath` test:
+
+1. Scan expected resources from classpath
+2. Read current `resources` section from `reachability-metadata.json`
+3. Compare sorted lists
+4. **If they match:** test passes
+5. **If they differ:** rewrite the `resources` section (preserving `reflection` section), then fail with: `"Resource entries regenerated — review diff and commit"`
+
+### Files changed
+
+| File | Change |
+|---|---|
+| `NativeResourceDriftTest.kt` | Replace individual test methods with unified scanner + auto-fix |
+| `reachability-metadata.json` | Will be auto-updated by the test when drift is detected |
+| `scripts/generate-reachability-resources.ps1` | **Deleted** — absorbed by the test |
+| `docs/aot-native-image.md` | Update workflow documentation |
+
+### What stays the same
+
+- Reflection entries (168) — hand-maintained, stable
+- `NativeStartupCheck` — runtime validation unchanged
+- Native image CI pipeline — unchanged
+
+## Acceptance criteria
+
+- [x] Metadata workflow is scripted and reproducible (the test IS the workflow)
+- [x] Contributors have a documented way to refresh metadata (run the test, commit the diff)
+- [x] Drift is detectable (test fails on drift)
+- [x] Server native build is less dependent on manual edits (resources auto-generated)

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
@@ -10,6 +10,7 @@ import io.github.rygel.outerstellar.platform.security.SecurityComponents
 import io.github.rygel.outerstellar.platform.security.SecurityRules
 import io.github.rygel.outerstellar.platform.security.SessionRealm
 import io.github.rygel.outerstellar.platform.web.AdminNavItem
+import io.github.rygel.outerstellar.platform.web.ApiKeyRoutes
 import io.github.rygel.outerstellar.platform.web.AuthApi
 import io.github.rygel.outerstellar.platform.web.AuthRoutes
 import io.github.rygel.outerstellar.platform.web.ComponentRoutes
@@ -24,11 +25,13 @@ import io.github.rygel.outerstellar.platform.web.NotificationApi
 import io.github.rygel.outerstellar.platform.web.NotificationRoutes
 import io.github.rygel.outerstellar.platform.web.OAuthRoutes
 import io.github.rygel.outerstellar.platform.web.Page
+import io.github.rygel.outerstellar.platform.web.PasswordRoutes
 import io.github.rygel.outerstellar.platform.web.PlatformPlugin
 import io.github.rygel.outerstellar.platform.web.PluginAdminDashboardPage
 import io.github.rygel.outerstellar.platform.web.PluginContext
 import io.github.rygel.outerstellar.platform.web.PluginOptions
 import io.github.rygel.outerstellar.platform.web.PollApi
+import io.github.rygel.outerstellar.platform.web.ProfileRoutes
 import io.github.rygel.outerstellar.platform.web.SearchRoutes
 import io.github.rygel.outerstellar.platform.web.SettingsRoutes
 import io.github.rygel.outerstellar.platform.web.SyncApi
@@ -240,16 +243,16 @@ private fun buildUiRoutes(
             AuthRoutes(
                     pageFactory,
                     jteRenderer,
-                    sec.apiKeyService,
-                    sec.passwordResetService,
                     sec.authService,
-                    sec.accountService,
                     sec.sessionService,
-                    sessionCookieSecure,
+                    sec.passwordResetService,
                     web.analyticsService,
                     config,
                 )
                 .routes
+        routes += PasswordRoutes(pageFactory, jteRenderer, sec.accountService, sec.passwordResetService).routes
+        routes += ProfileRoutes(pageFactory, jteRenderer, sec.accountService, sessionCookieSecure).routes
+        routes += ApiKeyRoutes(pageFactory, jteRenderer, sec.apiKeyService).routes
         val oauthProviders = mutableMapOf<String, io.github.rygel.outerstellar.platform.security.OAuthProvider>()
         val appleConfig = config.appleOAuth
         if (appleConfig.enabled && appleConfig.clientId.isNotBlank()) {

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
@@ -1,26 +1,14 @@
 package io.github.rygel.outerstellar.platform
 
-import io.github.rygel.outerstellar.platform.analytics.AnalyticsService
-import io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService
+import io.github.rygel.outerstellar.platform.di.CoreComponents
+import io.github.rygel.outerstellar.platform.di.PersistenceComponents
+import io.github.rygel.outerstellar.platform.di.WebComponents
 import io.github.rygel.outerstellar.platform.model.UserRole
-import io.github.rygel.outerstellar.platform.persistence.MessageCache
-import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
-import io.github.rygel.outerstellar.platform.persistence.UserRepository
-import io.github.rygel.outerstellar.platform.security.AccountService
 import io.github.rygel.outerstellar.platform.security.ApiKeyRealm
-import io.github.rygel.outerstellar.platform.security.ApiKeyService
-import io.github.rygel.outerstellar.platform.security.AppleOAuthProvider
-import io.github.rygel.outerstellar.platform.security.AuthRealm
 import io.github.rygel.outerstellar.platform.security.AuthResult
-import io.github.rygel.outerstellar.platform.security.AuthService
-import io.github.rygel.outerstellar.platform.security.OAuthService
-import io.github.rygel.outerstellar.platform.security.PasswordResetService
+import io.github.rygel.outerstellar.platform.security.SecurityComponents
 import io.github.rygel.outerstellar.platform.security.SecurityRules
 import io.github.rygel.outerstellar.platform.security.SessionRealm
-import io.github.rygel.outerstellar.platform.security.SessionService
-import io.github.rygel.outerstellar.platform.security.TOTPService
-import io.github.rygel.outerstellar.platform.security.UserAdminService
-import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.web.AdminNavItem
 import io.github.rygel.outerstellar.platform.web.AuthApi
 import io.github.rygel.outerstellar.platform.web.AuthRoutes
@@ -44,13 +32,11 @@ import io.github.rygel.outerstellar.platform.web.PollApi
 import io.github.rygel.outerstellar.platform.web.SearchRoutes
 import io.github.rygel.outerstellar.platform.web.SettingsRoutes
 import io.github.rygel.outerstellar.platform.web.SyncApi
-import io.github.rygel.outerstellar.platform.web.SyncWebSocket
 import io.github.rygel.outerstellar.platform.web.TOTPApiRoutes
 import io.github.rygel.outerstellar.platform.web.TOTPRoutes
 import io.github.rygel.outerstellar.platform.web.UserAdminApi
 import io.github.rygel.outerstellar.platform.web.UserAdminRoutes
 import io.github.rygel.outerstellar.platform.web.VoteApi
-import io.github.rygel.outerstellar.platform.web.WebPageFactory
 import io.github.rygel.outerstellar.platform.web.analyticsPageViewFilter
 import io.github.rygel.outerstellar.platform.web.etagCachingFilter
 import io.github.rygel.outerstellar.platform.web.rateLimitFilter
@@ -78,186 +64,47 @@ import org.http4k.routing.routes
 import org.http4k.routing.static
 import org.http4k.routing.websocket.bind as wsBind
 import org.http4k.routing.websockets
-import org.http4k.template.TemplateRenderer
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger("io.github.rygel.outerstellar.platform.App")
 
-private class OptionalServices(
-    val messageService: MessageService?,
-    val contactService: io.github.rygel.outerstellar.platform.service.ContactService?,
-    val outboxRepository: OutboxRepository?,
-    val cache: MessageCache?,
-    val notificationService: io.github.rygel.outerstellar.platform.service.NotificationService?,
-    val jwtService: io.github.rygel.outerstellar.platform.security.JwtService?,
-    val deviceTokenRepository: io.github.rygel.outerstellar.platform.persistence.DeviceTokenRepository?,
-    val syncWebSocket: SyncWebSocket?,
-    val plugin: PlatformPlugin?,
-    val voteService: io.github.rygel.outerstellar.platform.service.VoteService?,
-    val pollService: io.github.rygel.outerstellar.platform.service.PollService?,
-)
-
-private class AuthServices(
-    val apiKeyService: ApiKeyService,
-    val passwordResetService: PasswordResetService,
-    val oauthService: OAuthService,
-    val auth: AuthService,
-    val account: AccountService,
-)
-
-private class AppContext(
-    val config: AppConfig,
-    val authServices: AuthServices,
-    val userAdminService: UserAdminService,
-    val sessionService: SessionService,
-    val userRepository: UserRepository,
-    val jteRenderer: TemplateRenderer,
-    val pageFactory: WebPageFactory,
-    val analytics: AnalyticsService,
-    val services: OptionalServices,
-    val totpService: TOTPService? = null,
-) {
-    val apiKeyService
-        get() = authServices.apiKeyService
-
-    val passwordResetService
-        get() = authServices.passwordResetService
-
-    val oauthService
-        get() = authServices.oauthService
-
-    val authService
-        get() = authServices.auth
-
-    val accountService
-        get() = authServices.account
-
-    val messageService
-        get() = services.messageService
-
-    val contactService
-        get() = services.contactService
-
-    val outboxRepository
-        get() = services.outboxRepository
-
-    val cache
-        get() = services.cache
-
-    val notificationService
-        get() = services.notificationService
-
-    val jwtService
-        get() = services.jwtService
-
-    val deviceTokenRepository
-        get() = services.deviceTokenRepository
-
-    val syncWebSocket
-        get() = services.syncWebSocket
-
-    val plugin
-        get() = services.plugin
-
-    val voteService
-        get() = services.voteService
-
-    val pollService
-        get() = services.pollService
-
-    val appLabel: String
-        get() = plugin?.appLabel ?: "Outerstellar"
-
-    val excludedRoutes: Set<String>
-        get() = plugin?.excludeDefaultRoutes ?: emptySet()
-
-    fun pluginContext(): PluginContext =
-        PluginContext(
-            jteRenderer,
-            config,
-            apiKeyService,
-            oauthService,
-            userRepository,
-            analytics,
-            notificationService,
-            pageFactory,
-        )
-}
-
-@Suppress("LongParameterList", "DEPRECATION")
 fun app(
-    messageService: MessageService? = null,
-    contactService: io.github.rygel.outerstellar.platform.service.ContactService? = null,
-    outboxRepository: OutboxRepository? = null,
-    cache: MessageCache? = null,
-    jteRenderer: TemplateRenderer,
-    pageFactory: WebPageFactory,
     config: AppConfig,
-    apiKeyService: ApiKeyService,
-    passwordResetService: PasswordResetService,
-    oauthService: OAuthService,
-    authService: AuthService,
-    accountService: AccountService,
-    userAdminService: UserAdminService,
-    sessionService: SessionService,
-    userRepository: UserRepository,
-    deviceTokenRepository: io.github.rygel.outerstellar.platform.persistence.DeviceTokenRepository? = null,
-    analytics: AnalyticsService = NoOpAnalyticsService(),
-    notificationService: io.github.rygel.outerstellar.platform.service.NotificationService? = null,
-    jwtService: io.github.rygel.outerstellar.platform.security.JwtService? = null,
+    persistence: PersistenceComponents,
+    security: SecurityComponents,
+    core: CoreComponents,
+    web: WebComponents,
     plugin: PlatformPlugin? = null,
-    @Suppress("UNUSED_PARAMETER")
-    activityUpdater: io.github.rygel.outerstellar.platform.security.AsyncActivityUpdater? = null,
-    syncWebSocket: SyncWebSocket? = null,
-    totpService: TOTPService? = null,
-    voteService: io.github.rygel.outerstellar.platform.service.VoteService? = null,
-    pollService: io.github.rygel.outerstellar.platform.service.PollService? = null,
 ): PolyHandler {
     logger.info("Initializing Outerstellar application")
-    val ctx =
-        AppContext(
-            config = config,
-            authServices = AuthServices(apiKeyService, passwordResetService, oauthService, authService, accountService),
-            userAdminService = userAdminService,
-            sessionService = sessionService,
-            userRepository = userRepository,
-            jteRenderer = jteRenderer,
-            pageFactory = pageFactory,
-            analytics = analytics,
-            totpService = totpService,
-            services =
-                OptionalServices(
-                    messageService = messageService,
-                    contactService = contactService,
-                    outboxRepository = outboxRepository,
-                    cache = cache,
-                    notificationService = notificationService,
-                    jwtService = jwtService,
-                    deviceTokenRepository = deviceTokenRepository,
-                    syncWebSocket = syncWebSocket,
-                    plugin = plugin,
-                    voteService = voteService,
-                    pollService = pollService,
-                ),
-        )
-    val httpHandler = assembleHttpHandler(ctx)
-    val wsHandler = ctx.syncWebSocket?.let { websockets("/ws/sync" wsBind it.handler) }
+    val httpHandler = assembleHttpHandler(config, persistence, security, core, web, plugin)
+    val wsHandler = web.syncWebSocket.let { websockets("/ws/sync" wsBind it.handler) }
     return PolyHandler(httpHandler, wsHandler)
 }
 
-private fun assembleHttpHandler(ctx: AppContext): HttpHandler {
-    val realms: List<AuthRealm> = listOf(SessionRealm(ctx.sessionService), ApiKeyRealm(ctx.apiKeyService))
+private fun assembleHttpHandler(
+    config: AppConfig,
+    persistence: PersistenceComponents,
+    security: SecurityComponents,
+    core: CoreComponents,
+    web: WebComponents,
+    plugin: PlatformPlugin?,
+): HttpHandler {
+    val sec = security
+    val realms = listOf(SessionRealm(sec.sessionService), ApiKeyRealm(sec.apiKeyService))
     val (bearerSecurity, bearerAdminSecurity) = buildBearerSecurityPair(realms)
-    val apiRoutes = buildApiRoutes(ctx, bearerSecurity, bearerAdminSecurity)
-    val uiRoutes = buildUiRoutes(ctx)
-    val adminRoutes = buildAdminRoutes(ctx)
-    val componentRoutes = buildComponentRoutes(ctx)
-    val baseApp = buildBaseApp(ctx, adminRoutes, apiRoutes, uiRoutes, componentRoutes)
-    return buildFilterChain(ctx).then(baseApp)
+    val apiRoutes =
+        buildApiRoutes(config, persistence, security, core, web, plugin, bearerSecurity, bearerAdminSecurity)
+    val uiRoutes = buildUiRoutes(config, persistence, security, core, web, plugin)
+    val adminRoutes = buildAdminRoutes(config, persistence, security, web, plugin)
+    val componentRoutes = buildComponentRoutes(web, plugin)
+    val baseApp =
+        buildBaseApp(config, persistence, security, web, plugin, adminRoutes, apiRoutes, uiRoutes, componentRoutes)
+    return buildFilterChain(config, persistence, security, web, plugin).then(baseApp)
 }
 
 private fun buildBearerSecurityPair(
-    realms: List<AuthRealm>
+    realms: List<io.github.rygel.outerstellar.platform.security.AuthRealm>
 ): Pair<org.http4k.security.Security, org.http4k.security.Security> {
     val bearerAuthFilter = Filter { next ->
         { req ->
@@ -297,78 +144,63 @@ private fun buildBearerSecurityPair(
 }
 
 private fun buildApiRoutes(
-    ctx: AppContext,
+    config: AppConfig,
+    persistence: PersistenceComponents,
+    security: SecurityComponents,
+    core: CoreComponents,
+    web: WebComponents,
+    plugin: PlatformPlugin?,
     bearerSecurity: org.http4k.security.Security,
     bearerAdminSecurity: org.http4k.security.Security,
-): List<org.http4k.routing.RoutingHttpHandler> {
-    val apiKeyService = ctx.apiKeyService
-    val passwordResetService = ctx.passwordResetService
-    val userAdminService = ctx.userAdminService
-    val messageService = ctx.messageService
-    val contactService = ctx.contactService
-    val analytics = ctx.analytics
-    val deviceTokenRepository = ctx.deviceTokenRepository
-    val notificationService = ctx.notificationService
-    val appLabel = ctx.appLabel
-
-    val voteService = ctx.voteService
-    val pollService = ctx.pollService
+): List<RoutingHttpHandler> {
+    val sec = security
+    val appLabel = plugin?.appLabel ?: "Outerstellar"
 
     val apiRoutes = contract {
         renderer = OpenApi3(ApiInfo("$appLabel API", "v1.0"), KotlinxSerialization)
         descriptionPath = "/api/openapi.json"
         routes +=
             AuthApi(
-                    apiKeyService,
-                    passwordResetService,
-                    ctx.authService,
-                    ctx.accountService,
-                    ctx.sessionService,
-                    ctx.config,
+                    sec.apiKeyService,
+                    sec.passwordResetService,
+                    sec.authService,
+                    sec.accountService,
+                    sec.sessionService,
+                    config,
                 )
                 .routes
-        if (voteService != null) {
-            routes += VoteApi(voteService).routes
-        }
-        if (pollService != null) {
-            routes += PollApi(pollService).routes
-        }
+        routes += VoteApi(web.voteService).routes
+        routes += PollApi(web.pollService).routes
     }
 
     val syncContract = contract {
         renderer = OpenApi3(ApiInfo("Sync", "v1.0"), KotlinxSerialization)
         descriptionPath = "/api/v1/sync/openapi.json"
-        security = bearerSecurity
-        if (messageService != null || contactService != null) {
-            routes += SyncApi(messageService, contactService, analytics).routes
-        }
+        this.security = bearerSecurity
+        routes += SyncApi(core.messageService, core.contactService, web.analyticsService).routes
         routes +=
             AuthApi(
-                    apiKeyService,
-                    passwordResetService,
-                    ctx.authService,
-                    ctx.accountService,
-                    ctx.sessionService,
-                    ctx.config,
+                    sec.apiKeyService,
+                    sec.passwordResetService,
+                    sec.authService,
+                    sec.accountService,
+                    sec.sessionService,
+                    config,
                 )
                 .bearerRoutes
-        if (deviceTokenRepository != null) {
-            routes += DeviceRegistrationApi(deviceTokenRepository).routes
-        }
-        if (notificationService != null) {
-            routes += NotificationApi(notificationService).routes
-        }
+        routes += DeviceRegistrationApi(persistence.deviceTokenRepository).routes
+        routes += NotificationApi(web.notificationService).routes
     }
 
     val bearerAdminApiContract = contract {
         renderer = OpenApi3(ApiInfo("$appLabel Admin API", "v1.0"), KotlinxSerialization)
         descriptionPath = "/api/v1/admin/api-openapi.json"
-        security = bearerAdminSecurity
-        routes += UserAdminApi(userAdminService).routes
+        this.security = bearerAdminSecurity
+        routes += UserAdminApi(sec.userAdminService).routes
         val exportProviders =
             listOfNotNull(
-                messageService?.let { io.github.rygel.outerstellar.platform.export.MessageExportProvider(it) },
-                contactService?.let { io.github.rygel.outerstellar.platform.export.ContactExportProvider(it) },
+                io.github.rygel.outerstellar.platform.export.MessageExportProvider(core.messageService),
+                io.github.rygel.outerstellar.platform.export.ContactExportProvider(core.contactService),
             )
         if (exportProviders.isNotEmpty()) {
             routes += ExportRoutes(exportProviders).routes
@@ -379,49 +211,50 @@ private fun buildApiRoutes(
 }
 
 @Suppress("LongMethod")
-private fun buildUiRoutes(ctx: AppContext): org.http4k.routing.RoutingHttpHandler {
-    val messageService = ctx.messageService
-    val contactService = ctx.contactService
-    val notificationService = ctx.notificationService
-    val plugin = ctx.plugin
-    val excludedRoutes = ctx.excludedRoutes
-    val apiKeyService = ctx.apiKeyService
-    val passwordResetService = ctx.passwordResetService
-    val oauthService = ctx.oauthService
-    val sessionCookieSecure = ctx.config.sessionCookieSecure
-    val analytics = ctx.analytics
-    val pageFactory = ctx.pageFactory
-    val jteRenderer = ctx.jteRenderer
-    val appLabel = ctx.appLabel
+private fun buildUiRoutes(
+    config: AppConfig,
+    persistence: PersistenceComponents,
+    security: SecurityComponents,
+    core: CoreComponents,
+    web: WebComponents,
+    plugin: PlatformPlugin?,
+): RoutingHttpHandler {
+    val sec = security
+    val excludedRoutes = plugin?.excludeDefaultRoutes ?: emptySet()
+    val sessionCookieSecure = config.sessionCookieSecure
+    val pageFactory = web.pageFactory
+    val jteRenderer = web.templateRenderer
+    val appLabel = plugin?.appLabel ?: "Outerstellar"
+    val pluginCtx = plugin?.let { buildPluginContext(jteRenderer, config, persistence, security, web) }
 
     return contract {
         renderer = OpenApi3(ApiInfo("$appLabel UI", "v1.0"), KotlinxSerialization)
         descriptionPath = "/ui/openapi.json"
-        if (messageService != null && "/" !in excludedRoutes) {
-            routes += HomeRoutes(messageService, pageFactory, jteRenderer).routes
+        if ("/" !in excludedRoutes) {
+            routes += HomeRoutes(core.messageService, pageFactory, jteRenderer).routes
         }
-        if (contactService != null && "/contacts" !in excludedRoutes) {
-            routes += ContactsRoutes(pageFactory, jteRenderer, contactService).routes
+        if ("/contacts" !in excludedRoutes) {
+            routes += ContactsRoutes(pageFactory, jteRenderer, core.contactService).routes
         }
         routes +=
             AuthRoutes(
                     pageFactory,
                     jteRenderer,
-                    apiKeyService,
-                    passwordResetService,
-                    ctx.authService,
-                    ctx.accountService,
-                    ctx.sessionService,
+                    sec.apiKeyService,
+                    sec.passwordResetService,
+                    sec.authService,
+                    sec.accountService,
+                    sec.sessionService,
                     sessionCookieSecure,
-                    analytics,
-                    ctx.config,
+                    web.analyticsService,
+                    config,
                 )
                 .routes
         val oauthProviders = mutableMapOf<String, io.github.rygel.outerstellar.platform.security.OAuthProvider>()
-        val appleConfig = ctx.config.appleOAuth
+        val appleConfig = config.appleOAuth
         if (appleConfig.enabled && appleConfig.clientId.isNotBlank()) {
             oauthProviders["apple"] =
-                AppleOAuthProvider(
+                io.github.rygel.outerstellar.platform.security.AppleOAuthProvider(
                     teamId = appleConfig.teamId,
                     clientId = appleConfig.clientId,
                     keyId = appleConfig.keyId,
@@ -431,32 +264,30 @@ private fun buildUiRoutes(ctx: AppContext): org.http4k.routing.RoutingHttpHandle
         routes +=
             OAuthRoutes(
                     providers = oauthProviders,
-                    oauthService = oauthService,
-                    sessionService = ctx.sessionService,
+                    oauthService = sec.oauthService,
+                    sessionService = sec.sessionService,
                     sessionCookieSecure = sessionCookieSecure,
-                    appBaseUrl = ctx.config.appBaseUrl,
+                    appBaseUrl = config.appBaseUrl,
                 )
                 .routes
         routes += ErrorRoutes(pageFactory, jteRenderer).routes
         val searchProviders =
             listOfNotNull(
-                ctx.messageService?.let { io.github.rygel.outerstellar.platform.search.MessageSearchProvider(it) },
-                ctx.contactService?.let { io.github.rygel.outerstellar.platform.search.ContactSearchProvider(it) },
+                io.github.rygel.outerstellar.platform.search.MessageSearchProvider(core.messageService),
+                io.github.rygel.outerstellar.platform.search.ContactSearchProvider(core.contactService),
             )
         routes += SearchRoutes(pageFactory, jteRenderer, searchProviders).routes
         routes += SettingsRoutes(pageFactory, jteRenderer).routes
-        if (notificationService != null) {
-            routes += NotificationRoutes(pageFactory, jteRenderer, notificationService).routes
-        }
-        if (plugin != null) {
-            routes += plugin.routes(ctx.pluginContext())
+        routes += NotificationRoutes(pageFactory, jteRenderer, web.notificationService).routes
+        if (plugin != null && pluginCtx != null) {
+            routes += plugin.routes(pluginCtx)
         }
         routes +=
             ("/logout" bindContract POST).to { request: org.http4k.core.Request ->
                 val rawToken =
                     request.cookie(io.github.rygel.outerstellar.platform.web.RequestContext.SESSION_COOKIE)?.value
                 if (rawToken != null) {
-                    ctx.sessionService.deleteSession(rawToken)
+                    sec.sessionService.deleteSession(rawToken)
                 }
                 Response(Status.FOUND)
                     .header("location", request.shellRenderer.url("/"))
@@ -468,46 +299,54 @@ private fun buildUiRoutes(ctx: AppContext): org.http4k.routing.RoutingHttpHandle
     }
 }
 
-private fun buildComponentRoutes(ctx: AppContext): RoutingHttpHandler {
-    val pageFactory = ctx.pageFactory
-    val jteRenderer = ctx.jteRenderer
-    val appLabel = ctx.appLabel
+private fun buildComponentRoutes(web: WebComponents, plugin: PlatformPlugin?): RoutingHttpHandler {
+    val appLabel = plugin?.appLabel ?: "Outerstellar"
     return contract {
         renderer = OpenApi3(ApiInfo("$appLabel Components", "v1.0"), KotlinxSerialization)
         descriptionPath = "/components/openapi.json"
-        routes += ComponentRoutes(pageFactory, jteRenderer, ctx.voteService, ctx.pollService).routes
+        routes += ComponentRoutes(web.pageFactory, web.templateRenderer, web.voteService, web.pollService).routes
     }
 }
 
-private fun buildAdminRoutes(ctx: AppContext): org.http4k.routing.RoutingHttpHandler {
-    val outboxRepository = ctx.outboxRepository
-    val cache = ctx.cache
-    val pageFactory = ctx.pageFactory
-    val jteRenderer = ctx.jteRenderer
-    val devDashboardEnabled = ctx.config.devDashboardEnabled
-    val userAdminService = ctx.userAdminService
-    val appLabel = ctx.appLabel
+private fun buildAdminRoutes(
+    config: AppConfig,
+    persistence: PersistenceComponents,
+    security: SecurityComponents,
+    web: WebComponents,
+    plugin: PlatformPlugin?,
+): RoutingHttpHandler {
+    val sec = security
+    val pageFactory = web.pageFactory
+    val jteRenderer = web.templateRenderer
+    val devDashboardEnabled = config.devDashboardEnabled
+    val appLabel = plugin?.appLabel ?: "Outerstellar"
     val adminSecurity =
         object : org.http4k.security.Security {
             override val filter = Filter { next ->
                 SecurityRules.authenticated(SecurityRules.hasRole(UserRole.ADMIN, next))
             }
         }
-    val plugin = ctx.plugin
+    val pluginCtx = plugin?.let { buildPluginContext(jteRenderer, config, persistence, security, web) }
     val pluginSections =
-        if (plugin != null) {
-            plugin.adminSections(ctx.pluginContext())
+        if (plugin != null && pluginCtx != null) {
+            plugin.adminSections(pluginCtx)
         } else {
             emptyList()
         }
     val adminContract = contract {
         renderer = OpenApi3(ApiInfo("$appLabel Admin", "v1.0"), KotlinxSerialization)
         descriptionPath = "/admin/openapi.json"
-        security = adminSecurity
-        if (outboxRepository != null && cache != null) {
-            routes += DevDashboardRoutes(outboxRepository, cache, pageFactory, jteRenderer, devDashboardEnabled).routes
-        }
-        routes += UserAdminRoutes(pageFactory, jteRenderer, userAdminService).routes
+        this.security = adminSecurity
+        routes +=
+            DevDashboardRoutes(
+                    persistence.outboxRepository,
+                    web.messageCache,
+                    pageFactory,
+                    jteRenderer,
+                    devDashboardEnabled,
+                )
+                .routes
+        routes += UserAdminRoutes(pageFactory, jteRenderer, sec.userAdminService).routes
         pluginSections.forEach { section -> routes += section.route }
     }
     return if (pluginSections.isNotEmpty()) {
@@ -522,7 +361,7 @@ private fun buildAdminRoutes(ctx: AppContext): org.http4k.routing.RoutingHttpHan
                         val pluginRequestContext =
                             io.github.rygel.outerstellar.platform.web.RequestContext(
                                 req,
-                                sessionService = ctx.sessionService,
+                                sessionService = sec.sessionService,
                             )
                         val pluginShellRenderer =
                             io.github.rygel.outerstellar.platform.web.ShellRenderer(
@@ -540,7 +379,7 @@ private fun buildAdminRoutes(ctx: AppContext): org.http4k.routing.RoutingHttpHan
                             )
                         val shell = pluginShellRenderer.shell("Plugin Dashboard", "/admin/plugins")
                         val page = Page(shell, PluginAdminDashboardPage(pluginSections.map { it.summaryCard }))
-                        Response(Status.OK).body(ctx.jteRenderer(page) ?: "")
+                        Response(Status.OK).body(jteRenderer(page) ?: "")
                     }
             )
         routes(adminContract, pluginDashboardRoute)
@@ -548,6 +387,24 @@ private fun buildAdminRoutes(ctx: AppContext): org.http4k.routing.RoutingHttpHan
         adminContract
     }
 }
+
+private fun buildPluginContext(
+    jteRenderer: org.http4k.template.TemplateRenderer,
+    config: AppConfig,
+    persistence: PersistenceComponents,
+    security: SecurityComponents,
+    web: WebComponents,
+): PluginContext =
+    PluginContext(
+        jteRenderer,
+        config,
+        security.apiKeyService,
+        security.oauthService,
+        persistence.userRepository,
+        web.analyticsService,
+        web.notificationService,
+        web.pageFactory,
+    )
 
 private val localhostOnly = Filter { next ->
     { request ->
@@ -564,12 +421,20 @@ private fun String.isLocalhostHost(): Boolean =
     startsWith("localhost") || startsWith("127.0.0.1") || startsWith("[::1]")
 
 private fun buildBaseApp(
-    ctx: AppContext,
-    adminContract: org.http4k.routing.RoutingHttpHandler,
-    apiRoutes: List<org.http4k.routing.RoutingHttpHandler>,
-    uiRoutes: org.http4k.routing.RoutingHttpHandler,
-    componentRoutes: org.http4k.routing.RoutingHttpHandler,
+    config: AppConfig,
+    persistence: PersistenceComponents,
+    security: SecurityComponents,
+    web: WebComponents,
+    plugin: PlatformPlugin?,
+    adminContract: RoutingHttpHandler,
+    apiRoutes: List<RoutingHttpHandler>,
+    uiRoutes: RoutingHttpHandler,
+    componentRoutes: RoutingHttpHandler,
 ): HttpHandler {
+    val sec = security
+    val userRepository = persistence.userRepository
+    val excludedRoutes = plugin?.excludeDefaultRoutes ?: emptySet()
+
     val filteredAdminHandler =
         Filter { next -> SecurityRules.authenticated(SecurityRules.hasRole(UserRole.ADMIN, next)) }.then(adminContract)
 
@@ -577,32 +442,30 @@ private fun buildBaseApp(
         Filter { next -> SecurityRules.authenticated(SecurityRules.hasRole(UserRole.ADMIN, next)) }
             .then { Response(Status.OK).body(io.github.rygel.outerstellar.platform.web.Metrics.registry.scrape()) }
 
-    // Unfiltered routes — no user resolution, no CSRF, no rate limiting
     val unfiltered =
         mutableListOf(
             static(ResourceLoader.Classpath("static")),
-            "/health" bind GET to localhostOnly.then { buildHealthResponse(ctx.userRepository) },
+            "/health" bind GET to localhostOnly.then { buildHealthResponse(userRepository) },
             "/metrics" bind GET to metricsHandler,
             "/robots.txt" bind GET to { buildRobotsTxtResponse() },
-            "/sitemap.xml" bind GET to { buildSitemapResponse(ctx.config.appBaseUrl) },
+            "/sitemap.xml" bind GET to { buildSitemapResponse(config.appBaseUrl) },
         )
 
-    // Filtered routes — user session, CSRF, rate limiting, state
     val appRoutes = mutableListOf(uiRoutes, componentRoutes)
-    ctx.totpService?.let { totpService ->
+    sec.totpService.let { totpService ->
         appRoutes +=
             TOTPRoutes(
-                    ctx.authService,
-                    ctx.jteRenderer,
-                    ctx.config.sessionCookieSecure,
+                    sec.authService,
+                    web.templateRenderer,
+                    config.sessionCookieSecure,
                     totpService,
-                    ctx.sessionService,
+                    sec.sessionService,
                 )
                 .routes
-        appRoutes += TOTPApiRoutes(ctx.authService, totpService, ctx.sessionService).routes
+        appRoutes += TOTPApiRoutes(sec.authService, totpService, sec.sessionService).routes
     }
     appRoutes.addAll(apiRoutes)
-    if ("/" !in ctx.excludedRoutes) {
+    if ("/" !in excludedRoutes) {
         appRoutes += "/" bind filteredAdminHandler
     }
 
@@ -665,7 +528,9 @@ private fun buildSitemapResponse(appBaseUrl: String): Response {
 }
 
 @Suppress("TooGenericExceptionCaught", "SwallowedException")
-private fun buildHealthResponse(userRepository: UserRepository): Response {
+private fun buildHealthResponse(
+    userRepository: io.github.rygel.outerstellar.platform.persistence.UserRepository
+): Response {
     val checks = mutableMapOf<String, Any>("status" to "UP")
     try {
         userRepository.countAll()
@@ -681,19 +546,23 @@ private fun buildHealthResponse(userRepository: UserRepository): Response {
         .body(KotlinxSerialization.asJsonObject(checks).toString())
 }
 
-private fun buildFilterChain(ctx: AppContext): Filter {
-    val config = ctx.config
-    val userRepository = ctx.userRepository
-    val jwtService = ctx.jwtService
-    val plugin = ctx.plugin
-    val pageFactory = ctx.pageFactory
-    val jteRenderer = ctx.jteRenderer
-    val analytics = ctx.analytics
+private fun buildFilterChain(
+    config: AppConfig,
+    persistence: PersistenceComponents,
+    security: SecurityComponents,
+    web: WebComponents,
+    plugin: PlatformPlugin?,
+): Filter {
+    val sec = security
+    val userRepository = persistence.userRepository
+    val jwtService = sec.jwtService
+    val pageFactory = web.pageFactory
+    val jteRenderer = web.templateRenderer
+    val analytics = web.analyticsService
+    val pluginCtx = plugin?.let { buildPluginContext(jteRenderer, config, persistence, security, web) }
     val adminNavItems =
-        if (plugin != null) {
-            plugin.adminSections(ctx.pluginContext()).map {
-                AdminNavItem(it.navLabel, it.summaryCard.linkUrl, it.navIcon)
-            }
+        if (plugin != null && pluginCtx != null) {
+            plugin.adminSections(pluginCtx).map { AdminNavItem(it.navLabel, it.summaryCard.linkUrl, it.navIcon) }
         } else {
             emptyList()
         }
@@ -706,11 +575,11 @@ private fun buildFilterChain(ctx: AppContext): Filter {
             .then(Filters.telemetry)
             .then(
                 rateLimitFilter(
-                    trustedProxies = ctx.config.trustedProxies.split(",").map { it.trim() }.filter { it.isNotBlank() }
+                    trustedProxies = config.trustedProxies.split(",").map { it.trim() }.filter { it.isNotBlank() }
                 )
             )
             .then(Filters.csrfProtection(config.sessionCookieSecure, config.csrfEnabled))
-            .then(Filters.devAutoLogin(config.devMode, userRepository, ctx.sessionService, config.sessionCookieSecure))
+            .then(Filters.devAutoLogin(config.devMode, userRepository, sec.sessionService, config.sessionCookieSecure))
             .then(
                 Filters.stateFilter(
                     config.devDashboardEnabled,
@@ -721,17 +590,19 @@ private fun buildFilterChain(ctx: AppContext): Filter {
                         navItems = plugin?.navItems ?: emptyList(),
                         textResolver = plugin?.textResolver,
                         adminNavItems = adminNavItems,
-                        bannerProviders = plugin?.bannerProviders(ctx.pluginContext()) ?: emptyList(),
+                        bannerProviders =
+                            if (plugin != null && pluginCtx != null) plugin.bannerProviders(pluginCtx) else emptyList(),
                     ),
                     cookieSecure = config.sessionCookieSecure,
                     appBaseUrl = config.appBaseUrl,
-                    bannerProviders = plugin?.bannerProviders(ctx.pluginContext()) ?: emptyList(),
-                    sessionService = ctx.sessionService,
+                    bannerProviders =
+                        if (plugin != null && pluginCtx != null) plugin.bannerProviders(pluginCtx) else emptyList(),
+                    sessionService = sec.sessionService,
                 )
             )
 
-    if (plugin != null) {
-        for (filter in plugin.filters(ctx.pluginContext())) {
+    if (plugin != null && pluginCtx != null) {
+        for (filter in plugin.filters(pluginCtx)) {
             chain = chain.then(filter)
         }
     }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
@@ -98,11 +98,11 @@ private fun assembleHttpHandler(
     val (bearerSecurity, bearerAdminSecurity) = buildBearerSecurityPair(realms)
     val apiRoutes =
         buildApiRoutes(config, persistence, security, core, web, plugin, bearerSecurity, bearerAdminSecurity)
-    val uiRoutes = buildUiRoutes(config, persistence, security, core, web, plugin)
+    val uiRouteSet = buildUiRoutes(config, persistence, security, core, web, plugin)
+    val componentRouteSet = buildComponentRoutes(web, plugin)
     val adminRoutes = buildAdminRoutes(config, persistence, security, web, plugin)
-    val componentRoutes = buildComponentRoutes(web, plugin)
     val baseApp =
-        buildBaseApp(config, persistence, security, web, plugin, adminRoutes, apiRoutes, uiRoutes, componentRoutes)
+        buildBaseApp(config, persistence, security, web, plugin, adminRoutes, apiRoutes, uiRouteSet, componentRouteSet)
     return buildFilterChain(config, persistence, security, web, plugin).then(baseApp)
 }
 
@@ -213,6 +213,10 @@ private fun buildApiRoutes(
     return listOf(bearerAdminApiContract, apiRoutes, syncContract)
 }
 
+private data class UiRouteSet(val publicRoutes: RoutingHttpHandler, val protectedRoutes: RoutingHttpHandler)
+
+private data class ComponentRouteSet(val publicRoutes: RoutingHttpHandler, val protectedRoutes: RoutingHttpHandler)
+
 @Suppress("LongMethod")
 private fun buildUiRoutes(
     config: AppConfig,
@@ -221,7 +225,7 @@ private fun buildUiRoutes(
     core: CoreComponents,
     web: WebComponents,
     plugin: PlatformPlugin?,
-): RoutingHttpHandler {
+): UiRouteSet {
     val sec = security
     val excludedRoutes = plugin?.excludeDefaultRoutes ?: emptySet()
     val sessionCookieSecure = config.sessionCookieSecure
@@ -229,16 +233,15 @@ private fun buildUiRoutes(
     val jteRenderer = web.templateRenderer
     val appLabel = plugin?.appLabel ?: "Outerstellar"
     val pluginCtx = plugin?.let { buildPluginContext(jteRenderer, config, persistence, security, web) }
+    val passwordRoutes = PasswordRoutes(pageFactory, jteRenderer, sec.accountService, sec.passwordResetService)
+    val homeRoutes = if ("/" !in excludedRoutes) HomeRoutes(core.messageService, pageFactory, jteRenderer) else null
+    val contactsRoutes =
+        if ("/contacts" !in excludedRoutes) ContactsRoutes(pageFactory, jteRenderer, core.contactService) else null
+    val notificationRoutes = NotificationRoutes(pageFactory, jteRenderer, web.notificationService)
 
-    return contract {
+    val publicContract = contract {
         renderer = OpenApi3(ApiInfo("$appLabel UI", "v1.0"), KotlinxSerialization)
         descriptionPath = "/ui/openapi.json"
-        if ("/" !in excludedRoutes) {
-            routes += HomeRoutes(core.messageService, pageFactory, jteRenderer).routes
-        }
-        if ("/contacts" !in excludedRoutes) {
-            routes += ContactsRoutes(pageFactory, jteRenderer, core.contactService).routes
-        }
         routes +=
             AuthRoutes(
                     pageFactory,
@@ -250,9 +253,7 @@ private fun buildUiRoutes(
                     config,
                 )
                 .routes
-        routes += PasswordRoutes(pageFactory, jteRenderer, sec.accountService, sec.passwordResetService).routes
-        routes += ProfileRoutes(pageFactory, jteRenderer, sec.accountService, sessionCookieSecure).routes
-        routes += ApiKeyRoutes(pageFactory, jteRenderer, sec.apiKeyService).routes
+        routes += passwordRoutes.publicRoutes
         val oauthProviders = mutableMapOf<String, io.github.rygel.outerstellar.platform.security.OAuthProvider>()
         val appleConfig = config.appleOAuth
         if (appleConfig.enabled && appleConfig.clientId.isNotBlank()) {
@@ -280,8 +281,26 @@ private fun buildUiRoutes(
                 io.github.rygel.outerstellar.platform.search.ContactSearchProvider(core.contactService),
             )
         routes += SearchRoutes(pageFactory, jteRenderer, searchProviders).routes
+        if (homeRoutes != null) {
+            routes += homeRoutes.publicRoutes
+        }
+        routes += notificationRoutes.publicRoutes
+    }
+
+    val protectedContract = contract {
+        renderer = OpenApi3(ApiInfo("$appLabel Protected UI", "v1.0"), KotlinxSerialization)
+        descriptionPath = "/ui-protected/openapi.json"
+        if (homeRoutes != null) {
+            routes += homeRoutes.protectedRoutes
+        }
+        if (contactsRoutes != null) {
+            routes += contactsRoutes.routes
+        }
+        routes += passwordRoutes.protectedRoutes
+        routes += ProfileRoutes(pageFactory, jteRenderer, sec.accountService, sessionCookieSecure).routes
+        routes += ApiKeyRoutes(pageFactory, jteRenderer, sec.apiKeyService).routes
         routes += SettingsRoutes(pageFactory, jteRenderer).routes
-        routes += NotificationRoutes(pageFactory, jteRenderer, web.notificationService).routes
+        routes += notificationRoutes.protectedRoutes
         if (plugin != null && pluginCtx != null) {
             routes += plugin.routes(pluginCtx)
         }
@@ -300,15 +319,24 @@ private fun buildUiRoutes(
                     )
             }
     }
+
+    return UiRouteSet(publicRoutes = publicContract, protectedRoutes = protectedContract)
 }
 
-private fun buildComponentRoutes(web: WebComponents, plugin: PlatformPlugin?): RoutingHttpHandler {
+private fun buildComponentRoutes(web: WebComponents, plugin: PlatformPlugin?): ComponentRouteSet {
     val appLabel = plugin?.appLabel ?: "Outerstellar"
-    return contract {
+    val componentRoutes = ComponentRoutes(web.pageFactory, web.templateRenderer, web.voteService, web.pollService)
+    val publicContract = contract {
         renderer = OpenApi3(ApiInfo("$appLabel Components", "v1.0"), KotlinxSerialization)
         descriptionPath = "/components/openapi.json"
-        routes += ComponentRoutes(web.pageFactory, web.templateRenderer, web.voteService, web.pollService).routes
+        routes += componentRoutes.publicRoutes
     }
+    val protectedContract = contract {
+        renderer = OpenApi3(ApiInfo("$appLabel Protected Components", "v1.0"), KotlinxSerialization)
+        descriptionPath = "/components-protected/openapi.json"
+        routes += componentRoutes.protectedRoutes
+    }
+    return ComponentRouteSet(publicRoutes = publicContract, protectedRoutes = protectedContract)
 }
 
 private fun buildAdminRoutes(
@@ -431,12 +459,14 @@ private fun buildBaseApp(
     plugin: PlatformPlugin?,
     adminContract: RoutingHttpHandler,
     apiRoutes: List<RoutingHttpHandler>,
-    uiRoutes: RoutingHttpHandler,
-    componentRoutes: RoutingHttpHandler,
+    uiRouteSet: UiRouteSet,
+    componentRouteSet: ComponentRouteSet,
 ): HttpHandler {
     val sec = security
     val userRepository = persistence.userRepository
     val excludedRoutes = plugin?.excludeDefaultRoutes ?: emptySet()
+
+    val authenticatedFilter = Filter { next -> SecurityRules.authenticated(next) }
 
     val filteredAdminHandler =
         Filter { next -> SecurityRules.authenticated(SecurityRules.hasRole(UserRole.ADMIN, next)) }.then(adminContract)
@@ -454,7 +484,11 @@ private fun buildBaseApp(
             "/sitemap.xml" bind GET to { buildSitemapResponse(config.appBaseUrl) },
         )
 
-    val appRoutes = mutableListOf(uiRoutes, componentRoutes)
+    val appRoutes = mutableListOf<RoutingHttpHandler>()
+    appRoutes += uiRouteSet.publicRoutes
+    appRoutes += componentRouteSet.publicRoutes
+    appRoutes += authenticatedFilter.then(uiRouteSet.protectedRoutes)
+    appRoutes += authenticatedFilter.then(componentRouteSet.protectedRoutes)
     sec.totpService.let { totpService ->
         appRoutes +=
             TOTPRoutes(

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/ServerComponents.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/ServerComponents.kt
@@ -70,32 +70,7 @@ fun createServerComponents(plugin: PlatformPlugin? = null): ServerComponents {
         )
 
     val polyHandler =
-        app(
-            messageService = core.messageService,
-            contactService = core.contactService,
-            outboxRepository = persistence.outboxRepository,
-            cache = web.messageCache,
-            jteRenderer = web.templateRenderer,
-            pageFactory = web.pageFactory,
-            config = config,
-            apiKeyService = security.apiKeyService,
-            passwordResetService = security.passwordResetService,
-            oauthService = security.oauthService,
-            authService = security.authService,
-            accountService = security.accountService,
-            userAdminService = security.userAdminService,
-            sessionService = security.sessionService,
-            userRepository = persistence.userRepository,
-            analytics = web.analyticsService,
-            notificationService = web.notificationService,
-            jwtService = security.jwtService,
-            plugin = plugin,
-            activityUpdater = security.asyncActivityUpdater,
-            syncWebSocket = web.syncWebSocket,
-            totpService = security.totpService,
-            voteService = web.voteService,
-            pollService = web.pollService,
-        )
+        app(config = config, persistence = persistence, security = security, core = core, web = web, plugin = plugin)
 
     return ServerComponents(
         config = config,

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyRoutes.kt
@@ -32,11 +32,7 @@ class ApiKeyRoutes(
                 { request: org.http4k.core.Request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    } else {
-                        renderer.render(pageFactory.buildApiKeysPage(ctx, shellRenderer))
-                    }
+                    renderer.render(pageFactory.buildApiKeysPage(ctx, shellRenderer))
                 },
             "/auth/api-keys/create" meta
                 {
@@ -46,24 +42,20 @@ class ApiKeyRoutes(
                 { request: org.http4k.core.Request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    val user = ctx.user
-                    if (user == null) {
-                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
+                    val user = ctx.user!!
+                    val name = request.form("name").orEmpty()
+                    if (name.isBlank()) {
+                        renderer.render(pageFactory.buildApiKeysPage(ctx, shellRenderer))
                     } else {
-                        val name = request.form("name").orEmpty()
-                        if (name.isBlank()) {
-                            renderer.render(pageFactory.buildApiKeysPage(ctx, shellRenderer))
-                        } else {
-                            val result = apiKeyService.createApiKey(user.id, name)
-                            renderer.render(
-                                pageFactory.buildApiKeysPage(
-                                    ctx,
-                                    shellRenderer,
-                                    newKey = result.key,
-                                    newKeyName = result.name,
-                                )
+                        val result = apiKeyService.createApiKey(user.id, name)
+                        renderer.render(
+                            pageFactory.buildApiKeysPage(
+                                ctx,
+                                shellRenderer,
+                                newKey = result.key,
+                                newKeyName = result.name,
                             )
-                        }
+                        )
                     }
                 },
             "/auth/api-keys" / apiKeyIdPath / "delete" meta
@@ -73,15 +65,10 @@ class ApiKeyRoutes(
                 POST to
                 { id, _ ->
                     { request: org.http4k.core.Request ->
-                        val ctx = request.requestContext
                         val shellRenderer = request.shellRenderer
-                        val user = ctx.user
-                        if (user == null) {
-                            Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        } else {
-                            apiKeyService.deleteApiKey(user.id, id)
-                            Response(Status.FOUND).header("location", shellRenderer.url("/auth/api-keys"))
-                        }
+                        val user = request.requestContext.user!!
+                        apiKeyService.deleteApiKey(user.id, id)
+                        Response(Status.FOUND).header("location", shellRenderer.url("/auth/api-keys"))
                     }
                 },
         )

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ApiKeyRoutes.kt
@@ -1,0 +1,88 @@
+package io.github.rygel.outerstellar.platform.web
+
+import io.github.rygel.outerstellar.platform.infra.render
+import io.github.rygel.outerstellar.platform.security.ApiKeyService
+import org.http4k.contract.ContractRoute
+import org.http4k.contract.bindContract
+import org.http4k.contract.div
+import org.http4k.contract.meta
+import org.http4k.core.Method.GET
+import org.http4k.core.Method.POST
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.body.form
+import org.http4k.lens.Path
+import org.http4k.lens.long
+import org.http4k.template.TemplateRenderer
+
+class ApiKeyRoutes(
+    private val pageFactory: WebPageFactory,
+    private val renderer: TemplateRenderer,
+    private val apiKeyService: ApiKeyService,
+) : ServerRoutes {
+    private val apiKeyIdPath = Path.long().of("id")
+
+    override val routes: List<ContractRoute> =
+        listOf(
+            "/auth/api-keys" meta
+                {
+                    summary = "API keys management page"
+                } bindContract
+                GET to
+                { request: org.http4k.core.Request ->
+                    val ctx = request.requestContext
+                    val shellRenderer = request.shellRenderer
+                    if (ctx.user == null) {
+                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
+                    } else {
+                        renderer.render(pageFactory.buildApiKeysPage(ctx, shellRenderer))
+                    }
+                },
+            "/auth/api-keys/create" meta
+                {
+                    summary = "Create a new API key"
+                } bindContract
+                POST to
+                { request: org.http4k.core.Request ->
+                    val ctx = request.requestContext
+                    val shellRenderer = request.shellRenderer
+                    val user = ctx.user
+                    if (user == null) {
+                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
+                    } else {
+                        val name = request.form("name").orEmpty()
+                        if (name.isBlank()) {
+                            renderer.render(pageFactory.buildApiKeysPage(ctx, shellRenderer))
+                        } else {
+                            val result = apiKeyService.createApiKey(user.id, name)
+                            renderer.render(
+                                pageFactory.buildApiKeysPage(
+                                    ctx,
+                                    shellRenderer,
+                                    newKey = result.key,
+                                    newKeyName = result.name,
+                                )
+                            )
+                        }
+                    }
+                },
+            "/auth/api-keys" / apiKeyIdPath / "delete" meta
+                {
+                    summary = "Delete an API key"
+                } bindContract
+                POST to
+                { id, _ ->
+                    { request: org.http4k.core.Request ->
+                        val ctx = request.requestContext
+                        val shellRenderer = request.shellRenderer
+                        val user = ctx.user
+                        if (user == null) {
+                            Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
+                        } else {
+                            apiKeyService.deleteApiKey(user.id, id)
+                            Response(Status.FOUND).header("location", shellRenderer.url("/auth/api-keys"))
+                        }
+                    }
+                },
+        )
+}

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AuthRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AuthRoutes.kt
@@ -6,8 +6,6 @@ import io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService
 import io.github.rygel.outerstellar.platform.infra.render
 import io.github.rygel.outerstellar.platform.model.UsernameAlreadyExistsException
 import io.github.rygel.outerstellar.platform.model.WeakPasswordException
-import io.github.rygel.outerstellar.platform.security.AccountService
-import io.github.rygel.outerstellar.platform.security.ApiKeyService
 import io.github.rygel.outerstellar.platform.security.AuthResult
 import io.github.rygel.outerstellar.platform.security.AuthService
 import io.github.rygel.outerstellar.platform.security.PasswordResetService
@@ -21,27 +19,19 @@ import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.body.form
 import org.http4k.lens.Path
-import org.http4k.lens.long
 import org.http4k.lens.string
 import org.http4k.template.TemplateRenderer
-import org.slf4j.LoggerFactory
 
 class AuthRoutes(
     private val pageFactory: WebPageFactory,
     private val renderer: TemplateRenderer,
-    private val apiKeyService: ApiKeyService,
-    private val passwordResetService: PasswordResetService,
     private val authService: AuthService,
-    private val accountService: AccountService,
     private val sessionService: SessionService,
-    private val sessionCookieSecure: Boolean,
+    private val passwordResetService: PasswordResetService,
     private val analytics: AnalyticsService = NoOpAnalyticsService(),
     private val appConfig: AppConfig,
 ) : ServerRoutes {
-    private val logger = LoggerFactory.getLogger(AuthRoutes::class.java)
     private val modePath = Path.string().of("mode")
-    private val apiKeyIdPath = Path.long().of("id")
-    private val tokenPath = Path.string().of("token")
 
     override val routes =
         listOf(
@@ -100,7 +90,7 @@ class AuthRoutes(
                             val sessionToken = sessionService.createSession(user.id)
                             Response(Status.FOUND)
                                 .header("location", shellRenderer.url(returnTo))
-                                .header("Set-Cookie", SessionCookie.create(sessionToken, sessionCookieSecure))
+                                .header("Set-Cookie", SessionCookie.create(sessionToken, appConfig.sessionCookieSecure))
                         } else {
                             renderer.render(
                                 AuthResultFragment(
@@ -168,310 +158,6 @@ class AuthRoutes(
                     } else {
                         val formValues = request.form().associate { it.first to it.second }
                         renderer.render(pageFactory.buildAuthResult(request.shellRenderer, formValues))
-                    }
-                },
-            "/auth/change-password" meta
-                {
-                    summary = "Change password page"
-                } bindContract
-                GET to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    } else {
-                        renderer.render(pageFactory.buildChangePasswordPage(shellRenderer))
-                    }
-                },
-            "/auth/components/change-password" meta
-                {
-                    summary = "Process password change form"
-                } bindContract
-                POST to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    val user = ctx.user
-                    if (user == null) {
-                        Response(Status.UNAUTHORIZED).body("Not logged in")
-                    } else {
-                        val currentPassword = request.form("currentPassword").orEmpty()
-                        val newPassword = request.form("newPassword").orEmpty()
-                        val confirmPassword = request.form("confirmPassword").orEmpty()
-
-                        if (newPassword != confirmPassword) {
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.password.error.title"),
-                                    message = shellRenderer.i18n.translate("web.password.error.mismatch"),
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
-                            )
-                        } else {
-                            try {
-                                accountService.changePassword(user.id, currentPassword, newPassword)
-                                renderer.render(
-                                    AuthResultFragment(
-                                        title = shellRenderer.i18n.translate("web.password.success.title"),
-                                        message = shellRenderer.i18n.translate("web.password.success.body"),
-                                        toneClass = "bg-success/10 border-success/30 text-success",
-                                    )
-                                )
-                            } catch (e: WeakPasswordException) {
-                                renderer.render(
-                                    AuthResultFragment(
-                                        title = shellRenderer.i18n.translate("web.password.error.title"),
-                                        message = e.message ?: "Password change failed",
-                                        toneClass = "bg-error/10 border-error/30 text-error",
-                                    )
-                                )
-                            }
-                        }
-                    }
-                },
-            "/auth/reset" / tokenPath meta
-                {
-                    summary = "Password reset page"
-                } bindContract
-                GET to
-                { token ->
-                    { request: org.http4k.core.Request ->
-                        val ctx = request.requestContext
-                        val shellRenderer = request.shellRenderer
-                        renderer.render(pageFactory.buildResetPasswordPage(shellRenderer, token))
-                    }
-                },
-            "/auth/components/reset-confirm" meta
-                {
-                    summary = "Process password reset form"
-                } bindContract
-                POST to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    val token = request.form("token").orEmpty()
-                    val newPassword = request.form("newPassword").orEmpty()
-                    val confirmPassword = request.form("confirmPassword").orEmpty()
-
-                    if (newPassword != confirmPassword) {
-                        renderer.render(
-                            AuthResultFragment(
-                                title = shellRenderer.i18n.translate("web.reset.error.title"),
-                                message = shellRenderer.i18n.translate("web.reset.error.mismatch"),
-                                toneClass = "bg-error/10 border-error/30 text-error",
-                            )
-                        )
-                    } else {
-                        try {
-                            passwordResetService.resetPassword(token, newPassword)
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.reset.success.title"),
-                                    message = shellRenderer.i18n.translate("web.reset.success.body"),
-                                    toneClass = "bg-success/10 border-success/30 text-success",
-                                )
-                            )
-                        } catch (e: IllegalArgumentException) {
-                            logger.warn("Password reset failed with invalid token: {}", e.message)
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.reset.error.title"),
-                                    message = shellRenderer.i18n.translate("web.reset.error.invalid"),
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
-                            )
-                        } catch (e: WeakPasswordException) {
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.reset.error.title"),
-                                    message = e.message ?: shellRenderer.i18n.translate("web.reset.error.invalid"),
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
-                            )
-                        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                            logger.error("Unexpected error during password reset", e)
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.reset.error.title"),
-                                    message = shellRenderer.i18n.translate("web.reset.error.invalid"),
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
-                            )
-                        }
-                    }
-                },
-            "/auth/profile" meta
-                {
-                    summary = "User profile page"
-                } bindContract
-                GET to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    } else {
-                        renderer.render(pageFactory.buildProfilePage(ctx, shellRenderer))
-                    }
-                },
-            "/auth/components/profile-update" meta
-                {
-                    summary = "Process profile update form"
-                } bindContract
-                POST to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    val user = ctx.user
-                    if (user == null) {
-                        Response(Status.UNAUTHORIZED).body("Not logged in")
-                    } else {
-                        val newEmail = request.form("email").orEmpty()
-                        val newUsername = request.form("username")?.takeIf { it.isNotBlank() }
-                        val newAvatarUrl = request.form("avatarUrl")
-                        try {
-                            accountService.updateProfile(user.id, newEmail, newUsername, newAvatarUrl)
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.profile.success.title"),
-                                    message = shellRenderer.i18n.translate("web.profile.success.body"),
-                                    toneClass = "bg-success/10 border-success/30 text-success",
-                                )
-                            )
-                        } catch (e: UsernameAlreadyExistsException) {
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.profile.error.title"),
-                                    message = e.message ?: "Update failed",
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
-                            )
-                        } catch (e: IllegalArgumentException) {
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.profile.error.title"),
-                                    message = e.message ?: "Update failed",
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
-                            )
-                        }
-                    }
-                },
-            "/auth/notification-preferences" meta
-                {
-                    summary = "Update notification preferences"
-                } bindContract
-                POST to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    val user = ctx.user
-                    if (user == null) {
-                        Response(Status.UNAUTHORIZED).body("Not logged in")
-                    } else {
-                        val emailEnabled = request.form("emailNotifications") == "on"
-                        val pushEnabled = request.form("pushNotifications") == "on"
-                        accountService.updateNotificationPreferences(user.id, emailEnabled, pushEnabled)
-                        renderer.render(
-                            AuthResultFragment(
-                                title = shellRenderer.i18n.translate("web.profile.notif.success.title"),
-                                message = shellRenderer.i18n.translate("web.profile.notif.success.body"),
-                                toneClass = "bg-success/10 border-success/30 text-success",
-                            )
-                        )
-                    }
-                },
-            "/auth/account/delete" meta
-                {
-                    summary = "Delete own account"
-                } bindContract
-                POST to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    val user = ctx.user
-                    if (user == null) {
-                        Response(Status.UNAUTHORIZED).body("Not logged in")
-                    } else {
-                        try {
-                            val currentPassword = request.form("currentPassword").orEmpty()
-                            if (currentPassword.isBlank()) {
-                                return@to Response(Status.BAD_REQUEST).body("Current password is required")
-                            }
-                            accountService.deleteAccount(user.id, currentPassword)
-                            Response(Status.FOUND)
-                                .header("location", shellRenderer.url("/auth?deleted=true"))
-                                .header("Set-Cookie", SessionCookie.clear(sessionCookieSecure))
-                        } catch (e: io.github.rygel.outerstellar.platform.model.InsufficientPermissionException) {
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.profile.delete.error.title"),
-                                    message = e.message ?: "Cannot delete account",
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
-                            )
-                        }
-                    }
-                },
-            "/auth/api-keys" meta
-                {
-                    summary = "API keys management page"
-                } bindContract
-                GET to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    } else {
-                        renderer.render(pageFactory.buildApiKeysPage(ctx, shellRenderer))
-                    }
-                },
-            "/auth/api-keys/create" meta
-                {
-                    summary = "Create a new API key"
-                } bindContract
-                POST to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    val user = ctx.user
-                    if (user == null) {
-                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    } else {
-                        val name = request.form("name").orEmpty()
-                        if (name.isBlank()) {
-                            renderer.render(pageFactory.buildApiKeysPage(ctx, shellRenderer))
-                        } else {
-                            val result = apiKeyService.createApiKey(user.id, name)
-                            renderer.render(
-                                pageFactory.buildApiKeysPage(
-                                    ctx,
-                                    shellRenderer,
-                                    newKey = result.key,
-                                    newKeyName = result.name,
-                                )
-                            )
-                        }
-                    }
-                },
-            "/auth/api-keys" / apiKeyIdPath / "delete" meta
-                {
-                    summary = "Delete an API key"
-                } bindContract
-                POST to
-                { id, _ ->
-                    { request: org.http4k.core.Request ->
-                        val ctx = request.requestContext
-                        val shellRenderer = request.shellRenderer
-                        val user = ctx.user
-                        if (user == null) {
-                            Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        } else {
-                            apiKeyService.deleteApiKey(user.id, id)
-                            Response(Status.FOUND).header("location", shellRenderer.url("/auth/api-keys"))
-                        }
                     }
                 },
         )

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ComponentRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ComponentRoutes.kt
@@ -37,7 +37,7 @@ class ComponentRoutes(
     private val optionIdLens = Query.string().required("optionId")
     private val pollSyncIdPath = Path.string().of("syncId")
 
-    override val routes =
+    val publicRoutes =
         listOf(
             "/components/navigation/page" meta
                 {
@@ -75,6 +75,10 @@ class ComponentRoutes(
                 { request: org.http4k.core.Request ->
                     renderer.render(pageFactory.buildLayoutSelector(request.requestContext, request.shellRenderer))
                 },
+        ) + votePublicRoutes() + pollPublicRoutes()
+
+    val protectedRoutes =
+        listOf(
             "/components/message-list" meta
                 {
                     summary = "Message list fragment"
@@ -87,18 +91,17 @@ class ComponentRoutes(
                 { request: org.http4k.core.Request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    }
                     val query = queryLens(request)
                     val limit = limitLens(request).coerceIn(1, MAX_LIMIT)
                     val offset = offsetLens(request).coerceAtLeast(0)
                     val year = yearLens(request)
                     renderer.render(pageFactory.buildMessageList(ctx, shellRenderer, query, limit, offset, year))
-                },
-        ) + voteRoutes() + pollRoutes()
+                }
+        ) + voteProtectedRoutes() + pollProtectedRoutes()
 
-    private fun voteRoutes() =
+    override val routes = publicRoutes + protectedRoutes
+
+    private fun votePublicRoutes() =
         if (voteService == null) {
             emptyList()
         } else {
@@ -115,7 +118,16 @@ class ComponentRoutes(
                         val userId = ctx.user?.id
                         val score = vs.getScore(syncId, userId)
                         renderer.render(VoteFragmentViewModel(score, syncId))
-                    },
+                    }
+            )
+        }
+
+    private fun voteProtectedRoutes() =
+        if (voteService == null) {
+            emptyList()
+        } else {
+            val vs = voteService
+            listOf(
                 "/components/messages/{syncId}/vote" meta
                     {
                         summary = "Submit a vote on a message"
@@ -123,20 +135,15 @@ class ComponentRoutes(
                     POST to
                     { request: org.http4k.core.Request ->
                         val syncId = extractVoteSyncId(request) ?: return@to Response(Status.BAD_REQUEST)
-                        val ctx = request.requestContext
-                        val shellRenderer = request.shellRenderer
-                        val user = ctx.user
-                        if (user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
+                        val user = request.requestContext.user!!
                         val direction = request.form("direction")?.toIntOrNull() ?: 0
                         val score = vs.vote(syncId, user.id, direction) ?: VoteScore(syncId, 0, 0, 0, null)
                         renderer.render(VoteFragmentViewModel(score, syncId))
-                    },
+                    }
             )
         }
 
-    private fun pollRoutes() =
+    private fun pollPublicRoutes() =
         if (pollService == null) {
             emptyList()
         } else {
@@ -153,7 +160,16 @@ class ComponentRoutes(
                             val results = ps.getPoll(syncId, ctx.user?.id) ?: return@to Response(Status.NOT_FOUND)
                             renderer.render(PollFragmentViewModel(results, syncId))
                         }
-                    },
+                    }
+            )
+        }
+
+    private fun pollProtectedRoutes() =
+        if (pollService == null) {
+            emptyList()
+        } else {
+            val ps = pollService
+            listOf(
                 "/components/polls" / pollSyncIdPath / "vote" meta
                     {
                         summary = "Cast a vote on a poll option"
@@ -161,12 +177,7 @@ class ComponentRoutes(
                     POST to
                     { syncId, _ ->
                         { request: org.http4k.core.Request ->
-                            val ctx = request.requestContext
-                            val shellRenderer = request.shellRenderer
-                            val user = ctx.user
-                            if (user == null) {
-                                return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                            }
+                            val user = request.requestContext.user!!
                             val optionId =
                                 request.form("optionId")?.toLongOrNull() ?: return@to Response(Status.BAD_REQUEST)
                             val results =
@@ -185,12 +196,7 @@ class ComponentRoutes(
                     DELETE to
                     { syncId, _ ->
                         { request: org.http4k.core.Request ->
-                            val ctx = request.requestContext
-                            val shellRenderer = request.shellRenderer
-                            val user = ctx.user
-                            if (user == null) {
-                                return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                            }
+                            val user = request.requestContext.user!!
                             val optionId =
                                 optionIdLens(request).toLongOrNull() ?: return@to Response(Status.BAD_REQUEST)
                             ps.removeVote(syncId, optionId, user.id)

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ContactsRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ContactsRoutes.kt
@@ -33,11 +33,7 @@ class ContactsRoutes(
                 } bindContract
                 GET to
                 { request: Request ->
-                    val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    }
                     val query = request.query("q")
                     val limit =
                         request.query("limit")?.toIntOrNull()?.coerceIn(1, MAX_CONTACTS_LIMIT) ?: DEFAULT_CONTACTS_LIMIT
@@ -50,11 +46,7 @@ class ContactsRoutes(
                 } bindContract
                 GET to
                 { request: Request ->
-                    val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    }
                     renderer.render(pageFactory.buildContactForm(shellRenderer))
                 },
             "/contacts" meta
@@ -63,11 +55,7 @@ class ContactsRoutes(
                 } bindContract
                 POST to
                 { request: Request ->
-                    val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    }
                     val params = request.bodyAsForm()
                     val name = params.findSingle("name") ?: return@to Response(Status.BAD_REQUEST).body("name required")
                     contactService?.createContact(
@@ -93,11 +81,7 @@ class ContactsRoutes(
                 GET to
                 { syncId: String, _ ->
                     { request: Request ->
-                        val ctx = request.requestContext
                         val shellRenderer = request.shellRenderer
-                        if (ctx.user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
                         renderer.render(pageFactory.buildContactForm(shellRenderer, syncId))
                     }
                 },
@@ -108,11 +92,7 @@ class ContactsRoutes(
                 POST to
                 { syncId: String, _ ->
                     { request: Request ->
-                        val ctx = request.requestContext
                         val shellRenderer = request.shellRenderer
-                        if (ctx.user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
                         val params = request.bodyAsForm()
                         val existing =
                             contactService?.getContactBySyncId(syncId)
@@ -145,11 +125,7 @@ class ContactsRoutes(
                 POST to
                 { syncId: String, _ ->
                     { request: Request ->
-                        val ctx = request.requestContext
                         val shellRenderer = request.shellRenderer
-                        if (ctx.user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
                         contactService?.deleteContact(syncId)
                         val params = request.bodyAsForm()
                         val query = params.findSingle("q")
@@ -167,11 +143,7 @@ class ContactsRoutes(
                 POST to
                 { syncId: String, _ ->
                     { request: Request ->
-                        val ctx = request.requestContext
                         val shellRenderer = request.shellRenderer
-                        if (ctx.user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
                         contactService?.restoreContact(syncId)
                         Response(Status.FOUND).header("location", "/messages/trash")
                     }
@@ -182,11 +154,7 @@ class ContactsRoutes(
                 } bindContract
                 GET to
                 { request: Request ->
-                    val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    }
                     renderer.render(pageFactory.buildContactTrashList(shellRenderer))
                 },
         )

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/HomeRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/HomeRoutes.kt
@@ -32,7 +32,19 @@ class HomeRoutes(
     private val yearLens = Query.int().optional("year")
     private val syncIdPath = Path.string().of("syncId")
 
-    override val routes =
+    val publicRoutes =
+        listOf(
+            "/components/footer-status" meta
+                {
+                    summary = "Footer status fragment"
+                } bindContract
+                GET to
+                { request ->
+                    renderer.render(pageFactory.buildFooterStatus(request.shellRenderer))
+                }
+        )
+
+    val protectedRoutes =
         listOf(
             "/" meta
                 {
@@ -46,9 +58,6 @@ class HomeRoutes(
                 { request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    }
                     val query = queryLens(request)
                     val limit = limitLens(request).coerceIn(1, MAX_LIMIT)
                     val offset = offsetLens(request).coerceAtLeast(0)
@@ -63,9 +72,6 @@ class HomeRoutes(
                 { request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    }
                     renderer.render(pageFactory.buildTrashPage(ctx, shellRenderer))
                 },
             "/messages" meta
@@ -76,9 +82,6 @@ class HomeRoutes(
                 { request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    }
                     val author = request.form("author").orEmpty()
                     val content = request.form("content").orEmpty()
                     messageService.createServerMessage(author, content)
@@ -91,11 +94,7 @@ class HomeRoutes(
                 POST to
                 { syncId ->
                     { request: org.http4k.core.Request ->
-                        val ctx = request.requestContext
                         val shellRenderer = request.shellRenderer
-                        if (ctx.user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
                         messageService.restore(syncId)
                         Response(Status.FOUND).header("location", shellRenderer.url("/messages/trash"))
                     }
@@ -107,12 +106,7 @@ class HomeRoutes(
                 GET to
                 { syncId ->
                     { request: org.http4k.core.Request ->
-                        val ctx = request.requestContext
-                        val shellRenderer = request.shellRenderer
-                        if (ctx.user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
-                        val viewModel = pageFactory.buildConflictResolveModal(shellRenderer, syncId)
+                        val viewModel = pageFactory.buildConflictResolveModal(request.shellRenderer, syncId)
                         renderer.render(viewModel)
                     }
                 },
@@ -123,11 +117,6 @@ class HomeRoutes(
                 POST to
                 { syncId ->
                     { request: org.http4k.core.Request ->
-                        val ctx = request.requestContext
-                        val shellRenderer = request.shellRenderer
-                        if (ctx.user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
                         val strategy = ConflictStrategy.fromString(request.form("strategy") ?: "server")
                         messageService.resolveConflict(syncId, strategy)
                         Response(Status.OK).header("HX-Trigger", "refresh")
@@ -140,11 +129,6 @@ class HomeRoutes(
                 POST to
                 { syncId: String, _ ->
                     { request: Request ->
-                        val ctx = request.requestContext
-                        val shellRenderer = request.shellRenderer
-                        if (ctx.user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
                         messageService.deleteMessage(syncId)
                         Response(Status.OK)
                     }
@@ -156,12 +140,7 @@ class HomeRoutes(
                 GET to
                 { syncId: String, _ ->
                     { request: Request ->
-                        val ctx = request.requestContext
-                        val shellRenderer = request.shellRenderer
-                        if (ctx.user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
-                        renderer.render(pageFactory.buildMessageEditForm(shellRenderer, syncId))
+                        renderer.render(pageFactory.buildMessageEditForm(request.shellRenderer, syncId))
                     }
                 },
             "/messages" / syncIdPath / "update" meta
@@ -173,9 +152,6 @@ class HomeRoutes(
                     { request: Request ->
                         val ctx = request.requestContext
                         val shellRenderer = request.shellRenderer
-                        if (ctx.user == null) {
-                            return@to Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                        }
                         val msg = messageService.findBySyncId(syncId)
                         val author = request.form("author").orEmpty()
                         val content = request.form("content").orEmpty()
@@ -183,13 +159,7 @@ class HomeRoutes(
                         renderer.render(pageFactory.buildMessageList(ctx, shellRenderer))
                     }
                 },
-            "/components/footer-status" meta
-                {
-                    summary = "Footer status fragment"
-                } bindContract
-                GET to
-                { request ->
-                    renderer.render(pageFactory.buildFooterStatus(request.shellRenderer))
-                },
         )
+
+    override val routes = publicRoutes + protectedRoutes
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/NotificationRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/NotificationRoutes.kt
@@ -24,56 +24,8 @@ class NotificationRoutes(
     private val notificationIdPath = Path.string().of("notificationId")
     private val logger = LoggerFactory.getLogger(NotificationRoutes::class.java)
 
-    override val routes: List<ContractRoute> =
+    val publicRoutes: List<ContractRoute> =
         listOf(
-            "/notifications" meta
-                {
-                    summary = "In-app notifications page"
-                } bindContract
-                GET to
-                { request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        Response(Status.FOUND).header("location", "/auth")
-                    } else {
-                        renderer.render(pageFactory.buildNotificationsPage(ctx, shellRenderer))
-                    }
-                },
-            "/notifications/read-all" meta
-                {
-                    summary = "Mark all notifications as read"
-                } bindContract
-                POST to
-                { request ->
-                    val user = request.requestContext.user
-                    if (user == null) {
-                        Response(Status.FORBIDDEN)
-                    } else {
-                        notificationService.markAllRead(user.id)
-                        Response(Status.FOUND).header("location", "/notifications")
-                    }
-                },
-            "/notifications" / notificationIdPath / "read" meta
-                {
-                    summary = "Mark a single notification as read"
-                } bindContract
-                POST to
-                { notificationId, _ ->
-                    { request ->
-                        val user = request.requestContext.user
-                        if (user == null) {
-                            Response(Status.FORBIDDEN)
-                        } else {
-                            try {
-                                notificationService.markRead(UUID.fromString(notificationId), user.id)
-                            } catch (e: IllegalArgumentException) {
-                                logger.debug("Invalid notification UUID: {}", e.message)
-                            }
-                            Response(Status.FOUND).header("location", "/notifications")
-                        }
-                    }
-                },
             "/components/notification-bell" meta
                 {
                     summary = "Notification bell fragment (unread count)"
@@ -84,6 +36,48 @@ class NotificationRoutes(
                     val shellRenderer = request.shellRenderer
                     val fragment = pageFactory.buildNotificationBell(ctx, shellRenderer)
                     Response(Status.OK).header("content-type", "text/html; charset=utf-8").body(renderer(fragment))
+                }
+        )
+
+    val protectedRoutes: List<ContractRoute> =
+        listOf(
+            "/notifications" meta
+                {
+                    summary = "In-app notifications page"
+                } bindContract
+                GET to
+                { request ->
+                    val ctx = request.requestContext
+                    val shellRenderer = request.shellRenderer
+                    renderer.render(pageFactory.buildNotificationsPage(ctx, shellRenderer))
+                },
+            "/notifications/read-all" meta
+                {
+                    summary = "Mark all notifications as read"
+                } bindContract
+                POST to
+                { request ->
+                    val user = request.requestContext.user!!
+                    notificationService.markAllRead(user.id)
+                    Response(Status.FOUND).header("location", "/notifications")
+                },
+            "/notifications" / notificationIdPath / "read" meta
+                {
+                    summary = "Mark a single notification as read"
+                } bindContract
+                POST to
+                { notificationId, _ ->
+                    { request ->
+                        val user = request.requestContext.user!!
+                        try {
+                            notificationService.markRead(UUID.fromString(notificationId), user.id)
+                        } catch (e: IllegalArgumentException) {
+                            logger.debug("Invalid notification UUID: {}", e.message)
+                        }
+                        Response(Status.FOUND).header("location", "/notifications")
+                    }
                 },
         )
+
+    override val routes: List<ContractRoute> = publicRoutes + protectedRoutes
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PasswordRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PasswordRoutes.kt
@@ -1,0 +1,164 @@
+package io.github.rygel.outerstellar.platform.web
+
+import io.github.rygel.outerstellar.platform.infra.render
+import io.github.rygel.outerstellar.platform.model.WeakPasswordException
+import io.github.rygel.outerstellar.platform.security.AccountService
+import io.github.rygel.outerstellar.platform.security.PasswordResetService
+import org.http4k.contract.ContractRoute
+import org.http4k.contract.bindContract
+import org.http4k.contract.div
+import org.http4k.contract.meta
+import org.http4k.core.Method.GET
+import org.http4k.core.Method.POST
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.body.form
+import org.http4k.lens.Path
+import org.http4k.lens.string
+import org.http4k.template.TemplateRenderer
+import org.slf4j.LoggerFactory
+
+class PasswordRoutes(
+    private val pageFactory: WebPageFactory,
+    private val renderer: TemplateRenderer,
+    private val accountService: AccountService,
+    private val passwordResetService: PasswordResetService,
+) : ServerRoutes {
+    private val logger = LoggerFactory.getLogger(PasswordRoutes::class.java)
+    private val tokenPath = Path.string().of("token")
+
+    override val routes: List<ContractRoute> =
+        listOf(
+            "/auth/change-password" meta
+                {
+                    summary = "Change password page"
+                } bindContract
+                GET to
+                { request: org.http4k.core.Request ->
+                    val ctx = request.requestContext
+                    val shellRenderer = request.shellRenderer
+                    if (ctx.user == null) {
+                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
+                    } else {
+                        renderer.render(pageFactory.buildChangePasswordPage(shellRenderer))
+                    }
+                },
+            "/auth/components/change-password" meta
+                {
+                    summary = "Process password change form"
+                } bindContract
+                POST to
+                { request: org.http4k.core.Request ->
+                    val ctx = request.requestContext
+                    val shellRenderer = request.shellRenderer
+                    val user = ctx.user
+                    if (user == null) {
+                        Response(Status.UNAUTHORIZED).body("Not logged in")
+                    } else {
+                        val currentPassword = request.form("currentPassword").orEmpty()
+                        val newPassword = request.form("newPassword").orEmpty()
+                        val confirmPassword = request.form("confirmPassword").orEmpty()
+
+                        if (newPassword != confirmPassword) {
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.password.error.title"),
+                                    message = shellRenderer.i18n.translate("web.password.error.mismatch"),
+                                    toneClass = "bg-error/10 border-error/30 text-error",
+                                )
+                            )
+                        } else {
+                            try {
+                                accountService.changePassword(user.id, currentPassword, newPassword)
+                                renderer.render(
+                                    AuthResultFragment(
+                                        title = shellRenderer.i18n.translate("web.password.success.title"),
+                                        message = shellRenderer.i18n.translate("web.password.success.body"),
+                                        toneClass = "bg-success/10 border-success/30 text-success",
+                                    )
+                                )
+                            } catch (e: WeakPasswordException) {
+                                renderer.render(
+                                    AuthResultFragment(
+                                        title = shellRenderer.i18n.translate("web.password.error.title"),
+                                        message = e.message ?: "Password change failed",
+                                        toneClass = "bg-error/10 border-error/30 text-error",
+                                    )
+                                )
+                            }
+                        }
+                    }
+                },
+            "/auth/reset" / tokenPath meta
+                {
+                    summary = "Password reset page"
+                } bindContract
+                GET to
+                { token ->
+                    { request: org.http4k.core.Request ->
+                        val ctx = request.requestContext
+                        val shellRenderer = request.shellRenderer
+                        renderer.render(pageFactory.buildResetPasswordPage(shellRenderer, token))
+                    }
+                },
+            "/auth/components/reset-confirm" meta
+                {
+                    summary = "Process password reset form"
+                } bindContract
+                POST to
+                { request: org.http4k.core.Request ->
+                    val ctx = request.requestContext
+                    val shellRenderer = request.shellRenderer
+                    val token = request.form("token").orEmpty()
+                    val newPassword = request.form("newPassword").orEmpty()
+                    val confirmPassword = request.form("confirmPassword").orEmpty()
+
+                    if (newPassword != confirmPassword) {
+                        renderer.render(
+                            AuthResultFragment(
+                                title = shellRenderer.i18n.translate("web.reset.error.title"),
+                                message = shellRenderer.i18n.translate("web.reset.error.mismatch"),
+                                toneClass = "bg-error/10 border-error/30 text-error",
+                            )
+                        )
+                    } else {
+                        try {
+                            passwordResetService.resetPassword(token, newPassword)
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.reset.success.title"),
+                                    message = shellRenderer.i18n.translate("web.reset.success.body"),
+                                    toneClass = "bg-success/10 border-success/30 text-success",
+                                )
+                            )
+                        } catch (e: IllegalArgumentException) {
+                            logger.warn("Password reset failed with invalid token: {}", e.message)
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.reset.error.title"),
+                                    message = shellRenderer.i18n.translate("web.reset.error.invalid"),
+                                    toneClass = "bg-error/10 border-error/30 text-error",
+                                )
+                            )
+                        } catch (e: WeakPasswordException) {
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.reset.error.title"),
+                                    message = e.message ?: shellRenderer.i18n.translate("web.reset.error.invalid"),
+                                    toneClass = "bg-error/10 border-error/30 text-error",
+                                )
+                            )
+                        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                            logger.error("Unexpected error during password reset", e)
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.reset.error.title"),
+                                    message = shellRenderer.i18n.translate("web.reset.error.invalid"),
+                                    toneClass = "bg-error/10 border-error/30 text-error",
+                                )
+                            )
+                        }
+                    }
+                },
+        )
+}

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PasswordRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/PasswordRoutes.kt
@@ -10,8 +10,6 @@ import org.http4k.contract.div
 import org.http4k.contract.meta
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
-import org.http4k.core.Response
-import org.http4k.core.Status
 import org.http4k.core.body.form
 import org.http4k.lens.Path
 import org.http4k.lens.string
@@ -27,68 +25,8 @@ class PasswordRoutes(
     private val logger = LoggerFactory.getLogger(PasswordRoutes::class.java)
     private val tokenPath = Path.string().of("token")
 
-    override val routes: List<ContractRoute> =
+    val publicRoutes: List<ContractRoute> =
         listOf(
-            "/auth/change-password" meta
-                {
-                    summary = "Change password page"
-                } bindContract
-                GET to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    } else {
-                        renderer.render(pageFactory.buildChangePasswordPage(shellRenderer))
-                    }
-                },
-            "/auth/components/change-password" meta
-                {
-                    summary = "Process password change form"
-                } bindContract
-                POST to
-                { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
-                    val shellRenderer = request.shellRenderer
-                    val user = ctx.user
-                    if (user == null) {
-                        Response(Status.UNAUTHORIZED).body("Not logged in")
-                    } else {
-                        val currentPassword = request.form("currentPassword").orEmpty()
-                        val newPassword = request.form("newPassword").orEmpty()
-                        val confirmPassword = request.form("confirmPassword").orEmpty()
-
-                        if (newPassword != confirmPassword) {
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.password.error.title"),
-                                    message = shellRenderer.i18n.translate("web.password.error.mismatch"),
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
-                            )
-                        } else {
-                            try {
-                                accountService.changePassword(user.id, currentPassword, newPassword)
-                                renderer.render(
-                                    AuthResultFragment(
-                                        title = shellRenderer.i18n.translate("web.password.success.title"),
-                                        message = shellRenderer.i18n.translate("web.password.success.body"),
-                                        toneClass = "bg-success/10 border-success/30 text-success",
-                                    )
-                                )
-                            } catch (e: WeakPasswordException) {
-                                renderer.render(
-                                    AuthResultFragment(
-                                        title = shellRenderer.i18n.translate("web.password.error.title"),
-                                        message = e.message ?: "Password change failed",
-                                        toneClass = "bg-error/10 border-error/30 text-error",
-                                    )
-                                )
-                            }
-                        }
-                    }
-                },
             "/auth/reset" / tokenPath meta
                 {
                     summary = "Password reset page"
@@ -96,7 +34,6 @@ class PasswordRoutes(
                 GET to
                 { token ->
                     { request: org.http4k.core.Request ->
-                        val ctx = request.requestContext
                         val shellRenderer = request.shellRenderer
                         renderer.render(pageFactory.buildResetPasswordPage(shellRenderer, token))
                     }
@@ -107,7 +44,6 @@ class PasswordRoutes(
                 } bindContract
                 POST to
                 { request: org.http4k.core.Request ->
-                    val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
                     val token = request.form("token").orEmpty()
                     val newPassword = request.form("newPassword").orEmpty()
@@ -161,4 +97,60 @@ class PasswordRoutes(
                     }
                 },
         )
+
+    val protectedRoutes: List<ContractRoute> =
+        listOf(
+            "/auth/change-password" meta
+                {
+                    summary = "Change password page"
+                } bindContract
+                GET to
+                { request: org.http4k.core.Request ->
+                    val shellRenderer = request.shellRenderer
+                    renderer.render(pageFactory.buildChangePasswordPage(shellRenderer))
+                },
+            "/auth/components/change-password" meta
+                {
+                    summary = "Process password change form"
+                } bindContract
+                POST to
+                { request: org.http4k.core.Request ->
+                    val shellRenderer = request.shellRenderer
+                    val user = request.requestContext.user!!
+                    val currentPassword = request.form("currentPassword").orEmpty()
+                    val newPassword = request.form("newPassword").orEmpty()
+                    val confirmPassword = request.form("confirmPassword").orEmpty()
+
+                    if (newPassword != confirmPassword) {
+                        renderer.render(
+                            AuthResultFragment(
+                                title = shellRenderer.i18n.translate("web.password.error.title"),
+                                message = shellRenderer.i18n.translate("web.password.error.mismatch"),
+                                toneClass = "bg-error/10 border-error/30 text-error",
+                            )
+                        )
+                    } else {
+                        try {
+                            accountService.changePassword(user.id, currentPassword, newPassword)
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.password.success.title"),
+                                    message = shellRenderer.i18n.translate("web.password.success.body"),
+                                    toneClass = "bg-success/10 border-success/30 text-success",
+                                )
+                            )
+                        } catch (e: WeakPasswordException) {
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.password.error.title"),
+                                    message = e.message ?: "Password change failed",
+                                    toneClass = "bg-error/10 border-error/30 text-error",
+                                )
+                            )
+                        }
+                    }
+                },
+        )
+
+    override val routes: List<ContractRoute> = publicRoutes + protectedRoutes
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ProfileRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ProfileRoutes.kt
@@ -30,11 +30,7 @@ class ProfileRoutes(
                 { request: org.http4k.core.Request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
-                    } else {
-                        renderer.render(pageFactory.buildProfilePage(ctx, shellRenderer))
-                    }
+                    renderer.render(pageFactory.buildProfilePage(ctx, shellRenderer))
                 },
             "/auth/components/profile-update" meta
                 {
@@ -44,39 +40,35 @@ class ProfileRoutes(
                 { request: org.http4k.core.Request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    val user = ctx.user
-                    if (user == null) {
-                        Response(Status.UNAUTHORIZED).body("Not logged in")
-                    } else {
-                        val newEmail = request.form("email").orEmpty()
-                        val newUsername = request.form("username")?.takeIf { it.isNotBlank() }
-                        val newAvatarUrl = request.form("avatarUrl")
-                        try {
-                            accountService.updateProfile(user.id, newEmail, newUsername, newAvatarUrl)
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.profile.success.title"),
-                                    message = shellRenderer.i18n.translate("web.profile.success.body"),
-                                    toneClass = "bg-success/10 border-success/30 text-success",
-                                )
+                    val user = ctx.user!!
+                    val newEmail = request.form("email").orEmpty()
+                    val newUsername = request.form("username")?.takeIf { it.isNotBlank() }
+                    val newAvatarUrl = request.form("avatarUrl")
+                    try {
+                        accountService.updateProfile(user.id, newEmail, newUsername, newAvatarUrl)
+                        renderer.render(
+                            AuthResultFragment(
+                                title = shellRenderer.i18n.translate("web.profile.success.title"),
+                                message = shellRenderer.i18n.translate("web.profile.success.body"),
+                                toneClass = "bg-success/10 border-success/30 text-success",
                             )
-                        } catch (e: UsernameAlreadyExistsException) {
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.profile.error.title"),
-                                    message = e.message ?: "Update failed",
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
+                        )
+                    } catch (e: UsernameAlreadyExistsException) {
+                        renderer.render(
+                            AuthResultFragment(
+                                title = shellRenderer.i18n.translate("web.profile.error.title"),
+                                message = e.message ?: "Update failed",
+                                toneClass = "bg-error/10 border-error/30 text-error",
                             )
-                        } catch (e: IllegalArgumentException) {
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.profile.error.title"),
-                                    message = e.message ?: "Update failed",
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
+                        )
+                    } catch (e: IllegalArgumentException) {
+                        renderer.render(
+                            AuthResultFragment(
+                                title = shellRenderer.i18n.translate("web.profile.error.title"),
+                                message = e.message ?: "Update failed",
+                                toneClass = "bg-error/10 border-error/30 text-error",
                             )
-                        }
+                        )
                     }
                 },
             "/auth/notification-preferences" meta
@@ -87,21 +79,17 @@ class ProfileRoutes(
                 { request: org.http4k.core.Request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    val user = ctx.user
-                    if (user == null) {
-                        Response(Status.UNAUTHORIZED).body("Not logged in")
-                    } else {
-                        val emailEnabled = request.form("emailNotifications") == "on"
-                        val pushEnabled = request.form("pushNotifications") == "on"
-                        accountService.updateNotificationPreferences(user.id, emailEnabled, pushEnabled)
-                        renderer.render(
-                            AuthResultFragment(
-                                title = shellRenderer.i18n.translate("web.profile.notif.success.title"),
-                                message = shellRenderer.i18n.translate("web.profile.notif.success.body"),
-                                toneClass = "bg-success/10 border-success/30 text-success",
-                            )
+                    val user = ctx.user!!
+                    val emailEnabled = request.form("emailNotifications") == "on"
+                    val pushEnabled = request.form("pushNotifications") == "on"
+                    accountService.updateNotificationPreferences(user.id, emailEnabled, pushEnabled)
+                    renderer.render(
+                        AuthResultFragment(
+                            title = shellRenderer.i18n.translate("web.profile.notif.success.title"),
+                            message = shellRenderer.i18n.translate("web.profile.notif.success.body"),
+                            toneClass = "bg-success/10 border-success/30 text-success",
                         )
-                    }
+                    )
                 },
             "/auth/account/delete" meta
                 {
@@ -111,28 +99,24 @@ class ProfileRoutes(
                 { request: org.http4k.core.Request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    val user = ctx.user
-                    if (user == null) {
-                        Response(Status.UNAUTHORIZED).body("Not logged in")
-                    } else {
-                        try {
-                            val currentPassword = request.form("currentPassword").orEmpty()
-                            if (currentPassword.isBlank()) {
-                                return@to Response(Status.BAD_REQUEST).body("Current password is required")
-                            }
-                            accountService.deleteAccount(user.id, currentPassword)
-                            Response(Status.FOUND)
-                                .header("location", shellRenderer.url("/auth?deleted=true"))
-                                .header("Set-Cookie", SessionCookie.clear(sessionCookieSecure))
-                        } catch (e: InsufficientPermissionException) {
-                            renderer.render(
-                                AuthResultFragment(
-                                    title = shellRenderer.i18n.translate("web.profile.delete.error.title"),
-                                    message = e.message ?: "Cannot delete account",
-                                    toneClass = "bg-error/10 border-error/30 text-error",
-                                )
-                            )
+                    val user = ctx.user!!
+                    try {
+                        val currentPassword = request.form("currentPassword").orEmpty()
+                        if (currentPassword.isBlank()) {
+                            return@to Response(Status.BAD_REQUEST).body("Current password is required")
                         }
+                        accountService.deleteAccount(user.id, currentPassword)
+                        Response(Status.FOUND)
+                            .header("location", shellRenderer.url("/auth?deleted=true"))
+                            .header("Set-Cookie", SessionCookie.clear(sessionCookieSecure))
+                    } catch (e: InsufficientPermissionException) {
+                        renderer.render(
+                            AuthResultFragment(
+                                title = shellRenderer.i18n.translate("web.profile.delete.error.title"),
+                                message = e.message ?: "Cannot delete account",
+                                toneClass = "bg-error/10 border-error/30 text-error",
+                            )
+                        )
                     }
                 },
         )

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ProfileRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ProfileRoutes.kt
@@ -1,0 +1,139 @@
+package io.github.rygel.outerstellar.platform.web
+
+import io.github.rygel.outerstellar.platform.infra.render
+import io.github.rygel.outerstellar.platform.model.InsufficientPermissionException
+import io.github.rygel.outerstellar.platform.model.UsernameAlreadyExistsException
+import io.github.rygel.outerstellar.platform.security.AccountService
+import org.http4k.contract.ContractRoute
+import org.http4k.contract.bindContract
+import org.http4k.contract.meta
+import org.http4k.core.Method.GET
+import org.http4k.core.Method.POST
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.body.form
+import org.http4k.template.TemplateRenderer
+
+class ProfileRoutes(
+    private val pageFactory: WebPageFactory,
+    private val renderer: TemplateRenderer,
+    private val accountService: AccountService,
+    private val sessionCookieSecure: Boolean,
+) : ServerRoutes {
+    override val routes: List<ContractRoute> =
+        listOf(
+            "/auth/profile" meta
+                {
+                    summary = "User profile page"
+                } bindContract
+                GET to
+                { request: org.http4k.core.Request ->
+                    val ctx = request.requestContext
+                    val shellRenderer = request.shellRenderer
+                    if (ctx.user == null) {
+                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
+                    } else {
+                        renderer.render(pageFactory.buildProfilePage(ctx, shellRenderer))
+                    }
+                },
+            "/auth/components/profile-update" meta
+                {
+                    summary = "Process profile update form"
+                } bindContract
+                POST to
+                { request: org.http4k.core.Request ->
+                    val ctx = request.requestContext
+                    val shellRenderer = request.shellRenderer
+                    val user = ctx.user
+                    if (user == null) {
+                        Response(Status.UNAUTHORIZED).body("Not logged in")
+                    } else {
+                        val newEmail = request.form("email").orEmpty()
+                        val newUsername = request.form("username")?.takeIf { it.isNotBlank() }
+                        val newAvatarUrl = request.form("avatarUrl")
+                        try {
+                            accountService.updateProfile(user.id, newEmail, newUsername, newAvatarUrl)
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.profile.success.title"),
+                                    message = shellRenderer.i18n.translate("web.profile.success.body"),
+                                    toneClass = "bg-success/10 border-success/30 text-success",
+                                )
+                            )
+                        } catch (e: UsernameAlreadyExistsException) {
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.profile.error.title"),
+                                    message = e.message ?: "Update failed",
+                                    toneClass = "bg-error/10 border-error/30 text-error",
+                                )
+                            )
+                        } catch (e: IllegalArgumentException) {
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.profile.error.title"),
+                                    message = e.message ?: "Update failed",
+                                    toneClass = "bg-error/10 border-error/30 text-error",
+                                )
+                            )
+                        }
+                    }
+                },
+            "/auth/notification-preferences" meta
+                {
+                    summary = "Update notification preferences"
+                } bindContract
+                POST to
+                { request: org.http4k.core.Request ->
+                    val ctx = request.requestContext
+                    val shellRenderer = request.shellRenderer
+                    val user = ctx.user
+                    if (user == null) {
+                        Response(Status.UNAUTHORIZED).body("Not logged in")
+                    } else {
+                        val emailEnabled = request.form("emailNotifications") == "on"
+                        val pushEnabled = request.form("pushNotifications") == "on"
+                        accountService.updateNotificationPreferences(user.id, emailEnabled, pushEnabled)
+                        renderer.render(
+                            AuthResultFragment(
+                                title = shellRenderer.i18n.translate("web.profile.notif.success.title"),
+                                message = shellRenderer.i18n.translate("web.profile.notif.success.body"),
+                                toneClass = "bg-success/10 border-success/30 text-success",
+                            )
+                        )
+                    }
+                },
+            "/auth/account/delete" meta
+                {
+                    summary = "Delete own account"
+                } bindContract
+                POST to
+                { request: org.http4k.core.Request ->
+                    val ctx = request.requestContext
+                    val shellRenderer = request.shellRenderer
+                    val user = ctx.user
+                    if (user == null) {
+                        Response(Status.UNAUTHORIZED).body("Not logged in")
+                    } else {
+                        try {
+                            val currentPassword = request.form("currentPassword").orEmpty()
+                            if (currentPassword.isBlank()) {
+                                return@to Response(Status.BAD_REQUEST).body("Current password is required")
+                            }
+                            accountService.deleteAccount(user.id, currentPassword)
+                            Response(Status.FOUND)
+                                .header("location", shellRenderer.url("/auth?deleted=true"))
+                                .header("Set-Cookie", SessionCookie.clear(sessionCookieSecure))
+                        } catch (e: InsufficientPermissionException) {
+                            renderer.render(
+                                AuthResultFragment(
+                                    title = shellRenderer.i18n.translate("web.profile.delete.error.title"),
+                                    message = e.message ?: "Cannot delete account",
+                                    toneClass = "bg-error/10 border-error/30 text-error",
+                                )
+                            )
+                        }
+                    }
+                },
+        )
+}

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/SettingsRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/SettingsRoutes.kt
@@ -5,8 +5,6 @@ import org.http4k.contract.ContractRoute
 import org.http4k.contract.bindContract
 import org.http4k.contract.meta
 import org.http4k.core.Method.GET
-import org.http4k.core.Response
-import org.http4k.core.Status
 import org.http4k.template.TemplateRenderer
 
 class SettingsRoutes(private val pageFactory: WebPageFactory, private val renderer: TemplateRenderer) : ServerRoutes {
@@ -21,16 +19,12 @@ class SettingsRoutes(private val pageFactory: WebPageFactory, private val render
                 { request ->
                     val ctx = request.requestContext
                     val shellRenderer = request.shellRenderer
-                    if (ctx.user == null) {
-                        Response(Status.FOUND).header("location", shellRenderer.url("/auth"))
+                    val tab = request.query("tab") ?: "profile"
+                    val isHtmx = request.header("HX-Request") == "true"
+                    if (isHtmx) {
+                        renderer.render(pageFactory.buildSettingsFragment(ctx, shellRenderer, tab))
                     } else {
-                        val tab = request.query("tab") ?: "profile"
-                        val isHtmx = request.header("HX-Request") == "true"
-                        if (isHtmx) {
-                            renderer.render(pageFactory.buildSettingsFragment(ctx, shellRenderer, tab))
-                        } else {
-                            renderer.render(pageFactory.buildSettingsPage(shellRenderer, tab))
-                        }
+                        renderer.render(pageFactory.buildSettingsPage(shellRenderer, tab))
                     }
                 }
         )

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/PlatformAppTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/PlatformAppTest.kt
@@ -1,6 +1,9 @@
 package io.github.rygel.outerstellar.platform
 
 import com.natpryce.hamkrest.assertion.assertThat
+import io.github.rygel.outerstellar.platform.di.CoreComponents
+import io.github.rygel.outerstellar.platform.di.PersistenceComponents
+import io.github.rygel.outerstellar.platform.di.WebComponents
 import io.github.rygel.outerstellar.platform.infra.createRenderer
 import io.github.rygel.outerstellar.platform.persistence.MessageRepository
 import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
@@ -10,8 +13,11 @@ import io.github.rygel.outerstellar.platform.security.ApiKeyService
 import io.github.rygel.outerstellar.platform.security.AuthService
 import io.github.rygel.outerstellar.platform.security.OAuthService
 import io.github.rygel.outerstellar.platform.security.PasswordResetService
+import io.github.rygel.outerstellar.platform.security.SecurityComponents
 import io.github.rygel.outerstellar.platform.security.SessionService
+import io.github.rygel.outerstellar.platform.security.TOTPService
 import io.github.rygel.outerstellar.platform.security.UserAdminService
+import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.web.StubMessageCache
 import io.github.rygel.outerstellar.platform.web.WebPageFactory
@@ -44,27 +50,82 @@ class PlatformAppTest {
         val userAdminService = mockk<UserAdminService>(relaxed = true)
         val sessionService = mockk<SessionService>(relaxed = true)
         every { userRepository.countAll() } returns 0L
-        val contactService =
-            io.mockk.mockk<io.github.rygel.outerstellar.platform.service.ContactService>(relaxed = true)
+        val contactService = mockk<ContactService>(relaxed = true)
 
-        val polyHandler =
-            app(
-                messageService,
-                contactService,
-                outbox,
-                cache,
-                createRenderer(),
-                pageFactory,
-                config,
-                apiKeyService,
-                passwordResetService,
-                oauthService,
-                authService,
-                accountService,
-                userAdminService,
-                sessionService,
-                userRepository,
+        val persistence =
+            PersistenceComponents(
+                dataSource = mockk(relaxed = true),
+                jdbi = mockk(relaxed = true),
+                messageRepository = repository,
+                contactRepository = mockk(relaxed = true),
+                userRepository = userRepository,
+                outboxRepository = outbox,
+                transactionManager = mockk(relaxed = true),
+                auditRepository = mockk(relaxed = true),
+                passwordResetRepository = mockk(relaxed = true),
+                apiKeyRepository = mockk(relaxed = true),
+                oAuthRepository = mockk(relaxed = true),
+                deviceTokenRepository = mockk(relaxed = true),
+                sessionRepository = mockk(relaxed = true),
+                voteRepository = mockk(relaxed = true),
+                pollRepository = mockk(relaxed = true),
+                notificationRepository = mockk(relaxed = true),
             )
+
+        val security =
+            SecurityComponents(
+                jwtService = mockk(relaxed = true),
+                asyncActivityUpdater = mockk(relaxed = true),
+                authService = authService,
+                accountService = accountService,
+                apiKeyService = apiKeyService,
+                passwordResetService = passwordResetService,
+                oauthService = oauthService,
+                authRealms = emptyList(),
+                totpService = TOTPService(),
+                sessionService = sessionService,
+                userAdminService = userAdminService,
+            )
+
+        val core =
+            CoreComponents(
+                messageService = messageService,
+                contactService = contactService,
+                outboxProcessor = mockk(relaxed = true),
+                eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
+                emailService = io.github.rygel.outerstellar.platform.service.ConsoleEmailService(),
+                pushNotificationService = io.github.rygel.outerstellar.platform.service.ConsolePushNotificationService,
+            )
+
+        val notificationService =
+            mockk<io.github.rygel.outerstellar.platform.service.NotificationService>(relaxed = true)
+        val voteRepository = mockk<io.github.rygel.outerstellar.platform.persistence.VoteRepository>(relaxed = true)
+        val pollRepository = mockk<io.github.rygel.outerstellar.platform.persistence.PollRepository>(relaxed = true)
+
+        val web =
+            WebComponents(
+                templateRenderer = createRenderer(),
+                pageFactory = pageFactory,
+                messageCache = cache,
+                analyticsService = io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService(),
+                emailService = io.github.rygel.outerstellar.platform.service.NoOpEmailService(),
+                i18nService = io.github.rygel.outerstellar.i18n.I18nService.create("messages"),
+                syncWebSocket = io.github.rygel.outerstellar.platform.web.SyncWebSocket(sessionService),
+                eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
+                voteService = io.github.rygel.outerstellar.platform.service.VoteService(voteRepository, repository),
+                pollService = io.github.rygel.outerstellar.platform.service.PollService(pollRepository),
+                notificationService = notificationService,
+                adminPageFactory =
+                    io.github.rygel.outerstellar.platform.web.AdminPageFactory(
+                        apiKeyService,
+                        notificationService,
+                        userAdminService,
+                    ),
+                adminStatsService = io.github.rygel.outerstellar.platform.security.AdminStatsService(userRepository),
+                pluginMigrationSource = object : PluginMigrationSource {},
+            )
+
+        val polyHandler = app(config = config, persistence = persistence, security = security, core = core, web = web)
         val handler = polyHandler.http
         assertNotNull(handler)
 

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/PlatformAppTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/PlatformAppTest.kt
@@ -6,19 +6,12 @@ import io.github.rygel.outerstellar.platform.di.PersistenceComponents
 import io.github.rygel.outerstellar.platform.di.WebComponents
 import io.github.rygel.outerstellar.platform.infra.createRenderer
 import io.github.rygel.outerstellar.platform.persistence.MessageRepository
-import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
-import io.github.rygel.outerstellar.platform.security.AccountService
 import io.github.rygel.outerstellar.platform.security.ApiKeyService
-import io.github.rygel.outerstellar.platform.security.AuthService
-import io.github.rygel.outerstellar.platform.security.OAuthService
-import io.github.rygel.outerstellar.platform.security.PasswordResetService
 import io.github.rygel.outerstellar.platform.security.SecurityComponents
 import io.github.rygel.outerstellar.platform.security.SessionService
 import io.github.rygel.outerstellar.platform.security.TOTPService
 import io.github.rygel.outerstellar.platform.security.UserAdminService
-import io.github.rygel.outerstellar.platform.service.ContactService
-import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.web.StubMessageCache
 import io.github.rygel.outerstellar.platform.web.WebPageFactory
 import io.github.rygel.outerstellar.platform.web.bodyContains
@@ -34,103 +27,104 @@ import org.http4k.hamkrest.hasStatus
 class PlatformAppTest {
     @Test
     fun `can start the app and get home page`() {
-        val messageService = mockk<MessageService>(relaxed = true)
         val repository = mockk<MessageRepository>(relaxed = true)
-        val outbox = mockk<OutboxRepository>(relaxed = true)
-        val cache = StubMessageCache()
-        val pageFactory = WebPageFactory(repository, messageService, null, null)
+        val userRepository = mockk<UserRepository>(relaxed = true)
+        every { userRepository.countAll() } returns 0L
         val config = AppConfig(port = 8080, jdbcUrl = "jdbc:postgresql://localhost/test", devDashboardEnabled = true)
 
-        val apiKeyService = mockk<ApiKeyService>(relaxed = true)
-        val passwordResetService = mockk<PasswordResetService>(relaxed = true)
-        val oauthService = mockk<OAuthService>(relaxed = true)
-        val authService = mockk<AuthService>(relaxed = true)
-        val accountService = mockk<AccountService>(relaxed = true)
-        val userRepository = mockk<UserRepository>(relaxed = true)
-        val userAdminService = mockk<UserAdminService>(relaxed = true)
-        val sessionService = mockk<SessionService>(relaxed = true)
-        every { userRepository.countAll() } returns 0L
-        val contactService = mockk<ContactService>(relaxed = true)
+        val persistence = buildMockPersistence(repository, userRepository)
+        val security = buildMockSecurity()
+        val core = buildMockCore()
+        val web = buildMockWeb(repository, security.apiKeyService, security.sessionService, security.userAdminService)
 
-        val persistence =
-            PersistenceComponents(
-                dataSource = mockk(relaxed = true),
-                jdbi = mockk(relaxed = true),
-                messageRepository = repository,
-                contactRepository = mockk(relaxed = true),
-                userRepository = userRepository,
-                outboxRepository = outbox,
-                transactionManager = mockk(relaxed = true),
-                auditRepository = mockk(relaxed = true),
-                passwordResetRepository = mockk(relaxed = true),
-                apiKeyRepository = mockk(relaxed = true),
-                oAuthRepository = mockk(relaxed = true),
-                deviceTokenRepository = mockk(relaxed = true),
-                sessionRepository = mockk(relaxed = true),
-                voteRepository = mockk(relaxed = true),
-                pollRepository = mockk(relaxed = true),
-                notificationRepository = mockk(relaxed = true),
-            )
-
-        val security =
-            SecurityComponents(
-                jwtService = mockk(relaxed = true),
-                asyncActivityUpdater = mockk(relaxed = true),
-                authService = authService,
-                accountService = accountService,
-                apiKeyService = apiKeyService,
-                passwordResetService = passwordResetService,
-                oauthService = oauthService,
-                authRealms = emptyList(),
-                totpService = TOTPService(),
-                sessionService = sessionService,
-                userAdminService = userAdminService,
-            )
-
-        val core =
-            CoreComponents(
-                messageService = messageService,
-                contactService = contactService,
-                outboxProcessor = mockk(relaxed = true),
-                eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
-                emailService = io.github.rygel.outerstellar.platform.service.ConsoleEmailService(),
-                pushNotificationService = io.github.rygel.outerstellar.platform.service.ConsolePushNotificationService,
-            )
-
-        val notificationService =
-            mockk<io.github.rygel.outerstellar.platform.service.NotificationService>(relaxed = true)
-        val voteRepository = mockk<io.github.rygel.outerstellar.platform.persistence.VoteRepository>(relaxed = true)
-        val pollRepository = mockk<io.github.rygel.outerstellar.platform.persistence.PollRepository>(relaxed = true)
-
-        val web =
-            WebComponents(
-                templateRenderer = createRenderer(),
-                pageFactory = pageFactory,
-                messageCache = cache,
-                analyticsService = io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService(),
-                emailService = io.github.rygel.outerstellar.platform.service.NoOpEmailService(),
-                i18nService = io.github.rygel.outerstellar.i18n.I18nService.create("messages"),
-                syncWebSocket = io.github.rygel.outerstellar.platform.web.SyncWebSocket(sessionService),
-                eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
-                voteService = io.github.rygel.outerstellar.platform.service.VoteService(voteRepository, repository),
-                pollService = io.github.rygel.outerstellar.platform.service.PollService(pollRepository),
-                notificationService = notificationService,
-                adminPageFactory =
-                    io.github.rygel.outerstellar.platform.web.AdminPageFactory(
-                        apiKeyService,
-                        notificationService,
-                        userAdminService,
-                    ),
-                adminStatsService = io.github.rygel.outerstellar.platform.security.AdminStatsService(userRepository),
-                pluginMigrationSource = object : PluginMigrationSource {},
-            )
-
-        val polyHandler = app(config = config, persistence = persistence, security = security, core = core, web = web)
-        val handler = polyHandler.http
+        val handler = app(config = config, persistence = persistence, security = security, core = core, web = web).http
         assertNotNull(handler)
 
         val healthResponse = handler(Request(Method.GET, "/health"))
         assertThat(healthResponse, hasStatus(Status.OK))
         assertThat(healthResponse, bodyContains("UP"))
+    }
+
+    @Suppress("LongParameterList")
+    private fun buildMockPersistence(
+        repository: MessageRepository,
+        userRepository: UserRepository,
+    ): PersistenceComponents =
+        PersistenceComponents(
+            dataSource = mockk(relaxed = true),
+            jdbi = mockk(relaxed = true),
+            messageRepository = repository,
+            contactRepository = mockk(relaxed = true),
+            userRepository = userRepository,
+            outboxRepository = mockk(relaxed = true),
+            transactionManager = mockk(relaxed = true),
+            auditRepository = mockk(relaxed = true),
+            passwordResetRepository = mockk(relaxed = true),
+            apiKeyRepository = mockk(relaxed = true),
+            oAuthRepository = mockk(relaxed = true),
+            deviceTokenRepository = mockk(relaxed = true),
+            sessionRepository = mockk(relaxed = true),
+            voteRepository = mockk(relaxed = true),
+            pollRepository = mockk(relaxed = true),
+            notificationRepository = mockk(relaxed = true),
+        )
+
+    private fun buildMockSecurity(): SecurityComponents =
+        SecurityComponents(
+            jwtService = mockk(relaxed = true),
+            asyncActivityUpdater = mockk(relaxed = true),
+            authService = mockk(relaxed = true),
+            accountService = mockk(relaxed = true),
+            apiKeyService = mockk(relaxed = true),
+            passwordResetService = mockk(relaxed = true),
+            oauthService = mockk(relaxed = true),
+            authRealms = emptyList(),
+            totpService = TOTPService(),
+            sessionService = mockk(relaxed = true),
+            userAdminService = mockk(relaxed = true),
+        )
+
+    private fun buildMockCore(): CoreComponents =
+        CoreComponents(
+            messageService = mockk(relaxed = true),
+            contactService = mockk(relaxed = true),
+            outboxProcessor = mockk(relaxed = true),
+            eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
+            emailService = io.github.rygel.outerstellar.platform.service.ConsoleEmailService(),
+            pushNotificationService = io.github.rygel.outerstellar.platform.service.ConsolePushNotificationService,
+        )
+
+    @Suppress("LongParameterList")
+    private fun buildMockWeb(
+        repository: MessageRepository,
+        apiKeyService: ApiKeyService,
+        sessionService: SessionService,
+        userAdminService: UserAdminService,
+    ): WebComponents {
+        val notificationService =
+            mockk<io.github.rygel.outerstellar.platform.service.NotificationService>(relaxed = true)
+        val voteRepo = mockk<io.github.rygel.outerstellar.platform.persistence.VoteRepository>(relaxed = true)
+        val pollRepo = mockk<io.github.rygel.outerstellar.platform.persistence.PollRepository>(relaxed = true)
+        return WebComponents(
+            templateRenderer = createRenderer(),
+            pageFactory = WebPageFactory(repository, mockk(relaxed = true), null, null),
+            messageCache = StubMessageCache(),
+            analyticsService = io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService(),
+            emailService = io.github.rygel.outerstellar.platform.service.NoOpEmailService(),
+            i18nService = io.github.rygel.outerstellar.i18n.I18nService.create("messages"),
+            syncWebSocket = io.github.rygel.outerstellar.platform.web.SyncWebSocket(sessionService),
+            eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
+            voteService = io.github.rygel.outerstellar.platform.service.VoteService(voteRepo, repository),
+            pollService = io.github.rygel.outerstellar.platform.service.PollService(pollRepo),
+            notificationService = notificationService,
+            adminPageFactory =
+                io.github.rygel.outerstellar.platform.web.AdminPageFactory(
+                    apiKeyService,
+                    notificationService,
+                    userAdminService,
+                ),
+            adminStatsService = io.github.rygel.outerstellar.platform.security.AdminStatsService(mockk(relaxed = true)),
+            pluginMigrationSource = object : PluginMigrationSource {},
+        )
     }
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/PlaywrightE2ETest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/PlaywrightE2ETest.kt
@@ -113,29 +113,7 @@ class PlaywrightE2ETest {
         contactRepo.seedContacts()
 
         val polyHandler: PolyHandler =
-            app(
-                messageService = core.messageService,
-                contactService = core.contactService,
-                outboxRepository = persistence.outboxRepository,
-                cache = web.messageCache,
-                jteRenderer = web.templateRenderer,
-                pageFactory = web.pageFactory,
-                config = testConfig,
-                apiKeyService = security.apiKeyService,
-                passwordResetService = security.passwordResetService,
-                oauthService = security.oauthService,
-                authService = security.authService,
-                accountService = security.accountService,
-                userAdminService = security.userAdminService,
-                sessionService = security.sessionService,
-                userRepository = persistence.userRepository,
-                analytics = web.analyticsService,
-                notificationService = web.notificationService,
-                jwtService = security.jwtService,
-                syncWebSocket = web.syncWebSocket,
-                voteService = web.voteService,
-                pollService = web.pollService,
-            )
+            app(config = testConfig, persistence = persistence, security = security, core = core, web = web)
         server = polyHandler.asServer(Netty(0)).start()
 
         browserContext = browser.newContext()

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/ResponsiveLayoutE2ETest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/ResponsiveLayoutE2ETest.kt
@@ -117,29 +117,7 @@ class ResponsiveLayoutE2ETest {
         persistence.contactRepository.seedContacts()
 
         val polyHandler: PolyHandler =
-            app(
-                messageService = core.messageService,
-                contactService = core.contactService,
-                outboxRepository = persistence.outboxRepository,
-                cache = web.messageCache,
-                jteRenderer = web.templateRenderer,
-                pageFactory = web.pageFactory,
-                config = testConfig,
-                apiKeyService = security.apiKeyService,
-                passwordResetService = security.passwordResetService,
-                oauthService = security.oauthService,
-                authService = security.authService,
-                accountService = security.accountService,
-                userAdminService = security.userAdminService,
-                sessionService = security.sessionService,
-                userRepository = persistence.userRepository,
-                analytics = web.analyticsService,
-                notificationService = web.notificationService,
-                jwtService = security.jwtService,
-                syncWebSocket = web.syncWebSocket,
-                voteService = web.voteService,
-                pollService = web.pollService,
-            )
+            app(config = testConfig, persistence = persistence, security = security, core = core, web = web)
         server = polyHandler.asServer(Netty(0)).start()
         baseUrl = "http://localhost:${server.port()}"
     }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthHtmlFlowIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthHtmlFlowIntegrationTest.kt
@@ -312,7 +312,7 @@ class AuthHtmlFlowIntegrationTest : WebTest() {
     }
 
     @Test
-    fun `POST auth-components-change-password without session returns 401`() {
+    fun `POST auth-components-change-password without session redirects to auth`() {
         val response =
             app(
                 Request(POST, "/auth/components/change-password")
@@ -326,6 +326,7 @@ class AuthHtmlFlowIntegrationTest : WebTest() {
                     )
             )
 
-        assertThat(response, hasStatus(Status.UNAUTHORIZED))
+        assertThat(response, hasStatus(Status.FOUND))
+        assertTrue(response.header("location").orEmpty().contains("/auth"))
     }
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthProfileApiKeysIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthProfileApiKeysIntegrationTest.kt
@@ -83,14 +83,15 @@ class AuthProfileApiKeysIntegrationTest : WebTest() {
     }
 
     @Test
-    fun `POST profile-update without session returns 401`() {
+    fun `POST profile-update without session redirects to auth`() {
         val response =
             app(
                 Request(POST, "/auth/components/profile-update")
                     .header("content-type", "application/x-www-form-urlencoded")
                     .body(formBody("email" to "noauth@test.com"))
             )
-        assertThat(response, hasStatus(Status.UNAUTHORIZED))
+        assertThat(response, hasStatus(Status.FOUND))
+        assertTrue(response.header("location").orEmpty().contains("/auth"))
     }
 
     @Test
@@ -168,14 +169,15 @@ class AuthProfileApiKeysIntegrationTest : WebTest() {
     }
 
     @Test
-    fun `POST notification-preferences without session returns 401`() {
+    fun `POST notification-preferences without session redirects to auth`() {
         val response =
             app(
                 Request(POST, "/auth/notification-preferences")
                     .header("content-type", "application/x-www-form-urlencoded")
                     .body(formBody("emailNotifications" to "on"))
             )
-        assertThat(response, hasStatus(Status.UNAUTHORIZED))
+        assertThat(response, hasStatus(Status.FOUND))
+        assertTrue(response.header("location").orEmpty().contains("/auth"))
     }
 
     // ---- Delete account ----
@@ -195,14 +197,15 @@ class AuthProfileApiKeysIntegrationTest : WebTest() {
     }
 
     @Test
-    fun `POST account-delete without session returns 401`() {
+    fun `POST account-delete without session redirects to auth`() {
         val response =
             app(
                 Request(POST, "/auth/account/delete")
                     .header("content-type", "application/x-www-form-urlencoded")
                     .body(formBody("currentPassword" to "correct-password"))
             )
-        assertThat(response, hasStatus(Status.UNAUTHORIZED))
+        assertThat(response, hasStatus(Status.FOUND))
+        assertTrue(response.header("location").orEmpty().contains("/auth"))
     }
 
     @Test

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ChangePasswordWebIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ChangePasswordWebIntegrationTest.kt
@@ -99,14 +99,15 @@ class ChangePasswordWebIntegrationTest : WebTest() {
     }
 
     @Test
-    fun `POST change-password without session returns 401`() {
+    fun `POST change-password without session redirects to auth`() {
         val response =
             app(
                 Request(POST, "/auth/components/change-password")
                     .header("content-type", "application/x-www-form-urlencoded")
                     .body("currentPassword=old&newPassword=new&confirmPassword=new")
             )
-        assertThat(response, hasStatus(Status.UNAUTHORIZED))
+        assertThat(response, hasStatus(Status.FOUND))
+        assertTrue(response.header("location").orEmpty().contains("/auth"))
     }
 
     @Test

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/WebTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/WebTest.kt
@@ -21,6 +21,8 @@ import io.github.rygel.outerstellar.platform.persistence.JdbiSessionRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiUserRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiVoteRepository
 import io.github.rygel.outerstellar.platform.persistence.MessageCache
+import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
+import io.github.rygel.outerstellar.platform.persistence.TransactionManager
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import io.github.rygel.outerstellar.platform.security.AccountService
 import io.github.rygel.outerstellar.platform.security.ApiKeyService
@@ -140,6 +142,9 @@ abstract class WebTest {
         val resolvedContactService =
             overrides.contactService
                 ?: ContactService(contactRepository, transactionManager = txManager, auditRepository = auditRepository)
+        val resolvedPollService = overrides.pollService ?: pollService
+        val notificationService = overrides.notificationService ?: NotificationService(notificationRepository)
+
         val pageFactory =
             WebPageFactory(
                 messageRepository,
@@ -148,91 +153,13 @@ abstract class WebTest {
                 apiKeyService,
                 appleOAuthEnabled = true,
             )
-
         val authService = AuthService(userRepository, encoder, auditRepository)
         val accountService = AccountService(userRepository, encoder, sessionRepository, auditRepository)
-        val resolvedPollService = overrides.pollService ?: pollService
 
-        val persistence =
-            PersistenceComponents(
-                dataSource = testDb.dataSource,
-                jdbi = testJdbi,
-                messageRepository = messageRepository,
-                contactRepository = contactRepository,
-                userRepository = resolvedUserRepo,
-                outboxRepository = outbox,
-                transactionManager = txManager,
-                auditRepository = auditRepository,
-                passwordResetRepository = passwordResetRepository,
-                apiKeyRepository = apiKeyRepository,
-                oAuthRepository = oauthRepository,
-                deviceTokenRepository =
-                    overrides.deviceTokenRepository
-                        ?: io.github.rygel.outerstellar.platform.persistence.JdbiDeviceTokenRepository(testJdbi),
-                sessionRepository = sessionRepository,
-                voteRepository = voteRepository,
-                pollRepository = pollRepository,
-                notificationRepository = notificationRepository,
-            )
-
-        val security =
-            SecurityComponents(
-                jwtService =
-                    io.github.rygel.outerstellar.platform.security.JwtService(
-                        io.github.rygel.outerstellar.platform.JwtConfig()
-                    ),
-                asyncActivityUpdater =
-                    io.github.rygel.outerstellar.platform.security.AsyncActivityUpdater(resolvedUserRepo),
-                authService = authService,
-                accountService = accountService,
-                apiKeyService = apiKeyService,
-                passwordResetService = passwordResetService,
-                oauthService = oauthService,
-                authRealms = emptyList(),
-                totpService = TOTPService(),
-                sessionService = sessionSvc,
-                userAdminService = userAdminService,
-            )
-
-        val core =
-            CoreComponents(
-                messageService = messageService,
-                contactService = resolvedContactService,
-                outboxProcessor =
-                    io.github.rygel.outerstellar.platform.service.OutboxProcessor(
-                        outboxRepository = outbox,
-                        transactionManager = txManager,
-                    ),
-                eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
-                emailService = io.github.rygel.outerstellar.platform.service.ConsoleEmailService(),
-                pushNotificationService = io.github.rygel.outerstellar.platform.service.ConsolePushNotificationService,
-            )
-
-        val notificationService = overrides.notificationService ?: NotificationService(notificationRepository)
-        val voteService = VoteService(voteRepository, messageRepository)
-
-        val web =
-            WebComponents(
-                templateRenderer = renderer,
-                pageFactory = pageFactory,
-                messageCache = resolvedMessageCache,
-                analyticsService = io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService(),
-                emailService = io.github.rygel.outerstellar.platform.service.NoOpEmailService(),
-                i18nService = io.github.rygel.outerstellar.i18n.I18nService.create("messages"),
-                syncWebSocket = SyncWebSocket(sessionSvc),
-                eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
-                voteService = voteService,
-                pollService = resolvedPollService,
-                notificationService = notificationService,
-                adminPageFactory =
-                    io.github.rygel.outerstellar.platform.web.AdminPageFactory(
-                        apiKeyService,
-                        notificationService,
-                        userAdminService,
-                    ),
-                adminStatsService = io.github.rygel.outerstellar.platform.security.AdminStatsService(resolvedUserRepo),
-                pluginMigrationSource = object : io.github.rygel.outerstellar.platform.PluginMigrationSource {},
-            )
+        val persistence = buildPersistence(resolvedUserRepo, outbox, txManager, overrides)
+        val security = buildSecurity(resolvedUserRepo, authService, accountService)
+        val core = buildCore(messageService, resolvedContactService, outbox, txManager)
+        val web = buildWeb(pageFactory, resolvedMessageCache, resolvedPollService, notificationService)
 
         return app(
                 config = config,
@@ -244,6 +171,103 @@ abstract class WebTest {
             )
             .http!!
     }
+
+    private fun buildPersistence(
+        resolvedUserRepo: UserRepository,
+        outbox: OutboxRepository,
+        txManager: TransactionManager,
+        overrides: TestOverrides,
+    ): PersistenceComponents =
+        PersistenceComponents(
+            dataSource = testDb.dataSource,
+            jdbi = testJdbi,
+            messageRepository = messageRepository,
+            contactRepository = contactRepository,
+            userRepository = resolvedUserRepo,
+            outboxRepository = outbox,
+            transactionManager = txManager,
+            auditRepository = auditRepository,
+            passwordResetRepository = passwordResetRepository,
+            apiKeyRepository = apiKeyRepository,
+            oAuthRepository = oauthRepository,
+            deviceTokenRepository =
+                overrides.deviceTokenRepository
+                    ?: io.github.rygel.outerstellar.platform.persistence.JdbiDeviceTokenRepository(testJdbi),
+            sessionRepository = sessionRepository,
+            voteRepository = voteRepository,
+            pollRepository = pollRepository,
+            notificationRepository = notificationRepository,
+        )
+
+    private fun buildSecurity(
+        resolvedUserRepo: UserRepository,
+        authService: AuthService,
+        accountService: AccountService,
+    ): SecurityComponents =
+        SecurityComponents(
+            jwtService =
+                io.github.rygel.outerstellar.platform.security.JwtService(
+                    io.github.rygel.outerstellar.platform.JwtConfig()
+                ),
+            asyncActivityUpdater =
+                io.github.rygel.outerstellar.platform.security.AsyncActivityUpdater(resolvedUserRepo),
+            authService = authService,
+            accountService = accountService,
+            apiKeyService = apiKeyService,
+            passwordResetService = passwordResetService,
+            oauthService = oauthService,
+            authRealms = emptyList(),
+            totpService = TOTPService(),
+            sessionService = sessionSvc,
+            userAdminService = userAdminService,
+        )
+
+    private fun buildCore(
+        messageService: MessageService,
+        resolvedContactService: io.github.rygel.outerstellar.platform.service.ContactService,
+        outbox: OutboxRepository,
+        txManager: TransactionManager,
+    ): CoreComponents =
+        CoreComponents(
+            messageService = messageService,
+            contactService = resolvedContactService,
+            outboxProcessor =
+                io.github.rygel.outerstellar.platform.service.OutboxProcessor(
+                    outboxRepository = outbox,
+                    transactionManager = txManager,
+                ),
+            eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
+            emailService = io.github.rygel.outerstellar.platform.service.ConsoleEmailService(),
+            pushNotificationService = io.github.rygel.outerstellar.platform.service.ConsolePushNotificationService,
+        )
+
+    private fun buildWeb(
+        pageFactory: WebPageFactory,
+        resolvedMessageCache: MessageCache,
+        resolvedPollService: io.github.rygel.outerstellar.platform.service.PollService,
+        notificationService: io.github.rygel.outerstellar.platform.service.NotificationService,
+    ): WebComponents =
+        WebComponents(
+            templateRenderer = renderer,
+            pageFactory = pageFactory,
+            messageCache = resolvedMessageCache,
+            analyticsService = io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService(),
+            emailService = io.github.rygel.outerstellar.platform.service.NoOpEmailService(),
+            i18nService = io.github.rygel.outerstellar.i18n.I18nService.create("messages"),
+            syncWebSocket = SyncWebSocket(sessionSvc),
+            eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
+            voteService = VoteService(voteRepository, messageRepository),
+            pollService = resolvedPollService,
+            notificationService = notificationService,
+            adminPageFactory =
+                io.github.rygel.outerstellar.platform.web.AdminPageFactory(
+                    apiKeyService,
+                    notificationService,
+                    userAdminService,
+                ),
+            adminStatsService = io.github.rygel.outerstellar.platform.security.AdminStatsService(userRepository),
+            pluginMigrationSource = object : io.github.rygel.outerstellar.platform.PluginMigrationSource {},
+        )
 
     private val tablesToDelete =
         listOf(

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/WebTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/WebTest.kt
@@ -3,6 +3,9 @@ package io.github.rygel.outerstellar.platform.web
 import io.github.rygel.outerstellar.platform.AppConfig
 import io.github.rygel.outerstellar.platform.AppleOAuthConfig
 import io.github.rygel.outerstellar.platform.app
+import io.github.rygel.outerstellar.platform.di.CoreComponents
+import io.github.rygel.outerstellar.platform.di.PersistenceComponents
+import io.github.rygel.outerstellar.platform.di.WebComponents
 import io.github.rygel.outerstellar.platform.infra.createRenderer
 import io.github.rygel.outerstellar.platform.persistence.DeviceTokenRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiApiKeyRepository
@@ -11,10 +14,12 @@ import io.github.rygel.outerstellar.platform.persistence.JdbiContactRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiMessageRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiNotificationRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiOAuthRepository
+import io.github.rygel.outerstellar.platform.persistence.JdbiOutboxRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiPasswordResetRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiPollRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiSessionRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiUserRepository
+import io.github.rygel.outerstellar.platform.persistence.JdbiVoteRepository
 import io.github.rygel.outerstellar.platform.persistence.MessageCache
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import io.github.rygel.outerstellar.platform.security.AccountService
@@ -23,13 +28,16 @@ import io.github.rygel.outerstellar.platform.security.AuthService
 import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.OAuthService
 import io.github.rygel.outerstellar.platform.security.PasswordResetService
+import io.github.rygel.outerstellar.platform.security.SecurityComponents
 import io.github.rygel.outerstellar.platform.security.SecurityConfig
 import io.github.rygel.outerstellar.platform.security.SessionService
+import io.github.rygel.outerstellar.platform.security.TOTPService
 import io.github.rygel.outerstellar.platform.security.UserAdminService
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.service.NotificationService
 import io.github.rygel.outerstellar.platform.service.PollService
+import io.github.rygel.outerstellar.platform.service.VoteService
 import io.github.rygel.outerstellar.platform.testing.SharedPostgres
 import io.github.rygel.outerstellar.platform.testing.sanitizeDbName
 import java.util.UUID
@@ -85,8 +93,10 @@ abstract class WebTest {
     val auditRepository by lazy { JdbiAuditRepository(testJdbi) }
     val notificationRepository by lazy { JdbiNotificationRepository(testJdbi) }
     val passwordResetRepository by lazy { JdbiPasswordResetRepository(testJdbi) }
-    open val oauthRepository by lazy { JdbiOAuthRepository(testJdbi) }
+    val outboxRepository by lazy { JdbiOutboxRepository(testJdbi) }
+    val voteRepository by lazy { JdbiVoteRepository(testJdbi) }
     val pollRepository by lazy { JdbiPollRepository(testJdbi) }
+    open val oauthRepository by lazy { JdbiOAuthRepository(testJdbi) }
     val pollService by lazy { PollService(pollRepository) }
 
     val userAdminService by lazy { UserAdminService(userRepository, auditRepository) }
@@ -141,26 +151,95 @@ abstract class WebTest {
 
         val authService = AuthService(userRepository, encoder, auditRepository)
         val accountService = AccountService(userRepository, encoder, sessionRepository, auditRepository)
+        val resolvedPollService = overrides.pollService ?: pollService
+
+        val persistence =
+            PersistenceComponents(
+                dataSource = testDb.dataSource,
+                jdbi = testJdbi,
+                messageRepository = messageRepository,
+                contactRepository = contactRepository,
+                userRepository = resolvedUserRepo,
+                outboxRepository = outbox,
+                transactionManager = txManager,
+                auditRepository = auditRepository,
+                passwordResetRepository = passwordResetRepository,
+                apiKeyRepository = apiKeyRepository,
+                oAuthRepository = oauthRepository,
+                deviceTokenRepository =
+                    overrides.deviceTokenRepository
+                        ?: io.github.rygel.outerstellar.platform.persistence.JdbiDeviceTokenRepository(testJdbi),
+                sessionRepository = sessionRepository,
+                voteRepository = voteRepository,
+                pollRepository = pollRepository,
+                notificationRepository = notificationRepository,
+            )
+
+        val security =
+            SecurityComponents(
+                jwtService =
+                    io.github.rygel.outerstellar.platform.security.JwtService(
+                        io.github.rygel.outerstellar.platform.JwtConfig()
+                    ),
+                asyncActivityUpdater =
+                    io.github.rygel.outerstellar.platform.security.AsyncActivityUpdater(resolvedUserRepo),
+                authService = authService,
+                accountService = accountService,
+                apiKeyService = apiKeyService,
+                passwordResetService = passwordResetService,
+                oauthService = oauthService,
+                authRealms = emptyList(),
+                totpService = TOTPService(),
+                sessionService = sessionSvc,
+                userAdminService = userAdminService,
+            )
+
+        val core =
+            CoreComponents(
+                messageService = messageService,
+                contactService = resolvedContactService,
+                outboxProcessor =
+                    io.github.rygel.outerstellar.platform.service.OutboxProcessor(
+                        outboxRepository = outbox,
+                        transactionManager = txManager,
+                    ),
+                eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
+                emailService = io.github.rygel.outerstellar.platform.service.ConsoleEmailService(),
+                pushNotificationService = io.github.rygel.outerstellar.platform.service.ConsolePushNotificationService,
+            )
+
+        val notificationService = overrides.notificationService ?: NotificationService(notificationRepository)
+        val voteService = VoteService(voteRepository, messageRepository)
+
+        val web =
+            WebComponents(
+                templateRenderer = renderer,
+                pageFactory = pageFactory,
+                messageCache = resolvedMessageCache,
+                analyticsService = io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService(),
+                emailService = io.github.rygel.outerstellar.platform.service.NoOpEmailService(),
+                i18nService = io.github.rygel.outerstellar.i18n.I18nService.create("messages"),
+                syncWebSocket = SyncWebSocket(sessionSvc),
+                eventPublisher = io.github.rygel.outerstellar.platform.service.NoOpEventPublisher,
+                voteService = voteService,
+                pollService = resolvedPollService,
+                notificationService = notificationService,
+                adminPageFactory =
+                    io.github.rygel.outerstellar.platform.web.AdminPageFactory(
+                        apiKeyService,
+                        notificationService,
+                        userAdminService,
+                    ),
+                adminStatsService = io.github.rygel.outerstellar.platform.security.AdminStatsService(resolvedUserRepo),
+                pluginMigrationSource = object : io.github.rygel.outerstellar.platform.PluginMigrationSource {},
+            )
 
         return app(
-                messageService,
-                resolvedContactService,
-                outbox,
-                resolvedMessageCache,
-                renderer,
-                pageFactory,
-                config,
-                apiKeyService,
-                passwordResetService,
-                oauthService,
-                authService,
-                accountService,
-                userAdminService,
-                sessionSvc,
-                resolvedUserRepo,
-                deviceTokenRepository = overrides.deviceTokenRepository,
-                notificationService = overrides.notificationService,
-                pollService = overrides.pollService ?: pollService,
+                config = config,
+                persistence = persistence,
+                security = security,
+                core = core,
+                web = web,
                 plugin = plugin,
             )
             .http!!


### PR DESCRIPTION
## Summary

Three architectural deepening changes that reduce coupling and eliminate duplication in platform-web.

### 1. App.kt decoupling (25 params → 6)
Replaced pp()\s 25 individual parameters with the 4 existing component group objects (\PersistenceComponents\, \SecurityComponents\, \CoreComponents\, \WebComponents\). Deleted \OptionalServices\, \AuthServices\, and \AppContext\ inner classes (~100 lines of delegation boilerplate removed).

### 2. AuthRoutes decomposition (487 lines → 4 focused classes)
Split \AuthRoutes\ into:
- **AuthRoutes** — login/register/recover flow (~160 lines, 7 params)
- **PasswordRoutes** — change-password + reset (~160 lines, 4 params)
- **ProfileRoutes** — profile edit + notification prefs + account delete (~140 lines, 4 params)
- **ApiKeyRoutes** — API key CRUD (~80 lines, 3 params)

### 3. Auth guard consolidation (~125 lines removed)
Replaced 25+ scattered inline \if (ctx.user == null)\ guards with a single \SecurityRules.authenticated\ filter wrapping all protected UI routes. Unauthenticated users now get proper \eturnTo\ parameter on redirect.

## Files changed
- \App.kt\ — 572 lines refactored
- \ServerComponents.kt\ — simplified
- 3 new route files: \PasswordRoutes.kt\, \ProfileRoutes.kt\, \ApiKeyRoutes.kt\
- 8 route files with guards removed: HomeRoutes, ContactsRoutes, ComponentRoutes, NotificationRoutes, SettingsRoutes, PasswordRoutes, ProfileRoutes, ApiKeyRoutes
- Test files updated to construct component groups

## Verification
- Full reactor build passes (detekt, spotless, tests): 615 tests, 0 failures
- Pre-existing SpotBugs issue in \platform-test-infrastructure\ (unrelated)