### PR TITLE
ci: fix sync PR and CodeQL workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,18 @@ jobs:
           build-mode: manual
 
       - name: Build
-        run: mvn compile -q -Denforcer.skip -T 4
+        run: >
+          mvn install -q -DskipTests -T 1C
+          -Djacoco.skip=true
+          -Denforcer.skip=true
+          -Ddetekt.skip=true
+          -Dcheckstyle.skip=true
+          -Dpmd.skip=true
+          -Dcpd.skip=true
+          -Dspotbugs.skip=true
+          -Dspotless.apply.skip=true
+          -Dspotless.check.skip=true
+          -Dexec.skip=true
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -71,6 +71,13 @@ jobs:
           sarif_file: hadolint-docker.sarif
           category: hadolint-docker
 
+      - name: Upload Hadolint SARIF (build legacy)
+        if: always()
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: hadolint-docker.sarif
+          category: hadolint-build
+
       - name: Upload Hadolint SARIF (test-desktop legacy)
         if: always()
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -21,10 +21,15 @@ jobs:
 
       - name: Create sync branch and PR
         run: |
+          if [ -z "${SYNC_PR_TOKEN}" ]; then
+            echo "::error::Missing SYNC_PR_TOKEN secret. Configure a fine-grained PAT or GitHub App token with contents:write and pull-requests:write. The default GITHUB_TOKEN cannot be used here because PRs it creates do not trigger the required pull_request CI checks."
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          REMOTE="https://x-access-token:${SYNC_PR_TOKEN}@github.com/${{ github.repository }}.git"
 
           # Check if already in sync
           if git merge-base --is-ancestor main develop; then
@@ -51,9 +56,6 @@ jobs:
             --head "$SYNC_BRANCH" \
             --title "sync: merge main into develop" \
             --body "Automated sync of main into develop after release merge."
-
-          # GitHub does not trigger CI on PRs created by the Actions bot.
-          # Explicitly dispatch the CI workflow on the sync branch so checks run.
-          gh workflow run ci.yml --ref "$SYNC_BRANCH"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_PR_TOKEN }}
+          SYNC_PR_TOKEN: ${{ secrets.SYNC_PR_TOKEN }}


### PR DESCRIPTION
Applies the permanent workflow fixes to main without pulling in develop history:

- sync main→develop now uses SYNC_PR_TOKEN, so automated sync PRs trigger normal pull_request CI and satisfy the required Build, Test, and Quality check
- CodeQL uses a reactor install build so local test-jar dependencies resolve
- Hadolint uploads both current and legacy SARIF categories so Advanced Security check names stay green during workflow transitions

Validated locally with YAML parsing and actionlint.