### PR TITLE
fix(ci): address zizmor cache-poisoning and Hadolint DL3008 findings

### DIFF
--- a/.github/workflows/ci-docker-e2e.yml
+++ b/.github/workflows/ci-docker-e2e.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: 'maven'
+          cache: ${{ github.event_name == 'push' && 'maven' || '' }}
           server-id: github-rygel
           server-username: GITHUB_ACTOR
           server-password: GH_PACKAGES_TOKEN
@@ -69,7 +69,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: ${{ github.event_name == 'push' && 'npm' || '' }}
 
       - name: Install Node dependencies
         run: npm ci --no-audit --no-fund

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -24,7 +24,7 @@ RUN apt-get update && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
         > /etc/apt/sources.list.d/nodesource.list && \
     apt-get update && \
-    apt-get install -y --no-install-recommends nodejs && \
+    apt-get install -y --no-install-recommends nodejs='20.*' && \
     rm -rf /var/lib/apt/lists/*
 
 COPY pom.xml .


### PR DESCRIPTION
Fixes the code scanning findings from PR #369:

- **zizmor/cache-poisoning (alerts 193, 194)**: Scope Maven and npm caches to \push\ events only — prevents cache poisoning from untrusted pull requests
- **DL3008**: Pin nodejs apt-get version to \20.*\ in Dockerfile.build

Note: Alerts 108 (DL3008 on Dockerfile.test-desktop), 195 (PinnedDependencies on Dockerfile.native) will auto-resolve when PR #369 merges since those files are deleted on develop.