### PR TITLE
[codex] Skip deploying JTE extensions

### DIFF
--- a/jte-extensions/pom.xml
+++ b/jte-extensions/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>jte-extensions</artifactId>
     <name>JTE Extensions</name>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>gg.jte</groupId>


### PR DESCRIPTION
## What changed

- Marked the `jte-extensions` module with `maven.deploy.skip=true`.
- Keeps the module in the reactor so `platform-web` can still use the JTE Maven extension during source generation.

## Why

`jte-extensions` is build-time infrastructure for generating `JteClassRegistry`; it is not a public runtime library and should not be published to Maven Central.

## Validation

- `git diff --check`
- `mvn -q -pl jte-extensions help:evaluate "-Dexpression=maven.deploy.skip" "-DforceStdout"` -> `true`
- `mvn -pl platform-web -am clean compile "-Ddetekt.skip=true" "-Dspotbugs.skip=true" "-Dspotless.check.skip=true" "-Dexec.skip=true"` passed during investigation after restoring the extension dependency.
