### PR TITLE
[codex] slim hosted app context behind facades

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -550,9 +550,13 @@ Integrate [fragments4k](https://github.com/rygel/fragments4k) (v0.6.5+) for SEO 
   platform-page, text-resolver, and ownership metadata. `/admin/plugins` renders the collected contribution including
   capability flags, routes, included platform pages, shell assets, and ownership prefixes.
 
-- [ ] **Slim `PluginContext` behind plugin-facing facades**
-  Replace raw host services with narrower plugin facades such as users, analytics, notifications, rendering, and
-  security. Keep host internals behind adapters so plugins depend on a stable interface.
+- [x] ~~**Slim `PluginContext` behind plugin-facing facades**~~
+  Fixed — `HostedAppContext` now exposes safe `app`, `users`, `analytics`, `notifications`, `rendering`, and
+  `security` facades. Raw host internals such as full `AppConfig` and `WebPageFactory` are no longer plugin-facing;
+  compatibility aliases remain for the narrowed surfaces (`config`, `userRepository`, `apiKeyService`, `oauthService`,
+  `notificationService`, `renderer`).
+  — `platform-web/.../plugin/HostedAppApi.kt`, `platform-web/.../App.kt`,
+    `platform-web/.../HostedAppContextFacadeTest.kt`
 
 - [ ] **Extract plugin SPI package into `platform-plugin-api` module**
   The plugin-facing package is isolated but still compiled inside `platform-web`. Move it into a small standalone module

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -44,8 +44,8 @@
 ### Routing & Templates
 - **http4k** — contract-based routing with OpenAPI documentation
 - **JTE/KTE templates** — precompiled Kotlin templates with hot-reload in dev mode
-- **PlatformPlugin interface** — apps register routes, nav items, Koin modules, and migrations
-- **PluginContext** — shared services (renderer, config, security, analytics) passed to plugins
+- **HostedApp / PlatformPlugin interface** — hosted apps register routes, navigation, assets, layout, and migrations
+- **PluginContext** — safe app info plus users, security, analytics, notifications, and rendering facades passed to plugins
 - **Layout router** — sidebar and topbar layout variants with automatic dispatching
 
 ### Filters & Middleware

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -118,48 +118,41 @@ The platform uses JDBI as its persistence layer, implementing repository interfa
 Plugins implement `PlatformPlugin` and register as a Koin `single`:
 
 ```kotlin
-class MyPlugin : PlatformPlugin {
+class MyPlugin : HostedApp {
     override val id = "my-plugin"
     override val appLabel = "My App"
 
-    override fun navItems() = listOf(
-        PluginNavItem("Dashboard", "/dashboard", "dashboard-3-line")
-    )
-
-    override fun routes(context: PluginContext) = listOf(
-        myDashboardRoute(context)
-    )
-
-    override fun koinModules() = listOf(myPluginModule)
+    override fun contribute(context: HostedAppContributionContext) {
+        context.navigation.item("Dashboard", "/dashboard", "dashboard-3-line")
+        context.routes.protectedUi(myDashboardRoute(), "Dashboard", "/dashboard")
+    }
 }
 ```
-
-Pass the plugin to `startKoin` **before** host modules.
 
 ### What Plugins Can Do
 
 | Capability | Override | Description |
 |---|---|---|
-| Routes | `routes(context)` | Add HTTP routes (http4k `ContractRoute`) |
+| Routes | `contribute(context)` / `routeRegistrations(context)` | Add HTTP routes (public, protected, API, admin, static assets) |
 | Filters | `filters(context)` | Add filters before route dispatch |
-| Nav items | `navItems()` | Replace sidebar navigation |
-| Koin modules | `koinModules()` | Register additional services |
+| Navigation | `contribute(context)` | Add shell navigation items |
+| Admin | `contribute(context)` / `adminSections(context)` | Add admin summary cards and routes |
+| Layout & assets | `layoutRenderer(context)` / `contribute(context)` | Replace the shell layout and contribute styles/scripts/static assets |
 | Migrations | `PluginMigrationSource` | Separate Flyway instance with own history table |
 | Text overrides | `textResolver` | Custom translations |
 | Template overrides | `templateOverrides()` | Override JTE templates from plugin classpath |
-| Route exclusion | `excludeDefaultRoutes` | Remove specific host routes |
 
 ### PluginContext
 
-Passed to `routes()` and `filters()`, provides access to:
+Passed to hosted-app hooks, provides access to:
 
-- `renderer` — JTE template renderer
-- `config` — AppConfig
-- `securityService` — auth operations
-- `userRepository` — user data access
-- `analytics` — tracking service
-- `notificationService` — push notifications
-- `pageFactory` — web page construction
+- `app` (`config` compatibility alias) — safe app info: `version`, `appBaseUrl`, `devMode`, `registrationEnabled`
+- `users` (`userRepository` alias) — current user lookup plus `findById`, `findByUsername`, `findByEmail`
+- `analytics` — identify/track/page events
+- `notifications` (`notificationService` alias) — create/list/count/mark/delete notifications
+- `rendering` (`renderer` alias) — template renderer plus shell rendering
+- `security` (`apiKeyService` / `oauthService` aliases) — API key CRUD and OAuth user resolution
+- `currentUser(request)` / `renderShell(shell, bodyHtml)` convenience helpers
 
 ### Plugin Migrations
 

--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -2,31 +2,47 @@
 
 ## Overview
 
-Plugins extend the platform via the `PlatformPlugin` interface. They can add routes, filters, templates, admin sections, navigation items, i18n, and database migrations.
+Hosted apps extend the platform via the `HostedApp` interface. `PlatformPlugin` remains as a compatibility alias for older integrations, but `HostedApp` and `HostedAppContext` are the primary API names.
 
-## PlatformPlugin Interface
+Hosted apps can contribute:
+- routes and filters
+- shell navigation, admin sections, banners, layout replacement, and assets
+- i18n/text overrides and template overrides
+- database migrations through `PluginMigrationSource`
+
+## HostedApp Interface
 
 ```kotlin
-interface PlatformPlugin : PluginMigrationSource {
+interface HostedApp : PluginMigrationSource {
     val id: String
     val appLabel: String
-    val excludeDefaultRoutes: Set<String>
-    val navItems: List<NavItem>
-    val textResolver: I18nTextResolver?
-    fun templateOverrides(): Map<String, String>?
-    fun routes(): List<org.http4k.routing.RoutingHttpHandler>
-    fun filters(ctx: PluginContext): List<org.http4k.routing.RoutingHttpHandler>
-    fun adminSections(ctx: PluginContext): List<AdminSection>
-    fun koinModules(): List<Module>
+    val manifest: HostedAppManifest
+    val mode: PlatformMode
+
+    fun contribute(context: HostedAppContributionContext) {}
+    fun routeRegistrations(context: HostedAppContext): List<PluginRouteRegistration> = emptyList()
+    fun filters(context: HostedAppContext): List<Filter> = emptyList()
+    fun adminSections(context: HostedAppContext): List<AdminSection> = emptyList()
+    fun bannerProviders(context: HostedAppContext): List<BannerProvider> = emptyList()
+    fun includePlatformPages(): Set<PlatformPageSets> = emptySet()
+    fun layoutRenderer(context: HostedAppContext): PluginLayoutRenderer? = null
 }
 ```
 
 ## Plugin Context
 
-`PluginContext` provides access to:
+`HostedAppContext` / `PluginContext` provides access to stable plugin-facing facades:
+- `app` (`config` compatibility alias) — safe app info only: `version`, `appBaseUrl`, `devMode`, `registrationEnabled`
+- `users` (`userRepository` alias) — `currentUser(request)`, `findById`, `findByUsername`, `findByEmail`
+- `analytics` — `identify`, `track`, `page`
+- `notifications` (`notificationService` alias) — create/list/count/mark/delete user notifications
+- `rendering` (`renderer` alias) — template renderer plus `renderShell(shell, bodyHtml)`
+- `security` (`apiKeyService` / `oauthService` aliases) — API key CRUD and OAuth user resolution
+
+Convenience helpers remain on the context itself:
 - `currentUser(request)` — authenticated user
-- `buildPage(request, title, section, data)` — wrap ViewModel in platform shell
-- `forTesting(renderer, securityService, userRepository)` — test factory
+- `renderShell(shell, bodyHtml)` — wrap plugin HTML in the platform shell
+- `forTesting(...)` — construct a test context with mocked host services
 
 ## Template Overrides
 
@@ -53,17 +69,4 @@ Or better, use the bridge already in `WebModule.kt`:
 
 ## Registration
 
-```kotlin
-startKoin {
-    modules(
-        myPluginModule,         // Plugin's own Koin module(s)
-        configModule,
-        persistenceModule,
-        coreModule,
-        webModule,
-        securityModule,
-    )
-}
-```
-
-The web module discovers the plugin via Koin and wires its routes, filters, and admin sections.
+The server wires a single hosted app into application startup and collects its contributions once. Ownership validation ensures hosted-app routes and assets stay inside the prefixes declared by `HostedAppManifest.ownership`.

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/App.kt
@@ -956,15 +956,14 @@ private fun buildPluginContext(
     security: SecurityComponents,
     web: WebComponents,
 ): HostedAppContext =
-    HostedAppContext(
-        jteRenderer,
-        config,
-        security.apiKeyService,
-        security.oauthService,
-        persistence.userRepository,
-        web.analyticsService,
-        web.notificationService,
-        web.pageFactory,
+    HostedAppContext.fromHostServices(
+        renderer = jteRenderer,
+        config = config,
+        apiKeyService = security.apiKeyService,
+        oauthService = security.oauthService,
+        userRepository = persistence.userRepository,
+        analytics = web.analyticsService,
+        notificationService = web.notificationService,
     )
 
 private val localhostOnly = Filter { next ->

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/plugin/HostedAppApi.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/plugin/HostedAppApi.kt
@@ -12,16 +12,19 @@ import io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService
 import io.github.rygel.outerstellar.platform.banner.BannerProvider
 import io.github.rygel.outerstellar.platform.composition.PlatformMode
 import io.github.rygel.outerstellar.platform.composition.RouteGroup
+import io.github.rygel.outerstellar.platform.model.ApiKeySummary
+import io.github.rygel.outerstellar.platform.model.CreateApiKeyResponse
 import io.github.rygel.outerstellar.platform.model.User
+import io.github.rygel.outerstellar.platform.persistence.Notification
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import io.github.rygel.outerstellar.platform.security.ApiKeyService
 import io.github.rygel.outerstellar.platform.security.OAuthService
 import io.github.rygel.outerstellar.platform.service.NotificationService
 import io.github.rygel.outerstellar.platform.web.AdminSection
 import io.github.rygel.outerstellar.platform.web.ShellView
-import io.github.rygel.outerstellar.platform.web.WebPageFactory
 import io.github.rygel.outerstellar.platform.web.composition.PlatformPageSets
 import io.github.rygel.outerstellar.platform.web.requestContext
+import java.util.UUID
 import org.http4k.contract.ContractRoute
 import org.http4k.core.Filter
 import org.http4k.core.Request
@@ -113,43 +116,139 @@ data class PluginOptions(
     val assets: PluginAssets = PluginAssets(),
 )
 
+data class PluginAppInfo(
+    val version: String,
+    val appBaseUrl: String,
+    val devMode: Boolean,
+    val registrationEnabled: Boolean,
+) {
+    companion object {
+        fun from(config: AppConfig): PluginAppInfo =
+            PluginAppInfo(
+                version = config.version,
+                appBaseUrl = config.appBaseUrl,
+                devMode = config.devMode,
+                registrationEnabled = config.registrationEnabled,
+            )
+    }
+}
+
+interface PluginUsers {
+    fun currentUser(request: Request): User?
+
+    fun findById(id: UUID): User?
+
+    fun findByUsername(username: String): User?
+
+    fun findByEmail(email: String): User?
+}
+
+interface PluginAnalytics {
+    fun identify(userId: String, traits: Map<String, Any> = emptyMap())
+
+    fun track(userId: String, event: String, properties: Map<String, Any> = emptyMap())
+
+    fun page(userId: String, path: String)
+}
+
+interface PluginNotifications {
+    fun create(userId: UUID, title: String, body: String, type: String = "info")
+
+    fun listForUser(userId: UUID, limit: Int = 50): List<Notification>
+
+    fun countUnread(userId: UUID): Int
+
+    fun markRead(id: UUID, userId: UUID)
+
+    fun markAllRead(userId: UUID)
+
+    fun delete(id: UUID, userId: UUID)
+}
+
+interface PluginRendering {
+    val renderer: TemplateRenderer
+
+    fun renderShell(shell: ShellView, bodyHtml: String): String
+}
+
+interface PluginApiKeys {
+    fun createApiKey(userId: UUID, name: String): CreateApiKeyResponse
+
+    fun listApiKeys(userId: UUID): List<ApiKeySummary>
+
+    fun deleteApiKey(userId: UUID, keyId: Long)
+}
+
+interface PluginOAuth {
+    fun findOrCreateOAuthUser(providerName: String, oauthSubject: String, email: String?): User
+}
+
+data class PluginSecurity(val apiKeys: PluginApiKeys, val oauth: PluginOAuth)
+
 /**
  * Host services provided to the plugin when it builds its routes. The plugin should depend only on this context rather
  * than injecting host services directly.
  */
-data class HostedAppContext(
-    val renderer: TemplateRenderer,
-    val config: AppConfig,
-    val apiKeyService: ApiKeyService,
-    val oauthService: OAuthService,
-    val userRepository: UserRepository,
-    val analytics: AnalyticsService,
-    val notificationService: NotificationService?,
-    val pageFactory: WebPageFactory,
+class HostedAppContext(
+    val app: PluginAppInfo,
+    val users: PluginUsers,
+    val analytics: PluginAnalytics,
+    val notifications: PluginNotifications?,
+    val rendering: PluginRendering,
+    val security: PluginSecurity,
 ) {
+    @Deprecated("Use rendering.renderer", ReplaceWith("rendering.renderer"))
+    val renderer: TemplateRenderer
+        get() = rendering.renderer
+
+    @Deprecated("Use app", ReplaceWith("app"))
+    val config: PluginAppInfo
+        get() = app
+
+    @Deprecated("Use security.apiKeys", ReplaceWith("security.apiKeys"))
+    val apiKeyService: PluginApiKeys
+        get() = security.apiKeys
+
+    @Deprecated("Use security.oauth", ReplaceWith("security.oauth"))
+    val oauthService: PluginOAuth
+        get() = security.oauth
+
+    @Deprecated("Use users", ReplaceWith("users"))
+    val userRepository: PluginUsers
+        get() = users
+
+    @Deprecated("Use notifications", ReplaceWith("notifications"))
+    val notificationService: PluginNotifications?
+        get() = notifications
+
     /** Returns the authenticated user for this request, or null if no user is logged in. */
-    fun currentUser(request: Request): User? =
-        try {
-            request.requestContext.user
-        } catch (e: LensFailure) {
-            logger.debug("Lens extraction failed for current user check: {}", e.message)
-            null
-        }
+    fun currentUser(request: Request): User? = users.currentUser(request)
 
     /**
      * Renders [bodyHtml] wrapped inside the platform's standardized layout shell defined by [shell].
      *
      * The [bodyHtml] is rendered as-is with no escaping; hosted apps are trusted to produce safe HTML.
      */
-    fun renderShell(shell: ShellView, bodyHtml: String): String {
-        val output = StringOutput()
-        val content = Content { it.writeUnsafeContent(bodyHtml) }
-        JteLayoutRouterGenerated.render(OwaspHtmlTemplateOutput(output), null, shell, content)
-        return output.toString()
-    }
+    fun renderShell(shell: ShellView, bodyHtml: String): String = rendering.renderShell(shell, bodyHtml)
 
     companion object {
-        private val logger = LoggerFactory.getLogger(HostedAppContext::class.java)
+        internal fun fromHostServices(
+            renderer: TemplateRenderer,
+            config: AppConfig,
+            apiKeyService: ApiKeyService,
+            oauthService: OAuthService,
+            userRepository: UserRepository,
+            analytics: AnalyticsService,
+            notificationService: NotificationService?,
+        ): HostedAppContext =
+            HostedAppContext(
+                app = PluginAppInfo.from(config),
+                users = DefaultPluginUsers(userRepository),
+                analytics = DefaultPluginAnalytics(analytics),
+                notifications = notificationService?.let(::DefaultPluginNotifications),
+                rendering = DefaultPluginRendering(renderer),
+                security = PluginSecurity(DefaultPluginApiKeys(apiKeyService), DefaultPluginOAuth(oauthService)),
+            )
 
         /**
          * Creates a [HostedAppContext] with sensible defaults for testing. Only the services that cannot be stubbed
@@ -160,21 +259,89 @@ data class HostedAppContext(
             apiKeyService: ApiKeyService,
             oauthService: OAuthService,
             userRepository: UserRepository,
+            config: AppConfig = AppConfig(),
+            analyticsService: AnalyticsService = NoOpAnalyticsService(),
+            notificationService: NotificationService? = null,
         ): HostedAppContext =
-            HostedAppContext(
+            fromHostServices(
                 renderer = renderer,
-                config = AppConfig(),
+                config = config,
                 apiKeyService = apiKeyService,
                 oauthService = oauthService,
                 userRepository = userRepository,
-                analytics = NoOpAnalyticsService(),
-                notificationService = null,
-                pageFactory = WebPageFactory(),
+                analytics = analyticsService,
+                notificationService = notificationService,
             )
     }
 }
 
 typealias PluginContext = HostedAppContext
+
+private val hostedAppContextLogger = LoggerFactory.getLogger(HostedAppContext::class.java)
+
+private class DefaultPluginUsers(private val userRepository: UserRepository) : PluginUsers {
+    override fun currentUser(request: Request): User? =
+        try {
+            request.requestContext.user
+        } catch (e: LensFailure) {
+            hostedAppContextLogger.debug("Lens extraction failed for current user check: {}", e.message)
+            null
+        }
+
+    override fun findById(id: UUID): User? = userRepository.findById(id)
+
+    override fun findByUsername(username: String): User? = userRepository.findByUsername(username)
+
+    override fun findByEmail(email: String): User? = userRepository.findByEmail(email)
+}
+
+private class DefaultPluginAnalytics(private val analyticsService: AnalyticsService) : PluginAnalytics {
+    override fun identify(userId: String, traits: Map<String, Any>) = analyticsService.identify(userId, traits)
+
+    override fun track(userId: String, event: String, properties: Map<String, Any>) =
+        analyticsService.track(userId, event, properties)
+
+    override fun page(userId: String, path: String) = analyticsService.page(userId, path)
+}
+
+private class DefaultPluginNotifications(private val notificationService: NotificationService) : PluginNotifications {
+    override fun create(userId: UUID, title: String, body: String, type: String) =
+        notificationService.create(userId, title, body, type)
+
+    override fun listForUser(userId: UUID, limit: Int): List<Notification> =
+        notificationService.listForUser(userId, limit)
+
+    override fun countUnread(userId: UUID): Int = notificationService.countUnread(userId)
+
+    override fun markRead(id: UUID, userId: UUID) = notificationService.markRead(id, userId)
+
+    override fun markAllRead(userId: UUID) = notificationService.markAllRead(userId)
+
+    override fun delete(id: UUID, userId: UUID) = notificationService.delete(id, userId)
+}
+
+private class DefaultPluginRendering(override val renderer: TemplateRenderer) : PluginRendering {
+    override fun renderShell(shell: ShellView, bodyHtml: String): String {
+        val output = StringOutput()
+        val content = Content { it.writeUnsafeContent(bodyHtml) }
+        JteLayoutRouterGenerated.render(OwaspHtmlTemplateOutput(output), null, shell, content)
+        return output.toString()
+    }
+}
+
+private class DefaultPluginApiKeys(private val apiKeyService: ApiKeyService) : PluginApiKeys {
+    override fun createApiKey(userId: UUID, name: String): CreateApiKeyResponse =
+        apiKeyService.createApiKey(userId, name)
+
+    override fun listApiKeys(userId: UUID): List<ApiKeySummary> = apiKeyService.listApiKeys(userId)
+
+    override fun deleteApiKey(userId: UUID, keyId: Long) = apiKeyService.deleteApiKey(userId, keyId)
+}
+
+private class DefaultPluginOAuth(private val oauthService: OAuthService) : PluginOAuth {
+    override fun findOrCreateOAuthUser(providerName: String, oauthSubject: String, email: String?): User =
+        oauthService.findOrCreateOAuthUser(providerName, oauthSubject, email)
+}
 
 /**
  * Single hosted-app contract. One outerstellar-platform host accepts exactly one hosted app adapter.

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/HostedAppContextFacadeTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/HostedAppContextFacadeTest.kt
@@ -1,0 +1,133 @@
+package io.github.rygel.outerstellar.platform.web
+
+import io.github.rygel.outerstellar.platform.AppConfig
+import io.github.rygel.outerstellar.platform.model.ApiKeySummary
+import io.github.rygel.outerstellar.platform.model.CreateApiKeyResponse
+import io.github.rygel.outerstellar.platform.model.User
+import io.github.rygel.outerstellar.platform.model.UserRole
+import io.github.rygel.outerstellar.platform.persistence.Notification
+import io.github.rygel.outerstellar.platform.persistence.UserRepository
+import io.github.rygel.outerstellar.platform.security.ApiKeyService
+import io.github.rygel.outerstellar.platform.security.JwtService
+import io.github.rygel.outerstellar.platform.security.OAuthService
+import io.github.rygel.outerstellar.platform.service.NotificationService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.cookie.Cookie
+import org.http4k.core.cookie.cookie
+import org.http4k.template.TemplateRenderer
+import org.junit.jupiter.api.Test
+
+class HostedAppContextFacadeTest {
+
+    @Test
+    fun `forTesting projects safe app info and rendering facade`() {
+        val renderer: TemplateRenderer = { "rendered" }
+        val context =
+            HostedAppContext.forTesting(
+                renderer = renderer,
+                apiKeyService = mockk(relaxed = true),
+                oauthService = mockk(relaxed = true),
+                userRepository = mockk(relaxed = true),
+                config =
+                    AppConfig(
+                        version = "1.2.3",
+                        appBaseUrl = "https://platform.example",
+                        devMode = true,
+                        registrationEnabled = false,
+                    ),
+            )
+
+        assertEquals("1.2.3", context.app.version)
+        assertEquals("https://platform.example", context.app.appBaseUrl)
+        assertEquals(true, context.app.devMode)
+        assertEquals(false, context.app.registrationEnabled)
+        assertSame(renderer, context.rendering.renderer)
+        assertSame(renderer, context.renderer)
+        assertEquals(context.app, context.config)
+    }
+
+    @Test
+    fun `users facade resolves current user from request context and delegates lookups`() {
+        val userId = UUID.randomUUID()
+        val user = User(userId, "alex", "alex@example.com", "hash", UserRole.USER)
+        val userRepository = mockk<UserRepository>()
+        val jwtService = mockk<JwtService>()
+        val context =
+            HostedAppContext.forTesting(
+                renderer = mockk(relaxed = true),
+                apiKeyService = mockk(relaxed = true),
+                oauthService = mockk(relaxed = true),
+                userRepository = userRepository,
+            )
+
+        every { jwtService.extractClaims("jwt-token") } returns (userId to false)
+        every { userRepository.findById(userId) } returns user
+        every { userRepository.findByUsername("alex") } returns user
+        every { userRepository.findByEmail("alex@example.com") } returns user
+
+        val baseRequest = Request(GET, "/plugin/reports").cookie(Cookie(RequestContext.JWT_COOKIE, "jwt-token"))
+        val requestWithContext =
+            RequestContext.KEY(
+                RequestContext(request = baseRequest, userRepository = userRepository, jwtService = jwtService),
+                baseRequest,
+            )
+
+        assertSame(user, context.currentUser(requestWithContext))
+        assertSame(user, context.users.currentUser(requestWithContext))
+        assertSame(user, context.users.findById(userId))
+        assertSame(user, context.users.findByUsername("alex"))
+        assertSame(user, context.users.findByEmail("alex@example.com"))
+        assertSame(user, context.userRepository.findById(userId))
+    }
+
+    @Test
+    fun `security and notification facades delegate to narrowed host services`() {
+        val userId = UUID.randomUUID()
+        val notification = Notification(userId = userId, title = "Build ready", body = "Plugin build completed")
+        val apiKey = ApiKeySummary(7L, "osk_1234", "CLI", true, "2026-05-28T10:00:00Z", null)
+        val createdKey = CreateApiKeyResponse("osk_secret", "CLI", "osk_1234")
+        val apiKeyService = mockk<ApiKeyService>()
+        val oauthService = mockk<OAuthService>()
+        val notificationService = mockk<NotificationService>()
+        val user = User(userId, "alex", "alex@example.com", "hash", UserRole.USER)
+        val context =
+            HostedAppContext.forTesting(
+                renderer = mockk(relaxed = true),
+                apiKeyService = apiKeyService,
+                oauthService = oauthService,
+                userRepository = mockk(relaxed = true),
+                notificationService = notificationService,
+            )
+
+        every { apiKeyService.createApiKey(userId, "CLI") } returns createdKey
+        every { apiKeyService.listApiKeys(userId) } returns listOf(apiKey)
+        every { apiKeyService.deleteApiKey(userId, 7L) } returns Unit
+        every { oauthService.findOrCreateOAuthUser("github", "sub-1", "alex@example.com") } returns user
+        every { notificationService.listForUser(userId, 10) } returns listOf(notification)
+        every { notificationService.countUnread(userId) } returns 1
+        every { notificationService.markAllRead(userId) } returns Unit
+
+        assertEquals(createdKey, context.security.apiKeys.createApiKey(userId, "CLI"))
+        assertEquals(listOf(apiKey), context.apiKeyService.listApiKeys(userId))
+        context.security.apiKeys.deleteApiKey(userId, 7L)
+        assertEquals(user, context.security.oauth.findOrCreateOAuthUser("github", "sub-1", "alex@example.com"))
+        assertEquals(listOf(notification), context.notifications!!.listForUser(userId, 10))
+        assertEquals(1, context.notificationService!!.countUnread(userId))
+        context.notifications!!.markAllRead(userId)
+
+        verify { apiKeyService.createApiKey(userId, "CLI") }
+        verify { apiKeyService.listApiKeys(userId) }
+        verify { apiKeyService.deleteApiKey(userId, 7L) }
+        verify { oauthService.findOrCreateOAuthUser("github", "sub-1", "alex@example.com") }
+        verify { notificationService.listForUser(userId, 10) }
+        verify { notificationService.countUnread(userId) }
+        verify { notificationService.markAllRead(userId) }
+    }
+}


### PR DESCRIPTION
## Summary

This PR narrows the hosted-app context behind stable plugin-facing facades instead of exposing raw host services.

- Replaces raw `HostedAppContext` services with safe `app`, `users`, `analytics`, `notifications`, `rendering`, and `security` facades.
- Keeps compatibility aliases for the narrowed surfaces (`config`, `userRepository`, `apiKeyService`, `oauthService`, `notificationService`, `renderer`) while removing raw host internals such as full `AppConfig` and `WebPageFactory` from the plugin-facing API.
- Adds focused facade tests and updates plugin-facing docs plus `TODO.md`.

## Why

The next composition-model step is to make the hosted-app SPI stable without leaking host internals. Grouped facades keep plugins on a smaller contract and make the later `platform-plugin-api` module split more realistic.

## Validation

- `mvn -pl platform-web -am compile "-Ddetekt.skip=true" "-Dspotbugs.skip=true" "-Dspotless.check.skip=true"`
- `mvn -pl platform-web -am test "-Dtest=HostedAppContextFacadeTest,PluginRenderShellTest,PluginContributionTest,AdminSectionTest" "-Dexec.skip=true" "-Dsurefire.failIfNoSpecifiedTests=false"`
- `mvn -pl platform-web -am test "-Dexec.skip=true"`