### PR TITLE
fix: exclude internal artifacts from central bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1183,6 +1183,13 @@
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>
+                            <excludeArtifacts>
+                                <excludeArtifact>outerstellar-platform-seed</excludeArtifact>
+                                <excludeArtifact>outerstellar-platform-test-infrastructure</excludeArtifact>
+                                <excludeArtifact>outerstellar-platform-desktop</excludeArtifact>
+                                <excludeArtifact>outerstellar-platform-desktop-javafx</excludeArtifact>
+                                <excludeArtifact>platform-jte-extensions</excludeArtifact>
+                            </excludeArtifacts>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
## Summary
- exclude internal modules from the Sonatype Central bundle in the root release profile
- keep app/test/build-only modules out of Central even when the central-publishing plugin is injected across the reactor
- preserve the existing 3.6.4 release packaging behavior for the public modules

## Why
maven.deploy.skip and gpg.skip on internal modules were not enough by themselves: the root central-publishing-maven-plugin still staged those modules into the bundle, and Sonatype rejected the deployment because those excluded-from-signing modules had no .asc files.

## Validation
- mvn -q -N -Prelease help:effective-pom includes the new xcludeArtifacts list
- mvn -Prelease -pl platform-web -am clean package -DskipTests succeeds