### PR TITLE
release: v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [1.6.2] – 2026-05-25
+
+### Architecture
+
+- **App.kt decoupling** — Replaced `app()` 25-parameter signature with 6 component groups (`PersistenceComponents`, `SecurityComponents`, `CoreComponents`, `WebComponents`). Deleted `OptionalServices`, `AuthServices`, `AppContext` intermediate classes.
+- **AuthRoutes decomposition** — Split AuthRoutes (487 lines, 10 params) into AuthRoutes (login/register/recover), PasswordRoutes, ProfileRoutes, and ApiKeyRoutes.
+- **Auth guard consolidation** — Applied `SecurityRules.authenticated` filter to all protected UI routes. Removed ~25 inline null-check guards. Introduced `UiRouteSet(publicRoutes, protectedRoutes)` pattern for default-authenticated routing.
+- **JDBI shared infrastructure** — Created `JdbiSupport.kt` with `InstantArgumentFactory`, `InstantColumnMapper`, `FilterClause`, `escapeLike()`, and `ResultSet` extension helpers (`getNullableInstant`, `getRequiredInstant`, `getInstantOrDefault`). Removed ~40 lines of manual `Timestamp.from()`/`.toInstant()` boilerplate across 10 repositories.
+- **DeviceTokenService extraction** — New service layer between `DeviceRegistrationApi` and `DeviceTokenRepository`. Moves platform validation, token construction, ownership checks, and audit logging out of route handlers.
+- **OAuthRepository relocation** — Moved `OAuthRepository`, `OAuthConnection`, `OAuthUserInfo` from `platform-security` to `platform-core`. Fixes inverted dependency where `platform-persistence-jdbi` depended on `platform-security`.
+- **VoteService/PollService wiring** — Moved service creation from `WebFactory` (platform-web) to `CoreComponents` (platform-core), consistent with `MessageService`/`ContactService` pattern.
+- **MessageCache type safety** — Replaced untyped `get/put/getOrPut` (`Any`/`Any?`) with typed accessor methods (`getMessage`/`putMessage`, `getMessageList`/`putMessageList`, `getMessageListOrPut`). Eliminated all `@Suppress("UNCHECKED_CAST")` and unsafe casts from `MessageService`.
+
+### Changed
+
+- **TOTPService constructor injection** — Changed from hidden internal instantiation to constructor parameter in `AuthService`. Improves testability and ensures single instance via `SecurityComponents`.
+- **FQCN cleanup** — Replaced 35+ fully-qualified class names with proper imports in `App.kt` and `WebTest.kt`.
+- Removed dead `AdminPageFactory` from `WebComponents` (WebPageFactory has its own lazy instance).
+- Removed duplicate `bannerProviders` parameter from `stateFilter` call.
+- Removed unnecessary `.let {}` wrapper on non-nullable `totpService`.
+
+### Internal
+
+- Consolidated duplicate `docs/TODO.md` into root `TODO.md`. Marked 3 already-implemented items (TOTP UX, Search SPI, Export SPI) as done.
+- Added `JdbiSupportTest` with 12 unit tests covering `escapeLike`, `InstantArgumentFactory`, `InstantColumnMapper`.
+- Registered `InstantArgumentFactory`/`InstantColumnMapper` on both production and test JDBi instances.
+
+---
+
 ## [1.6.0] – 2026-05-08
 
 ### Breaking

--- a/jte-extensions/pom.xml
+++ b/jte-extensions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
     </parent>
 
     <artifactId>jte-extensions</artifactId>

--- a/platform-core/pom.xml
+++ b/platform-core/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
 
     </parent>
 

--- a/platform-desktop-javafx/pom.xml
+++ b/platform-desktop-javafx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
     </parent>
 
     <artifactId>outerstellar-platform-desktop-javafx</artifactId>

--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
 
     </parent>
 

--- a/platform-persistence-jdbi/pom.xml
+++ b/platform-persistence-jdbi/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
 
     </parent>
 

--- a/platform-security/pom.xml
+++ b/platform-security/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
 
     </parent>
 

--- a/platform-seed/pom.xml
+++ b/platform-seed/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
 
     </parent>
 

--- a/platform-sync-client/pom.xml
+++ b/platform-sync-client/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
 
     </parent>
 

--- a/platform-test-infrastructure/pom.xml
+++ b/platform-test-infrastructure/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
     </parent>
 
     <artifactId>outerstellar-platform-test-infrastructure</artifactId>

--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>1.6.2-SNAPSHOT</version>
+        <version>1.6.2</version>
 
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.rygel</groupId>
     <artifactId>outerstellar-platform-parent</artifactId>
 
-    <version>1.6.2-SNAPSHOT</version>
+    <version>1.6.2</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## v1.6.2 Point Release

Architecture deepening: component decoupling, service extraction, type safety, and code quality improvements.

### Highlights
- App.kt 25 params replaced with 6 component groups
- AuthRoutes split into 4 focused route classes
- JDBI shared infrastructure (Instant mapping, FilterClause, escapeLike)
- DeviceTokenService extracted from route handlers
- OAuthRepository moved to platform-core (fixes inverted dependency)
- VoteService/PollService moved to CoreComponents
- MessageCache made type-safe (typed accessor methods, no more unchecked casts)
- TOTPService constructor-injected into AuthService
- 35+ FQCNs replaced with proper imports
- CHANGELOG.md updated for v1.6.2

After merge: create GitHub release with tag v1.6.2, then sync main back to develop.