### PR TITLE
refactor: make MessageCache type-safe with typed accessor methods

### DIFF
--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/CaffeineMessageCache.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/CaffeineMessageCache.kt
@@ -1,6 +1,9 @@
 package io.github.rygel.outerstellar.platform.persistence
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import io.github.rygel.outerstellar.platform.model.MessageSummary
+import io.github.rygel.outerstellar.platform.model.PagedResult
+import io.github.rygel.outerstellar.platform.model.StoredMessage
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics
 import java.util.concurrent.ConcurrentHashMap
@@ -30,13 +33,23 @@ class CaffeineMessageCache(
         }
     }
 
-    override fun get(key: String): Any? = cache.getIfPresent(key)
+    override fun getMessage(syncId: String): StoredMessage? = cache.getIfPresent("entity:$syncId") as? StoredMessage
 
-    override fun put(key: String, value: Any) {
-        cache.put(key, value)
+    override fun putMessage(syncId: String, message: StoredMessage) {
+        cache.put("entity:$syncId", message)
     }
 
-    override fun getOrPut(key: String, loader: () -> Any): Any = cache.get(key) { loader() }
+    override fun getMessageList(key: String): PagedResult<MessageSummary>? =
+        cache.getIfPresent(key) as? PagedResult<MessageSummary>
+
+    override fun putMessageList(key: String, result: PagedResult<MessageSummary>) {
+        cache.put(key, result)
+    }
+
+    override fun getMessageListOrPut(
+        key: String,
+        loader: () -> PagedResult<MessageSummary>,
+    ): PagedResult<MessageSummary> = cache.get(key) { loader() } as PagedResult<MessageSummary>
 
     override fun invalidate(key: String) {
         cache.invalidate(key)

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/MessageCache.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/MessageCache.kt
@@ -1,11 +1,19 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.MessageSummary
+import io.github.rygel.outerstellar.platform.model.PagedResult
+import io.github.rygel.outerstellar.platform.model.StoredMessage
+
 interface MessageCache {
-    fun get(key: String): Any?
+    fun getMessage(syncId: String): StoredMessage?
 
-    fun put(key: String, value: Any)
+    fun putMessage(syncId: String, message: StoredMessage)
 
-    fun getOrPut(key: String, loader: () -> Any): Any = get(key) ?: loader().also { put(key, it) }
+    fun getMessageList(key: String): PagedResult<MessageSummary>?
+
+    fun putMessageList(key: String, result: PagedResult<MessageSummary>)
+
+    fun getMessageListOrPut(key: String, loader: () -> PagedResult<MessageSummary>): PagedResult<MessageSummary>
 
     fun invalidate(key: String)
 
@@ -17,25 +25,24 @@ interface MessageCache {
 }
 
 object NoOpMessageCache : MessageCache {
-    override fun get(key: String): Any? = null
+    override fun getMessage(syncId: String): StoredMessage? = null
 
-    override fun put(key: String, value: Any) {
-        // No-op
-    }
+    override fun putMessage(syncId: String, message: StoredMessage) = Unit
 
-    override fun getOrPut(key: String, loader: () -> Any): Any = loader()
+    override fun getMessageList(key: String): PagedResult<MessageSummary>? = null
 
-    override fun invalidate(key: String) {
-        // No-op
-    }
+    override fun putMessageList(key: String, result: PagedResult<MessageSummary>) = Unit
 
-    override fun invalidateAll() {
-        // No-op
-    }
+    override fun getMessageListOrPut(
+        key: String,
+        loader: () -> PagedResult<MessageSummary>,
+    ): PagedResult<MessageSummary> = loader()
 
-    override fun invalidateNamespace(namespace: String) {
-        // No-op
-    }
+    override fun invalidate(key: String) = Unit
+
+    override fun invalidateAll() = Unit
+
+    override fun invalidateNamespace(namespace: String) = Unit
 
     override fun getStats(): Map<String, Any> = emptyMap()
 }

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/MessageService.kt
@@ -53,8 +53,7 @@ class MessageService(
         val limit = limit.coerceIn(1, MAX_PAGE_LIMIT)
         val cacheKey = "list:$query:$year:$limit:$offset"
 
-        @Suppress("UNCHECKED_CAST")
-        return cache.getOrPut(cacheKey) {
+        return cache.getMessageListOrPut(cacheKey) {
             val result = repository.listMessagesWithTotal(query, year, limit, offset)
             PagedResult(
                 items = result.items,
@@ -65,7 +64,7 @@ class MessageService(
                         totalItems = result.totalItems,
                     ),
             )
-        } as PagedResult<MessageSummary>
+        }
     }
 
     fun searchMessages(query: String, limit: Int = 20): List<MessageSummary> {
@@ -87,12 +86,11 @@ class MessageService(
     }
 
     fun findBySyncId(syncId: String): StoredMessage? {
-        val cacheKey = "entity:$syncId"
-        val cached = cache.get(cacheKey) as? StoredMessage
+        val cached = cache.getMessage(syncId)
         if (cached != null) return cached
 
         val message = repository.findBySyncId(syncId) ?: throw MessageNotFoundException(syncId)
-        cache.put(cacheKey, message)
+        cache.putMessage(syncId, message)
         return message
     }
 
@@ -138,7 +136,7 @@ class MessageService(
                 detail = "author=$author",
             )
         )
-        cache.put("entity:${message.syncId}", message)
+        cache.putMessage(message.syncId, message)
         cache.invalidateNamespace("list")
         eventPublisher.publishRefresh("message-list-panel")
         return message
@@ -164,7 +162,7 @@ class MessageService(
                 detail = "author=$author",
             )
         )
-        cache.put("entity:${message.syncId}", message)
+        cache.putMessage(message.syncId, message)
         cache.invalidateNamespace("list")
         eventPublisher.publishRefresh("message-list-panel")
         return message
@@ -210,7 +208,7 @@ class MessageService(
         val applied =
             if (toApply.isNotEmpty()) {
                 val upserted = repository.batchUpsertSyncedMessages(toApply, dirty = false)
-                upserted.forEach { cache.put("entity:${it.syncId}", it) }
+                upserted.forEach { cache.putMessage(it.syncId, it) }
                 upserted.size
             } else 0
 
@@ -294,7 +292,7 @@ class MessageService(
                 detail = null,
             )
         )
-        cache.put("entity:${updated.syncId}", updated)
+        cache.putMessage(updated.syncId, updated)
         cache.invalidateNamespace("list")
         eventPublisher.publishRefresh("message-list-panel")
         return updated

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/CaffeineMessageCacheTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/CaffeineMessageCacheTest.kt
@@ -1,5 +1,9 @@
 package io.github.rygel.outerstellar.platform.persistence
 
+import io.github.rygel.outerstellar.platform.model.MessageSummary
+import io.github.rygel.outerstellar.platform.model.PagedResult
+import io.github.rygel.outerstellar.platform.model.PaginationMetadata
+import io.github.rygel.outerstellar.platform.model.StoredMessage
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -10,22 +14,26 @@ class CaffeineMessageCacheTest {
 
     @Test
     fun `invalidateNamespace bumps generation making old keys stale`() {
-        cache.put("list:0:all:null:10:0", "result-1")
-        cache.put("entity:abc-123", "message-1")
+        val result = PagedResult(listOf(MessageSummary("id", "a", "c", 0L, false)), PaginationMetadata(1, 10, 1L))
+        val msg = StoredMessage("abc-123", "author", "content", 0L, false, false, 1L)
+
+        cache.putMessageList("list:0:all:null:10:0", result)
+        cache.putMessage("abc-123", msg)
 
         cache.invalidateNamespace("list")
 
-        assertNull(cache.get("list:0:all:null:10:0"))
-        assertEquals("message-1", cache.get("entity:abc-123"))
+        assertNull(cache.getMessageList("list:0:all:null:10:0"))
+        assertEquals(msg, cache.getMessage("abc-123"))
     }
 
     @Test
     fun `invalidateNamespace with no prior keys is a no-op`() {
-        cache.put("entity:abc-123", "message-1")
+        val msg = StoredMessage("abc-123", "author", "content", 0L, false, false, 1L)
+        cache.putMessage("abc-123", msg)
 
         cache.invalidateNamespace("list")
 
-        assertEquals("message-1", cache.get("entity:abc-123"))
+        assertEquals(msg, cache.getMessage("abc-123"))
     }
 
     @Test
@@ -38,7 +46,8 @@ class CaffeineMessageCacheTest {
     @Test
     fun `constructor accepts custom size and TTL`() {
         val custom = CaffeineMessageCache(maxSize = 50, ttlMinutes = 1)
-        custom.put("key", "value")
-        assertEquals("value", custom.get("key"))
+        val msg = StoredMessage("key", "author", "content", 0L, false, false, 1L)
+        custom.putMessage("key", msg)
+        assertEquals(msg, custom.getMessage("key"))
     }
 }

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageCacheTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageCacheTest.kt
@@ -3,6 +3,7 @@ package io.github.rygel.outerstellar.platform.service
 import io.github.rygel.outerstellar.platform.model.MessageSummary
 import io.github.rygel.outerstellar.platform.model.PagedResult
 import io.github.rygel.outerstellar.platform.model.PaginationMetadata
+import io.github.rygel.outerstellar.platform.model.StoredMessage
 import io.github.rygel.outerstellar.platform.persistence.MessageCache
 import io.github.rygel.outerstellar.platform.persistence.MessageRepository
 import io.github.rygel.outerstellar.platform.sync.SyncPushRequest
@@ -23,27 +24,22 @@ class MessageCacheTest {
         val items = listOf(summary)
         val results = PagedResult(items, PaginationMetadata(1, 100, 1L))
 
-        every { cache.get(any()) } returns null
-        // getOrPut has a default impl in the interface but MockK relaxed mocks don't invoke it;
-        // replicate the default behaviour so get/put interactions are still verifiable.
-        every { cache.getOrPut(any(), any()) } answers
+        every { cache.getMessageListOrPut(any(), any()) } answers
             {
-                cache.get(firstArg()) ?: secondArg<() -> Any>()().also { cache.put(firstArg(), it) }
+                val loader = secondArg<() -> PagedResult<MessageSummary>>()
+                loader().also { cache.putMessageList(firstArg(), it) }
             }
         every { repository.listMessagesWithTotal(any(), any(), any(), any(), any()) } returns
             io.github.rygel.outerstellar.platform.model.PagedQueryResult(items, 1L)
 
-        // First call - cache miss
         val firstResult = service.listMessages("test")
         assertEquals(results, firstResult)
         verify { repository.listMessagesWithTotal("test", null, 100, 0, false) }
-        verify { cache.put("list:test:null:100:0", results) }
+        verify { cache.putMessageList("list:test:null:100:0", results) }
 
-        // Second call - cache hit
-        every { cache.get("list:test:null:100:0") } returns results
+        every { cache.getMessageListOrPut(any(), any()) } returns results
         val secondResult = service.listMessages("test")
         assertEquals(results, secondResult)
-        // Verify repository was not called again
         verify(exactly = 1) { repository.listMessagesWithTotal(any(), any(), any(), any(), any()) }
     }
 
@@ -51,34 +47,31 @@ class MessageCacheTest {
     fun `write operations invalidate cache and use entity cache`() {
         val msg = service.createServerMessage("author", "content")
         verify { cache.invalidateNamespace("list") }
-        verify { cache.put("entity:${msg.syncId}", msg) }
+        verify { cache.putMessage(msg.syncId, msg) }
 
         val localMsg = service.createLocalMessage("author", "content")
         verify(exactly = 2) { cache.invalidateNamespace("list") }
-        verify { cache.put("entity:${localMsg.syncId}", localMsg) }
+        verify { cache.putMessage(localMsg.syncId, localMsg) }
 
         service.processPushRequest(SyncPushRequest(emptyList()))
-        // SyncPushRequest with empty list appliedCount is 0, no invalidation
         verify(exactly = 2) { cache.invalidateNamespace("list") }
     }
 
     @Test
     fun `findBySyncId uses entity cache`() {
         val syncIdValue = "id-1"
-        val msg = mockk<io.github.rygel.outerstellar.platform.model.StoredMessage>(relaxed = true)
+        val msg = mockk<StoredMessage>(relaxed = true)
         every { msg.syncId } returns syncIdValue
 
-        every { cache.get("entity:$syncIdValue") } returns null
+        every { cache.getMessage(syncIdValue) } returns null
         every { repository.findBySyncId(syncIdValue) } returns msg
 
-        // Cache miss
         val firstResult = service.findBySyncId(syncIdValue)
         assertEquals(msg, firstResult)
         verify { repository.findBySyncId(syncIdValue) }
-        verify { cache.put("entity:$syncIdValue", msg) }
+        verify { cache.putMessage(syncIdValue, msg) }
 
-        // Cache hit
-        every { cache.get("entity:$syncIdValue") } returns msg
+        every { cache.getMessage(syncIdValue) } returns msg
         val secondResult = service.findBySyncId(syncIdValue)
         assertEquals(msg, secondResult)
         verify(exactly = 1) { repository.findBySyncId(syncIdValue) }

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageServiceTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/service/MessageServiceTest.kt
@@ -57,7 +57,7 @@ class MessageServiceTest {
         serviceWithCache.createServerMessage("Alice", "hello")
 
         // Entity key must still be present — not nuked by invalidateAll
-        assertEquals(msg, cache.get("entity:$syncId"))
+        assertEquals(msg, cache.getMessage(syncId))
     }
 
     @Test
@@ -69,12 +69,12 @@ class MessageServiceTest {
         every { repository.resolveConflict(syncId, any()) } just Runs
 
         val cache = CaffeineMessageCache()
-        cache.put("entity:$syncId", existing)
+        cache.putMessage(syncId, existing)
         val serviceWithCache = MessageService(repository, cache = cache)
 
         serviceWithCache.resolveConflict(syncId, ConflictStrategy.SERVER)
 
-        assertNull(cache.get("entity:$syncId"))
+        assertNull(cache.getMessage(syncId))
     }
 
     @Test
@@ -84,12 +84,13 @@ class MessageServiceTest {
         every { repository.createServerMessage("Alice", "hello") } returns msg
 
         val cache = CaffeineMessageCache()
-        cache.put("list:null:null:10:0", "stale-result")
+        val staleResult = PagedResult(emptyList<MessageSummary>(), PaginationMetadata(1, 10, 0L))
+        cache.putMessageList("list:null:null:10:0", staleResult)
 
         val serviceWithCache = MessageService(repository, cache = cache)
         serviceWithCache.createServerMessage("Alice", "hello")
 
-        assertNull(cache.get("list:null:null:10:0"))
+        assertNull(cache.getMessageList("list:null:null:10:0"))
     }
 
     @Test

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/Stubs.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/Stubs.kt
@@ -1,7 +1,10 @@
 package io.github.rygel.outerstellar.platform.web
 
 import io.github.rygel.outerstellar.platform.model.DeviceToken
+import io.github.rygel.outerstellar.platform.model.MessageSummary
+import io.github.rygel.outerstellar.platform.model.PagedResult
 import io.github.rygel.outerstellar.platform.model.Session
+import io.github.rygel.outerstellar.platform.model.StoredMessage
 import io.github.rygel.outerstellar.platform.persistence.DeviceTokenRepository
 import io.github.rygel.outerstellar.platform.persistence.MessageCache
 import io.github.rygel.outerstellar.platform.persistence.OutboxEntry
@@ -34,23 +37,24 @@ class StubOutboxRepository : OutboxRepository {
 }
 
 class StubMessageCache : MessageCache {
-    override fun get(key: String): Any? = null
+    override fun getMessage(syncId: String): StoredMessage? = null
 
-    override fun put(key: String, value: Any) {
-        // Stub implementation
-    }
+    override fun putMessage(syncId: String, message: StoredMessage) = Unit
 
-    override fun invalidate(key: String) {
-        // Stub implementation
-    }
+    override fun getMessageList(key: String): PagedResult<MessageSummary>? = null
 
-    override fun invalidateAll() {
-        // Stub implementation
-    }
+    override fun putMessageList(key: String, result: PagedResult<MessageSummary>) = Unit
 
-    override fun invalidateNamespace(namespace: String) {
-        // test stub — no-op
-    }
+    override fun getMessageListOrPut(
+        key: String,
+        loader: () -> PagedResult<MessageSummary>,
+    ): PagedResult<MessageSummary> = loader()
+
+    override fun invalidate(key: String) = Unit
+
+    override fun invalidateAll() = Unit
+
+    override fun invalidateNamespace(namespace: String) = Unit
 
     override fun getStats(): Map<String, Any> = emptyMap()
 }


### PR DESCRIPTION
Replaces untyped get/put/getOrPut (Any/Any?) with typed accessor methods: getMessage/putMessage (StoredMessage), getMessageList/putMessageList (PagedResult of MessageSummary), getMessageListOrPut. Type casts encapsulated inside CaffeineMessageCache. MessageService no longer has unchecked casts.

615 tests pass, detekt clean, spotless clean.