### PR TITLE
ci: add release version safeguards

### DIFF
--- a/.github/workflows/publish-central.yml
+++ b/.github/workflows/publish-central.yml
@@ -2,6 +2,15 @@ name: Publish to Maven Central
 
 on:
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: Exact release version from pom.xml and CHANGELOG.md (for example 1.6.4)
+        required: true
+        type: string
+      confirm_release_version:
+        description: Type the exact release version again to confirm
+        required: true
+        type: string
 
 permissions: {}
 
@@ -11,6 +20,7 @@ jobs:
     environment: maven-central
     permissions:
       contents: read
+      actions: read
 
     steps:
       - name: Checkout code
@@ -30,6 +40,63 @@ jobs:
           server-password: CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Guard Maven Central publish request
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::Publish to Maven Central must run from main. Current ref: ${GITHUB_REF}"
+            exit 1
+          fi
+
+          if ! [[ "${EXPECTED_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release_version must be plain semver like 1.6.4. Got: ${EXPECTED_VERSION}"
+            exit 1
+          fi
+
+          if [ "${CONFIRM_VERSION}" != "${EXPECTED_VERSION}" ]; then
+            echo "::error::confirm_release_version must exactly match release_version."
+            exit 1
+          fi
+
+          PROJECT_VERSION="$(mvn -q -N help:evaluate -Dexpression=project.version -DforceStdout)"
+          PROJECT_VERSION="${PROJECT_VERSION##*$'\n'}"
+
+          if [[ "${PROJECT_VERSION}" == *-SNAPSHOT ]]; then
+            echo "::error::Refusing to publish SNAPSHOT version ${PROJECT_VERSION} to Maven Central."
+            exit 1
+          fi
+
+          if [ "${PROJECT_VERSION}" != "${EXPECTED_VERSION}" ]; then
+            echo "::error::pom.xml version ${PROJECT_VERSION} does not match requested release ${EXPECTED_VERSION}."
+            exit 1
+          fi
+
+          if ! grep -Fq "## [${PROJECT_VERSION}]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md does not contain a section for ${PROJECT_VERSION}."
+            exit 1
+          fi
+
+          if ! gh release view "v${PROJECT_VERSION}" > /dev/null 2>&1; then
+            echo "::error::GitHub release v${PROJECT_VERSION} does not exist. Run Release and Publish first."
+            exit 1
+          fi
+
+          if ! gh run list \
+            --workflow "CI" \
+            --branch main \
+            --json headSha,conclusion \
+            --limit 50 \
+            --jq ".[] | select(.headSha == \"${GITHUB_SHA}\" and .conclusion == \"success\") | .headSha" \
+            | grep -q .; then
+            echo "::error::No successful CI run was found for ${GITHUB_SHA} on main."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_VERSION: ${{ inputs.release_version }}
+          CONFIRM_VERSION: ${{ inputs.confirm_release_version }}
 
       - name: Set up Node.js 20
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,16 @@
 name: Release and Publish
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'pom.xml'
   workflow_dispatch:
+    inputs:
+      release_version:
+        description: Exact release version from pom.xml and CHANGELOG.md (for example 1.6.4)
+        required: true
+        type: string
+      confirm_release_version:
+        description: Type the exact release version again to confirm
+        required: true
+        type: string
 
 permissions: {}
 
@@ -16,6 +21,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      actions: read
 
     steps:
       - name: Checkout code
@@ -24,38 +30,7 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
 
-      - name: Extract version from pom.xml
-        id: version
-        run: |
-          VERSION=$(grep -m1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Check if release already exists
-        id: check
-        run: |
-          if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-
-      - name: Create GitHub release
-        if: steps.check.outputs.exists == 'false'
-        run: |
-          gh release create "$RELEASE_TAG" \
-            --target main \
-            --title "$RELEASE_TAG" \
-            --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-
       - name: Set up JDK 21
-        if: steps.check.outputs.exists == 'false'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '21'
@@ -68,8 +43,74 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Guard release request
+        id: guard
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::Release workflow must run from main. Current ref: ${GITHUB_REF}"
+            exit 1
+          fi
+
+          if ! [[ "${EXPECTED_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release_version must be plain semver like 1.6.4. Got: ${EXPECTED_VERSION}"
+            exit 1
+          fi
+
+          if [ "${CONFIRM_VERSION}" != "${EXPECTED_VERSION}" ]; then
+            echo "::error::confirm_release_version must exactly match release_version."
+            exit 1
+          fi
+
+          PROJECT_VERSION="$(mvn -q -N help:evaluate -Dexpression=project.version -DforceStdout)"
+          PROJECT_VERSION="${PROJECT_VERSION##*$'\n'}"
+
+          if [[ "${PROJECT_VERSION}" == *-SNAPSHOT ]]; then
+            echo "::error::Refusing to release SNAPSHOT version ${PROJECT_VERSION}."
+            exit 1
+          fi
+
+          if [ "${PROJECT_VERSION}" != "${EXPECTED_VERSION}" ]; then
+            echo "::error::pom.xml version ${PROJECT_VERSION} does not match requested release ${EXPECTED_VERSION}."
+            exit 1
+          fi
+
+          if ! grep -Fq "## [${PROJECT_VERSION}]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md does not contain a section for ${PROJECT_VERSION}."
+            exit 1
+          fi
+
+          if gh release view "v${PROJECT_VERSION}" > /dev/null 2>&1; then
+            echo "::error::GitHub release v${PROJECT_VERSION} already exists."
+            exit 1
+          fi
+
+          echo "version=${PROJECT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${PROJECT_VERSION}" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXPECTED_VERSION: ${{ inputs.release_version }}
+          CONFIRM_VERSION: ${{ inputs.confirm_release_version }}
+
+      - name: Verify CI succeeded on this commit
+        run: |
+          set -euo pipefail
+
+          if ! gh run list \
+            --workflow "CI" \
+            --branch main \
+            --json headSha,conclusion \
+            --limit 50 \
+            --jq ".[] | select(.headSha == \"${GITHUB_SHA}\" and .conclusion == \"success\") | .headSha" \
+            | grep -q .; then
+            echo "::error::No successful CI run was found for ${GITHUB_SHA} on main."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Node.js 20
-        if: steps.check.outputs.exists == 'false'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
@@ -77,15 +118,22 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install Node dependencies
-        if: steps.check.outputs.exists == 'false'
         run: npm ci --no-audit --no-fund
 
       - name: Build and test
-        if: steps.check.outputs.exists == 'false'
         run: mvn clean verify -Pfast
 
       - name: Publish to GitHub Packages
-        if: steps.check.outputs.exists == 'false'
         run: mvn deploy -DskipTests -Denforcer.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        run: |
+          gh release create "${RELEASE_TAG}" \
+            --target main \
+            --title "${RELEASE_TAG}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ steps.guard.outputs.tag }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,13 @@ There are TWO `UserRole` enums — one in `platform-core` (model package) and on
 - Database migration:
   - `-Pmigrate` runs standalone migration via `MigratorKt`.
 
+## Release workflow safeguards
+
+- `Release and Publish` is manual-only and must be dispatched from `main` with two matching inputs: `release_version` and `confirm_release_version`.
+- `Publish to Maven Central` is also manual-only and requires the same exact version confirmation from `main`.
+- Both workflows fail unless the requested version exactly matches the root `pom.xml` version, is not a `-SNAPSHOT`, has a matching `CHANGELOG.md` heading, and already passed CI on that exact `main` commit.
+- Maven Central additionally requires the matching GitHub release tag to already exist, and the GitHub release is only created after the GitHub Packages publish succeeds.
+
 ## Database schema rules
 
 - Flyway migrations are the schema source of truth.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ To run all tests:
 mvn test
 ```
 
+### Release process
+
+Releases are now **manual and version-confirmed** to avoid publishing the wrong version.
+
+1. Merge the release commit to `main` with the exact target version in `pom.xml` and a matching `CHANGELOG.md` section like `## [1.6.4]`.
+2. Run **Release and Publish** from `main`, enter `release_version`, then type the exact same version again in `confirm_release_version`.
+3. After that succeeds, run **Publish to Maven Central** from `main` with the same two inputs.
+
+Both workflows now fail unless they run from `main`, the entered version exactly matches the root Maven version, the version is not a `-SNAPSHOT`, the changelog contains that exact release heading, and CI has already succeeded on that exact commit. Maven Central also refuses to run until the matching GitHub release tag already exists.
+
 ---
 
 ### Web Architecture & Adding Routes


### PR DESCRIPTION
## Summary
- make both release workflows manual-only with explicit `release_version` confirmation
- block release/publish unless the requested version matches the root pom, is not a SNAPSHOT, has a matching changelog entry, and already passed CI on that exact `main` commit
- create the GitHub release only after the GitHub Packages publish succeeds, and require that matching release before Maven Central can run
- document the stricter release procedure in README and AGENTS

## Why
This closes the failure mode where the wrong version can be released because the workflow simply publishes whatever is on `main` without an explicit human-confirmed version check.
