### PR TITLE
refactor: architecture cleanups batch 2 — DeviceTokenService, OAuthRepository move, VoteService/PollService to CoreComponents

### DIFF
--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/OAuthRepository.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/OAuthRepository.kt
@@ -1,0 +1,23 @@
+package io.github.rygel.outerstellar.platform.persistence
+
+import java.util.UUID
+
+data class OAuthUserInfo(val subject: String, val email: String?, val displayName: String?)
+
+data class OAuthConnection(
+    val id: Long = 0,
+    val userId: UUID,
+    val provider: String,
+    val subject: String,
+    val email: String?,
+)
+
+interface OAuthRepository {
+    fun findByProviderSubject(provider: String, subject: String): OAuthConnection?
+
+    fun save(connection: OAuthConnection)
+
+    fun findByUserId(userId: UUID): List<OAuthConnection>
+
+    fun delete(id: Long, userId: UUID)
+}

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/di/PersistenceFactory.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/di/PersistenceFactory.kt
@@ -25,6 +25,7 @@ import io.github.rygel.outerstellar.platform.persistence.JdbiUserRepository
 import io.github.rygel.outerstellar.platform.persistence.JdbiVoteRepository
 import io.github.rygel.outerstellar.platform.persistence.MessageRepository
 import io.github.rygel.outerstellar.platform.persistence.NotificationRepository
+import io.github.rygel.outerstellar.platform.persistence.OAuthRepository
 import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
 import io.github.rygel.outerstellar.platform.persistence.PasswordResetRepository
 import io.github.rygel.outerstellar.platform.persistence.PollRepository
@@ -33,7 +34,6 @@ import io.github.rygel.outerstellar.platform.persistence.TransactionManager
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import io.github.rygel.outerstellar.platform.persistence.VoteRepository
 import io.github.rygel.outerstellar.platform.security.CachingUserRepository
-import io.github.rygel.outerstellar.platform.security.OAuthRepository
 import io.micrometer.core.instrument.Metrics
 import javax.sql.DataSource
 import org.jdbi.v3.core.Jdbi

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiOAuthRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiOAuthRepository.kt
@@ -1,7 +1,5 @@
 package io.github.rygel.outerstellar.platform.persistence
 
-import io.github.rygel.outerstellar.platform.security.OAuthConnection
-import io.github.rygel.outerstellar.platform.security.OAuthRepository
 import java.sql.ResultSet
 import java.util.UUID
 import org.jdbi.v3.core.Jdbi

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiOAuthRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiOAuthRepositoryTest.kt
@@ -1,6 +1,5 @@
 package io.github.rygel.outerstellar.platform.persistence
 
-import io.github.rygel.outerstellar.platform.security.OAuthConnection
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AppleOAuthProvider.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AppleOAuthProvider.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.security
 
