### PR TITLE
Add Jazzer regression coverage for web parsing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -572,8 +572,10 @@ Integrate [fragments4k](https://github.com/rygel/fragments4k) (v0.6.5+) for SEO 
 - [x] ~~**Mobile responsive layout**~~
   `SidebarLayout` and `TopbarLayout` are desktop-oriented. Add responsive breakpoints, hamburger navigation, touch-friendly controls.
 
-- [ ] **Jazzer fuzz tests for high-risk surfaces**
-  Add Jazzer (JVM fuzzing) tests for: CSP parsing, JWT validation, OAuth callback parsing, rate limiter token bucket math, input validation.
+- [x] ~~**Jazzer fuzz tests for high-risk surfaces**~~
+  Fixed — strengthened `WebFuzzTest` coverage for CSP headers, JWT validation, OAuth callback parsing,
+  rate limiter parsing, token bucket behavior, and URL validation, plus added deterministic regression
+  tests so malformed percent-encoded OAuth and rate-limiter form inputs fail safely instead of throwing.
 
 ### Low Priority
 

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/OAuthRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/OAuthRoutes.kt
@@ -101,10 +101,18 @@ class OAuthRoutes(
 
     private data class ValidatedCallback(val code: String, val state: String)
 
-    private fun validateCallback(request: Request, providerName: String): ValidatedCallback? {
-        val code = request.query("code") ?: request.bodyString().parseFormField("code")
+    private fun Request.callbackField(name: String, providerName: String): String? =
+        query(name)
+            ?: try {
+                bodyString().parseFormField(name)
+            } catch (e: IllegalArgumentException) {
+                logger.warn("OAuth callback parse failure for provider={} field={}: {}", providerName, name, e.message)
+                null
+            }
 
-        val returnedState = request.query("state") ?: request.bodyString().parseFormField("state")
+    private fun validateCallback(request: Request, providerName: String): ValidatedCallback? {
+        val code = request.callbackField("code", providerName)
+        val returnedState = request.callbackField("state", providerName)
         val expectedState = request.cookie("oauth_state")?.value
         val stateValid = returnedState != null && returnedState == expectedState
 

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiter.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiter.kt
@@ -1,6 +1,7 @@
 package io.github.rygel.outerstellar.platform.web
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import java.net.URLDecoder
 import java.util.concurrent.TimeUnit
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
@@ -133,13 +134,29 @@ internal fun extractAccountIdentifier(request: org.http4k.core.Request): String?
         extractJsonValue(body, "username") ?: extractJsonValue(body, "email")
     } else {
         val params =
-            body.split("&").associate {
-                val parts = it.split("=", limit = 2)
-                if (parts.size == 2) parts[0] to java.net.URLDecoder.decode(parts[1], "UTF-8") else null to null
-            }
+            body
+                .split("&")
+                .mapNotNull {
+                    val parts = it.split("=", limit = 2)
+                    if (parts.size != 2) {
+                        return@mapNotNull null
+                    }
+                    val key = decodeFormComponent(parts[0]) ?: return@mapNotNull null
+                    val value = decodeFormComponent(parts[1]) ?: return@mapNotNull null
+                    key to value
+                }
+                .toMap()
         params["email"]?.trim()?.lowercase() ?: params["username"]?.trim()?.lowercase()
     }
 }
+
+private fun decodeFormComponent(value: String): String? =
+    try {
+        URLDecoder.decode(value, "UTF-8")
+    } catch (e: IllegalArgumentException) {
+        logger.warn("Failed to decode rate-limit form field: {}", e.message)
+        null
+    }
 
 private fun extractJsonValue(json: String, key: String): String? {
     val pattern = "\"$key\"\\s*:\\s*\"([^\"]+)\""

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
@@ -221,6 +221,24 @@ class OAuthIntegrationTest : WebTest() {
         )
     }
 
+    @Test
+    fun `POST callback with malformed percent encoding redirects to auth with oauth_error`() {
+        val state = UUID.randomUUID().toString()
+        val response =
+            app(
+                Request(POST, "/auth/oauth/apple/callback")
+                    .header("content-type", "application/x-www-form-urlencoded")
+                    .body("code=%ZZ&state=$state")
+                    .cookie(Cookie("oauth_state", state))
+            )
+        assertThat(response, hasStatus(Status.FOUND))
+        val location = response.header("location").orEmpty()
+        assertTrue(
+            location.contains("oauth_error=true"),
+            "Malformed OAuth callback body must redirect to oauth_error, got: $location",
+        )
+    }
+
     // ---- Not-configured error page ----
 
     @Test

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiterParsingTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/RateLimiterParsingTest.kt
@@ -1,0 +1,18 @@
+package io.github.rygel.outerstellar.platform.web
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.http4k.core.Method.POST
+import org.http4k.core.Request
+
+class RateLimiterParsingTest {
+    @Test
+    fun `malformed form encoding skips broken fields and still parses valid email`() {
+        val request =
+            Request(POST, "/api/v1/auth/login")
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body("username=%ZZ&email=valid@example.com")
+
+        assertEquals("valid@example.com", extractAccountIdentifier(request))
+    }
+}

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/fuzz/WebFuzzTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/fuzz/WebFuzzTest.kt
@@ -2,20 +2,39 @@ package io.github.rygel.outerstellar.platform.web.fuzz
 
 import com.code_intelligence.jazzer.junit.FuzzTest
 import io.github.rygel.outerstellar.platform.JwtConfig
+import io.github.rygel.outerstellar.platform.persistence.OAuthUserInfo
 import io.github.rygel.outerstellar.platform.security.JwtService
+import io.github.rygel.outerstellar.platform.security.OAuthException
+import io.github.rygel.outerstellar.platform.security.OAuthProvider
+import io.github.rygel.outerstellar.platform.security.OAuthService
+import io.github.rygel.outerstellar.platform.security.SessionService
 import io.github.rygel.outerstellar.platform.service.UrlValidator
 import io.github.rygel.outerstellar.platform.web.Filters
+import io.github.rygel.outerstellar.platform.web.OAuthRoutes
 import io.github.rygel.outerstellar.platform.web.TokenBucket
 import io.github.rygel.outerstellar.platform.web.extractAccountIdentifier
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.http4k.contract.contract
+import org.http4k.contract.openapi.ApiInfo
+import org.http4k.contract.openapi.v3.OpenApi3
 import org.http4k.core.Method
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status
+import org.http4k.core.cookie.Cookie
+import org.http4k.core.cookie.cookie
 import org.http4k.core.then
+import org.http4k.format.KotlinxSerialization
 
 class WebFuzzTest {
 
     companion object {
+        private const val OAUTH_STATE = "fuzzstate"
+
         private val jwtService =
             JwtService(
                 JwtConfig(
@@ -25,63 +44,97 @@ class WebFuzzTest {
                     expirySeconds = 3600L,
                 )
             )
+
+        private val oauthHandler = contract {
+            renderer = OpenApi3(ApiInfo("OAuth Fuzz", "v1.0"), KotlinxSerialization)
+            routes +=
+                OAuthRoutes(
+                        providers =
+                            mapOf(
+                                "test" to
+                                    object : OAuthProvider {
+                                        override val name: String = "test"
+
+                                        override fun authorizationUrl(state: String, redirectUri: String): String =
+                                            "$redirectUri?state=$state"
+
+                                        override fun exchangeCode(
+                                            code: String,
+                                            state: String,
+                                            redirectUri: String,
+                                        ): OAuthUserInfo = throw OAuthException("Fuzzed callback should fail closed")
+                                    }
+                            ),
+                        oauthService = mockk<OAuthService>(relaxed = true),
+                        sessionService = mockk<SessionService>(relaxed = true),
+                    )
+                    .routes
+        }
     }
 
     @FuzzTest
     fun cspPolicyFuzz(data: String?) {
-        val input = data ?: return
-        Filters.securityHeaders(cspPolicy = input)
-            .then { request -> Response(Status.OK).body("ok") }
-            .invoke(Request(Method.GET, "/"))
+        val input = data.orEmpty()
+        val filter = Filters.securityHeaders(cspPolicy = input).then { _: Request -> Response(Status.OK).body("ok") }
+
+        val uiResponse = filter(Request(Method.GET, "/"))
+        assertEquals(input, uiResponse.header("Content-Security-Policy"))
+
+        val apiResponse = filter(Request(Method.GET, "/api/v1/health"))
+        assertNull(apiResponse.header("Content-Security-Policy"))
     }
 
     @FuzzTest
     fun jwtValidationFuzz(data: String?) {
-        val input = data ?: return
-        jwtService.extractClaims(input)
+        jwtService.extractClaims(data.orEmpty())
     }
 
     @FuzzTest
     fun oauthCallbackParsingFuzz(data: String?) {
-        val input = data ?: return
-        val get = Request(Method.GET, "/auth/oauth/test/callback?code=$input&state=fuzzstate")
-        get.query("code")
-        get.query("state")
-        val post =
+        val request =
             Request(Method.POST, "/auth/oauth/test/callback")
-                .body(input)
+                .body(data.orEmpty())
                 .header("content-type", "application/x-www-form-urlencoded")
-        post.bodyString()
+                .cookie(Cookie("oauth_state", OAUTH_STATE))
+        val response = oauthHandler(request)
+
+        assertEquals(Status.FOUND, response.status)
+        assertTrue(response.header("location").orEmpty().contains("oauth_error=true"))
     }
 
     @FuzzTest
     fun rateLimiterFuzz(data: String?) {
-        val input = data ?: return
+        val input = data.orEmpty()
         val jsonRequest =
             Request(Method.POST, "/api/v1/auth/login")
                 .body("""{"username":"$input","email":"$input"}""")
                 .header("content-type", "application/json")
-        extractAccountIdentifier(jsonRequest)
+        val jsonIdentifier = extractAccountIdentifier(jsonRequest)
+        assertTrue(jsonIdentifier == null || jsonIdentifier == jsonIdentifier.trim().lowercase())
+
         val formRequest =
             Request(Method.POST, "/api/v1/auth/login")
                 .body("username=$input&email=$input")
                 .header("content-type", "application/x-www-form-urlencoded")
-        extractAccountIdentifier(formRequest)
+        val formIdentifier = extractAccountIdentifier(formRequest)
+        assertTrue(formIdentifier == null || formIdentifier == formIdentifier.trim().lowercase())
     }
 
     @FuzzTest
     fun tokenBucketFuzz(data: String?) {
-        val input = data ?: return
-        val maxRequests = (input.hashCode() and 0x7FFFFFFF) % 100 + 1
-        val windowMs = ((input.hashCode() / 100) and 0x7FFFFFFF).toLong() % 86400000 + 1
-        TokenBucket(maxRequests, windowMs).tryConsume()
+        val input = data.orEmpty()
+        val maxRequests = (input.hashCode() and 0x7FFFFFFF) % 32 + 1
+        val windowMs = ((input.hashCode() / 100) and 0x7FFFFFFF).toLong() % 86_400_000 + 1
+        val bucket = TokenBucket(maxRequests, windowMs)
+
+        repeat(maxRequests) { assertTrue(bucket.tryConsume()) }
+        assertFalse(bucket.tryConsume())
     }
 
     @FuzzTest
     fun inputValidationFuzz(data: String?) {
-        val input = data ?: return
         try {
-            UrlValidator.validate(input)
+            UrlValidator.validate(data.orEmpty())
         } catch (_: IllegalArgumentException) {}
     }
 }


### PR DESCRIPTION
## Summary
- deepen existing Jazzer coverage in platform-web for CSP, JWT validation, OAuth callback parsing, rate limiter parsing, token bucket behavior, and URL validation
- harden OAuth callback and rate limiter form parsing so malformed percent-encoded input fails safely instead of throwing
- add deterministic regression tests for malformed OAuth and rate limiter form inputs and mark the TODO item complete

## Testing
- mvn -pl platform-web -am test "-Dtest=WebFuzzTest,OAuthIntegrationTest,RateLimiterParsingTest,TokenBucketTest,RateLimiterIntegrationTest" "-Dexec.skip=true" "-Dsurefire.failIfNoSpecifiedTests=false"
- mvn -pl platform-web -am test "-Dexec.skip=true"
- mvn clean verify -T4 -pl platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-plugin-api,platform-web,platform-seed