+import io.github.rygel.outerstellar.platform.persistence.OAuthUserInfo
 import org.slf4j.LoggerFactory
 
 class AppleOAuthProvider(

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/OAuthProvider.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/OAuthProvider.kt
@@ -1,33 +1,6 @@
 package io.github.rygel.outerstellar.platform.security
 
-import java.util.UUID
-
-/** Represents the user information returned after a successful OAuth handshake. */
-data class OAuthUserInfo(val subject: String, val email: String?, val displayName: String?)
-
-/** An OAuth connection record stored in the database. */
-data class OAuthConnection(
-    val id: Long = 0,
-    val userId: UUID,
-    val provider: String,
-    val subject: String,
-    val email: String?,
-)
-
-/** Repository for persisting OAuth provider↔user linkages. */
-interface OAuthRepository {
-    /** Find an existing connection by provider name and provider-issued subject ID. */
-    fun findByProviderSubject(provider: String, subject: String): OAuthConnection?
-
-    /** Create a new connection linking a provider identity to a local user. */
-    fun save(connection: OAuthConnection)
-
-    /** List all OAuth connections for a given user. */
-    fun findByUserId(userId: UUID): List<OAuthConnection>
-
-    /** Remove a specific connection (e.g. user unlinks a provider). */
-    fun delete(id: Long, userId: UUID)
-}
+import io.github.rygel.outerstellar.platform.persistence.OAuthUserInfo
 
 /**
  * Strategy interface for OAuth 2.0 identity providers.

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/OAuthService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/OAuthService.kt
@@ -3,6 +3,8 @@ package io.github.rygel.outerstellar.platform.security
 import io.github.rygel.outerstellar.platform.model.User
 import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.persistence.AuditRepository
+import io.github.rygel.outerstellar.platform.persistence.OAuthConnection
+import io.github.rygel.outerstellar.platform.persistence.OAuthRepository
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import java.util.UUID
 import org.slf4j.LoggerFactory

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
@@ -3,6 +3,7 @@ package io.github.rygel.outerstellar.platform.security
 import io.github.rygel.outerstellar.platform.AppConfig
 import io.github.rygel.outerstellar.platform.persistence.ApiKeyRepository
 import io.github.rygel.outerstellar.platform.persistence.AuditRepository
+import io.github.rygel.outerstellar.platform.persistence.OAuthRepository
 import io.github.rygel.outerstellar.platform.persistence.PasswordResetRepository
 import io.github.rygel.outerstellar.platform.persistence.SessionRepository
 import io.github.rygel.outerstellar.platform.persistence.UserRepository

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/OAuthServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/OAuthServiceTest.kt
@@ -3,6 +3,8 @@ package io.github.rygel.outerstellar.platform.security
 import io.github.rygel.outerstellar.platform.model.User
 import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.persistence.AuditRepository
+import io.github.rygel.outerstellar.platform.persistence.OAuthConnection
+import io.github.rygel.outerstellar.platform.persistence.OAuthRepository
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import io.mockk.every
 import io.mockk.mockk

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/Stubs.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/Stubs.kt
@@ -4,12 +4,12 @@ import io.github.rygel.outerstellar.platform.model.DeviceToken
 import io.github.rygel.outerstellar.platform.model.Session
 import io.github.rygel.outerstellar.platform.persistence.DeviceTokenRepository
 import io.github.rygel.outerstellar.platform.persistence.MessageCache
+import io.github.rygel.outerstellar.platform.persistence.OAuthConnection
+import io.github.rygel.outerstellar.platform.persistence.OAuthRepository
 import io.github.rygel.outerstellar.platform.persistence.OutboxEntry
 import io.github.rygel.outerstellar.platform.persistence.OutboxRepository
 import io.github.rygel.outerstellar.platform.persistence.OutboxStatus
 import io.github.rygel.outerstellar.platform.persistence.SessionRepository
-import io.github.rygel.outerstellar.platform.security.OAuthConnection
-import io.github.rygel.outerstellar.platform.security.OAuthRepository
 import java.time.Instant
 import java.util.UUID
 


### PR DESCRIPTION
## Summary

Three architectural improvements from the architecture review:

1. **Extract DeviceTokenService** — New service layer between DeviceRegistrationApi routes and DeviceTokenRepository. Moves platform validation, token construction, ownership checks, and audit logging out of route handlers into a proper service.

2. **Move OAuthRepository to platform-core** — OAuthRepository, OAuthConnection, and OAuthUserInfo moved from platform-security to platform-core/persistence. Fixes inverted dependency where platform-persistence-jdbi depended on platform-security just for this interface.

3. **Move VoteService/PollService to CoreComponents** — Service creation moved from WebFactory (platform-web) to CoreComponents (platform-core), consistent with MessageService/ContactService pattern. Makes services available to desktop and other consumers.

Kept: NotificationService stays as a service layer seam (future home for auth checks, push dispatch, dedup).

## Test plan
- [x] Full reactor build: 615 tests, 0 failures
- [x] Detekt clean
- [x] Spotless clean