### PR TITLE
Recover issue 407 follow-up changes

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2,6 +2,32 @@
 
 This guide covers the main migration path from the older **1.6.x** plugin model to the current **3.6.4** platform surface.
 
+## Quick checklist: 1.6.x to 3.6.x
+
+- [ ] Depend on `outerstellar-platform-plugin-api` instead of `platform-web`
+- [ ] Implement `HostedApp` directly (or keep `PlatformPlugin` — it is a deprecated alias)
+- [ ] Start the app with `createServerComponents(plugin = MyHostedApp())`
+- [ ] Set `mode = PlatformMode.PluginHostedApp` for custom product UI
+- [ ] Move route/page selection to `mode` + `includePlatformPages()`
+- [ ] Replace legacy migration properties with `override val migrations = PluginMigrations(...)`
+- [ ] Use `HostedAppContributionContext` in `contribute()` for route registration
+- [ ] Add `emailService` parameter to `createSecurityComponents(...)` calls
+- [ ] Check Jackson version alignment if your app uses Jackson 3.x
+
+## Primary import paths
+
+```kotlin
+import io.github.rygel.outerstellar.platform.plugin.HostedApp
+import io.github.rygel.outerstellar.platform.plugin.HostedAppContributionContext
+import io.github.rygel.outerstellar.platform.PluginMigrations
+import io.github.rygel.outerstellar.platform.composition.PlatformMode
+import io.github.rygel.outerstellar.platform.web.composition.PlatformPageSets
+import io.github.rygel.outerstellar.platform.createServerComponents
+```
+
+The `outerstellar-platform-plugin-api` module re-exports these under `io.github.rygel.outerstellar.platform.web` as
+typealiases for older integrations. New code should import from the `plugin` package directly.
+
 ## Recommended path
 
 For most hosted apps, the fastest path is:
@@ -48,19 +74,50 @@ The biggest behavior change is that platform UI is now explicit:
 
 ### Root routes in `PluginHostedApp`
 
-In `PluginHostedApp`, the hosted app now gets `/` as a default **UI ownership prefix**. That means a plugin can register:
+In `PluginHostedApp`, the hosted app automatically gets `/` as a **UI ownership prefix**. This means the hosted app
+can register routes at `/`, `/dashboard`, `/about`, and any other top-level UI path without prefixing them with
+`/<plugin-id>`.
 
-- `/`
-- `/dashboard`
-- `/about`
+How it works internally: `HostedAppContribution.from(...)` calls `HostedAppOwnership.withMode(mode)` which prepends `"/"`
+to the `uiPrefixes` list when the mode is `PluginHostedApp`. The validation in `requirePathOwnedByManifest` then
+accepts any path that matches `/` or starts with `/…`.
 
-without forcing everything under `/<plugin-id>`.
+**What stays under explicit prefixes:**
 
-API, admin, and asset ownership are still explicit and stay under their own prefixes unless the manifest overrides them.
+- API routes — still require `/api/<plugin-id>` or similar declared prefixes
+- Admin routes — still require `/admin/<plugin-id>`
+- Static assets — still require `/plugins/<plugin-id>/assets`
+
+Example of a hosted app claiming the root:
+
+```kotlin
+class DashboardApp : HostedApp {
+    override val id = "dashboard"
+    override val appLabel = "Dashboard"
+    override val mode = PlatformMode.PluginHostedApp
+
+    override fun contribute(context: HostedAppContributionContext) {
+        // These all work because PluginHostedApp grants "/" as a UI prefix
+        context.routes.publicUi(rootRoute(), "Root", "/")
+        context.routes.protectedUi(dashboardRoute(), "Dashboard", "/dashboard")
+        context.routes.publicUi(aboutRoute(), "About", "/about")
+    }
+}
+```
 
 ## Replacing `excludeDefaultRoutes`
 
 Older integrations often fought the platform UI by filtering or excluding platform-owned paths. The new model is opt-in.
+
+**Before (1.6.x):**
+
+```kotlin
+class MyPlugin : PlatformPlugin {
+    override fun excludeDefaultRoutes() = setOf("home", "contacts")
+}
+```
+
+**After (3.6.x):**
 
 ```kotlin
 override val mode = PlatformMode.PluginHostedApp
@@ -75,7 +132,15 @@ If the plugin does not include a page set, the default platform UI for that page
 
 ## Hosted app migrations
 
-Use `HostedApp.migrations` instead of the legacy `migrationLocation`, `migrationHistoryTable`, and `migrationNames` properties:
+**Before (1.6.x):**
+
+```kotlin
+override val migrationLocation = "classpath:db/migration/my-app"
+override val migrationHistoryTable = "flyway_my_app_history"
+override val migrationNames = listOf("V1__init", "V2__seed")
+```
+
+**After (3.6.x):**
 
 ```kotlin
 override val migrations =
@@ -109,6 +174,29 @@ The host passes `plugin.migrations` into persistence startup automatically when 
 
 The compatibility aliases still exist, but they are deprecated.
 
+## Route registration: before and after
+
+**Before (1.6.x) — `routeRegistrations` returning a list:**
+
+```kotlin
+override fun routeRegistrations(context: HostedAppContext): List<PluginRouteRegistration> =
+    listOf(
+        PluginRouteRegistration(myRoute(), RouteGroup.ProtectedUi, "My page", "/my-page"),
+    )
+```
+
+**After (3.6.x) — `contribute` with the contribution context:**
+
+```kotlin
+override fun contribute(context: HostedAppContributionContext) {
+    context.routes.protectedUi(myRoute(), "My page", "/my-page")
+    context.navigation.item("My Page", "/my-page", "my-icon")
+}
+```
+
+The `contribute` method is the preferred registration path. `routeRegistrations(...)` still works for backward
+compatibility — both are called during `HostedAppContribution.from(...)`.
+
 ## Testing
 
 Two patterns are supported:
@@ -123,9 +211,7 @@ val context = HostedAppContext.forTesting(rendering = rendering, users = users, 
 
 ### Full-stack web tests
 
-For integration coverage against the real platform wiring, prefer the platform test harnesses such as `WebTest`, or boot through `createServerComponents(plugin = ...)` instead of manually wiring every `createXxxComponents(...)` function.
-
-When a test already owns an `AppConfig` or a test database, pass it directly:
+For integration coverage against the real platform wiring, use `createServerComponents` directly:
 
 ```kotlin
 val server = createServerComponents(
@@ -138,6 +224,10 @@ val response = server.app.http!!(Request(GET, "/my-app"))
 
 Close `server.persistence` when the test is done.
 
+The platform's `WebTest` base class is an internal test harness. Downstream hosted apps should **not** extend it.
+Instead, create a test database (e.g. using `SharedPostgres` or Testcontainers) and boot through
+`createServerComponents(config, plugin)`.
+
 ## Factory wiring guidance
 
 The lower-level `createSecurityComponents(...)`, `createCoreComponents(...)`, and `createWebComponents(...)` functions are still available, but they are assembly seams, not the preferred application entrypoint.
@@ -149,3 +239,41 @@ createServerComponents(plugin = MyHostedApp())
 ```
 
 That keeps persistence migrations, email wiring, websocket/event wiring, and hosted-app context assembly aligned with production.
+
+### Deprecated factory overloads
+
+The following deprecated overloads are provided for backward compatibility:
+
+**`createPersistenceComponents(config, pluginMigrationSource: String?)`** — wraps the string location into a
+`PluginMigrations`. Migrate to `createPersistenceComponents(config, PluginMigrations?)` or use
+`createServerComponents(plugin = ...)`.
+
+**`createSecurityComponents(config, userRepository, ..., oauthRepository?, sessionRepository?)`** — calls without
+`emailService` default to `NoOpEmailService`. Migrate by adding an explicit `emailService` parameter.
+
+## Jackson and Flyway dependency compatibility
+
+The platform manages Jackson **2.21.4** via the `jackson-bom` in its root POM dependency management. Flyway 11.x
+also depends on Jackson 2.x, so there is no conflict within the platform itself.
+
+**If your downstream app uses Jackson 3.x**, Flyway 11 will still pull in Jackson 2.x on the classpath. To avoid
+convergence failures:
+
+1. Declare the platform's `jackson-bom` in your dependency management to pin the 2.x versions that Flyway requires.
+2. Or exclude `jackson-*` from the Flyway dependency and ensure Flyway's Jackson usage still resolves:
+   ```xml
+   <dependency>
+       <groupId>org.flywaydb</groupId>
+       <artifactId>flyway-core</artifactId>
+       <exclusions>
+           <exclusion>
+               <groupId>com.fasterxml.jackson.core</groupId>
+               <artifactId>jackson-databind</artifactId>
+           </exclusion>
+       </exclusions>
+   </dependency>
+   ```
+3. Use the Maven Enforcer plugin's `dependencyConvergence` rule to catch conflicts early.
+
+The platform already runs `dependencyConvergence` and `banDuplicateClasses` as part of its build, so the published
+artifacts have a clean classpath. Conflicts only appear when downstream consumers introduce different Jackson versions.

--- a/TODO.md
+++ b/TODO.md
@@ -2,13 +2,19 @@
 
 Issue: https://github.com/rygel/outerstellar-platform/issues/407
 
-Current follow-up PR: https://github.com/rygel/outerstellar-platform/pull/410
+Merged PRs:
+
+- https://github.com/rygel/outerstellar-platform/pull/409
+- https://github.com/rygel/outerstellar-platform/pull/410
+
+Current recovery branch: `fix/issue-407-missing-followups`
 
 ## Status
 
 - PR #409 merged the plugin-hosted UI/root-route work and fixed the native-image Flyway reflection failure.
-- PR #410 is open with `createServerComponents(config = ..., plugin = ...)`, a production-wiring integration test, and docs for config-driven hosted-app tests.
-- Do not close #407 yet. It is still an umbrella customer migration-pain ticket unless the remaining items below are split into separate issues or explicitly accepted as complete.
+- PR #410 merged `createServerComponents(config = ..., plugin = ...)`, a production-wiring integration test, and docs for config-driven hosted-app tests.
+- The follow-up commit `3b7d327f` was left only on the deleted PR branch. This recovery branch reapplies that missing work from latest `origin/develop`.
+- Items 1-5 below are now complete on this recovery branch. Only item 6 remains after this branch is merged.
 
 ## Before continuing
 
@@ -16,80 +22,85 @@ Current follow-up PR: https://github.com/rygel/outerstellar-platform/pull/410
 - Preserve unrelated local edits unless the owner explicitly asks to change them.
 - Use Podman only; do not use the Docker CLI.
 - Run `pwsh scripts/test.ps1` and `pwsh scripts/test-desktop.ps1` before committing.
+- Include `platform-plugin-api` in reactor `-pl` lists because `platform-web` depends on it.
+
+## Completed work
+
+### 1. Test infrastructure decision - DONE
+
+- `createServerComponents(config, plugin)` is sufficient for downstream hosted-app integration tests.
+- Customers can pass their own `AppConfig` with a test database and get back a `ServerComponents` with `.app.http` and `.persistence.close()`.
+- `WebTest` is an internal test harness. Downstream apps should use their own test database setup plus `createServerComponents(config, plugin)`.
+- Documented in `MIGRATION.md` under "Full-stack web tests".
+- No separate test-fixtures/test-support module is needed at this time.
+
+### 2. Factory method compatibility/deprecation - DONE
+
+Added two safe deprecated overloads:
+
+- `createPersistenceComponents(config, pluginMigrationSource: String?)` in `PersistenceFactory.kt`
+  - Wraps the string location into `PluginMigrations(location = source)` and delegates to the current overload.
+  - `@ReplaceWith` points to `createPersistenceComponents(config, PluginMigrations?)`.
+
+- `createSecurityComponents(config, userRepository, ..., oauthRepository?, sessionRepository?)` in `SecurityComponents.kt`
+  - Calls without `emailService` default to `NoOpEmailService()`.
+  - `@ReplaceWith` points to the overload with explicit `emailService`.
+
+Not restored because the old API shape is ambiguous:
+
+- `createWebComponents(...)` with old `sessionService` shape.
+- `createCoreComponents(...)` with old parameter ordering.
+
+Downstream customers should migrate those calls to the current parameter list or use `createServerComponents(plugin = ...)`.
+
+### 3. Jackson/Flyway dependency story - DONE
+
+- Platform manages Jackson 2.21.4 via `jackson-bom` in root POM dependency management.
+- Flyway 11.20.3 brings Jackson 2.x transitively, so there is no conflict within the platform.
+- Dependency convergence and `banDuplicateClasses` are enforced by `maven-enforcer-plugin`.
+- Conflicts only appear when downstream consumers introduce Jackson 3.x alongside Flyway/Jackson 2.x.
+- Documented in `MIGRATION.md` under "Jackson and Flyway dependency compatibility".
+
+### 4. Migration guide documentation polish - DONE
+
+`MIGRATION.md` now includes:
+
+- Quick checklist for "1.6.x to 3.6.x".
+- Primary import paths.
+- Before/after examples for default route selection, plugin migrations, and route registration.
+- Deprecated factory overloads section.
+- Jackson/Flyway dependency compatibility section.
+
+### 5. Root-route ownership - DONE
+
+- `MIGRATION.md` explains that `HostedAppContribution.from(...)` grants `/` as a UI ownership prefix in `PluginHostedApp` mode.
+- API, admin, and asset ownership remain under explicit prefixes.
+- Regression coverage in `ServerComponentsIntegrationTest` verifies:
+  - `PluginHostedApp` can own `/`, `/dashboard`, and `/about`.
+  - `FullPlatformApp` still rejects root route ownership.
 
 ## Remaining work for #407
 
-### 1. Decide whether PR #410 is enough for test infrastructure
+### 6. Close or split issues after this recovery branch merges
 
-- After PR #410 merges, verify whether customers can write hosted-app integration tests without copying `WebTest` internals.
-- If not enough, design a real public test helper, likely one of:
-  - `TestServerComponentsBuilder`
-  - `createServerComponents(config, plugin, testOverrides)`
-  - a published test-fixtures/test-support module
-- Make sure the helper supports at least:
-  - explicit `AppConfig`
-  - hosted app/plugin instance
-  - test database config
-  - optional service/repository overrides for mocks
-  - deterministic cleanup/close behavior
-- Add customer-facing example tests.
-
-### 2. Factory method compatibility/deprecation path
-
-- Review old v1.6.x factory signatures called out in #407:
-  - `createPersistenceComponents(config, pluginMigrationSource)`
-  - `createSecurityComponents(...)` without required `emailService`
-  - `createWebComponents(...)` with old `sessionService` shape
-  - `createCoreComponents(...)` older parameter ordering/shape
-- Decide which compatibility overloads are technically safe to restore.
-- Add deprecated wrapper overloads only where behavior is unambiguous.
-- Each deprecated overload should include `ReplaceWith(...)` guidance or clear KDoc pointing to `createServerComponents(...)`.
-- Add compile tests or focused integration tests proving old-style calls still route to the current wiring where feasible.
-
-### 3. Jackson/Flyway dependency story
-
-- Native-image runtime reflection was fixed, but #407 also reports a downstream Jackson 2.x/3.x classpath conflict.
-- Reproduce the customer scenario if possible with a minimal downstream app using http4k + Flyway 12.
-- Decide on one path:
-  - manage the required Jackson versions in the platform dependency management/BOM,
-  - document exact downstream overrides,
-  - or investigate shading/relocation if dependency management is insufficient.
-- Add documentation to `MIGRATION.md` with the chosen workaround or supported dependency set.
-- Add a dependency convergence or sample-app check if practical.
-
-### 4. Documentation polish for migration guide
-
-- Review `MIGRATION.md` against every bullet in #407 and ensure each has a concrete answer.
-- Add a short "1.6.x to 3.6.x checklist" at the top.
-- Include import paths for the primary SPI:
-  - `io.github.rygel.outerstellar.platform.plugin.HostedApp`
-  - `io.github.rygel.outerstellar.platform.PluginMigrations`
-  - `io.github.rygel.outerstellar.platform.composition.PlatformMode`
-- Add a before/after route registration example using `contribute(context)` and `context.routes`.
-- Add a before/after migration example from deprecated `migrationLocation` to `migrations = PluginMigrations(...)`.
-
-### 5. Confirm root-route ownership is fully documented
-
-- Verify the docs explain that `PlatformMode.PluginHostedApp` grants `/` as the default UI ownership prefix.
-- Confirm examples include a hosted app registering `/`.
-- Add a regression test if a gap remains around `/`, `/dashboard`, and plugin-prefixed fallback routes.
-
-### 6. Close or split issues after PR #410
-
-- After PR #410 merges, reassess #407 item by item.
+- Reassess #407 item by item.
 - Close #376 if it is still open and PR #409 really completed it.
-- Close #408 if it is only tracking #376/#409 work and nothing remains.
+- Close #408 if it only tracked #376/#409 work and nothing remains.
 - For #407, either:
-  - keep it open until all items above are complete, or
-  - split remaining work into smaller issues and close #407 with links to those issues.
+  - close it if all reported migration pain points are accepted as addressed, or
+  - split any remaining work into smaller issues and close #407 with links.
 
-## Validation already run for PR #410
+## Validation
 
-- `mvn -pl platform-web -am test -Dtest=ServerComponentsIntegrationTest -Dexec.skip=true -Dsurefire.failIfNoSpecifiedTests=false`
-- `pwsh scripts/test.ps1`
-- `pwsh scripts/test-desktop.ps1`
+Focused validation on this recovery branch:
 
-## Notes
+```powershell
+mvn -pl platform-web -am test -Dtest=ServerComponentsIntegrationTest "-Dexec.skip=true" "-Dsurefire.failIfNoSpecifiedTests=false"
+```
 
-- PR #410 branch: `fix/issue-407-plugin-migration-followups`
-- Commit: `ef82f227 feat: support explicit config server components`
+Expected before merge:
+
+```powershell
+pwsh scripts/test.ps1
+pwsh scripts/test-desktop.ps1
+```

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/di/PersistenceFactory.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/di/PersistenceFactory.kt
@@ -107,6 +107,13 @@ fun createPersistenceComponents(config: AppConfig, pluginMigrations: PluginMigra
     )
 }
 
+@Deprecated(
+    "Use createPersistenceComponents(config, PluginMigrations?) instead.",
+    ReplaceWith("createPersistenceComponents(config, pluginMigrationSource?.let { PluginMigrations(location = it) })"),
+)
+fun createPersistenceComponents(config: AppConfig, pluginMigrationSource: String?): PersistenceComponents =
+    createPersistenceComponents(config, pluginMigrationSource?.let { PluginMigrations(location = it) })
+
 private fun runMigrations(ds: DataSource, config: AppConfig, pluginMigrations: PluginMigrations?) {
     if (!config.runtime.flywayEnabled) return
     migrate(ds)

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
@@ -8,6 +8,7 @@ import io.github.rygel.outerstellar.platform.persistence.PasswordResetRepository
 import io.github.rygel.outerstellar.platform.persistence.SessionRepository
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import io.github.rygel.outerstellar.platform.service.EmailService
+import io.github.rygel.outerstellar.platform.service.NoOpEmailService
 
 class SecurityComponents(
     val jwtService: JwtService,
@@ -22,6 +23,32 @@ class SecurityComponents(
     val sessionService: SessionService,
     val userAdminService: UserAdminService,
 )
+
+@Deprecated(
+    "Use createSecurityComponents with an explicit emailService parameter.",
+    ReplaceWith(
+        "createSecurityComponents(config, userRepository, auditRepository, resetRepository, apiKeyRepository, NoOpEmailService(), oauthRepository, sessionRepository)"
+    ),
+)
+fun createSecurityComponents(
+    config: AppConfig,
+    userRepository: UserRepository,
+    auditRepository: AuditRepository? = null,
+    resetRepository: PasswordResetRepository? = null,
+    apiKeyRepository: ApiKeyRepository? = null,
+    oauthRepository: OAuthRepository? = null,
+    sessionRepository: SessionRepository? = null,
+): SecurityComponents =
+    createSecurityComponents(
+        config = config,
+        userRepository = userRepository,
+        auditRepository = auditRepository,
+        resetRepository = resetRepository,
+        apiKeyRepository = apiKeyRepository,
+        emailService = NoOpEmailService(),
+        oauthRepository = oauthRepository,
+        sessionRepository = sessionRepository,
+    )
 
 fun createSecurityComponents(
     config: AppConfig,

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/ServerComponentsIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/ServerComponentsIntegrationTest.kt
@@ -32,6 +32,101 @@ class ServerComponentsIntegrationTest : WebTest() {
         }
     }
 
+    @Test
+    fun `hosted app in PluginHostedApp mode owns root route`() {
+        val config = testConfig.copy(platformMode = PlatformMode.PluginHostedApp)
+        val app = rootOwningApp()
+        val components = createServerComponents(config = config, plugin = app)
+
+        try {
+            val rootResponse = components.app.http!!(Request(GET, "/"))
+            assertThat(rootResponse, hasStatus(Status.OK))
+            assertThat(rootResponse.bodyString(), equalTo("root-owned"))
+
+            val dashboardResponse = components.app.http!!(Request(GET, "/dashboard"))
+            assertThat(dashboardResponse, hasStatus(Status.OK))
+            assertThat(dashboardResponse.bodyString(), equalTo("dashboard"))
+
+            val aboutResponse = components.app.http!!(Request(GET, "/about"))
+            assertThat(aboutResponse, hasStatus(Status.OK))
+            assertThat(aboutResponse.bodyString(), equalTo("about"))
+        } finally {
+            components.persistence.close()
+        }
+    }
+
+    @Test
+    fun `hosted app with FullPlatformApp mode cannot register root route`() {
+        val thrown =
+            org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+                val config = testConfig.copy(platformMode = PlatformMode.FullPlatformApp)
+                createServerComponents(config = config, plugin = rootClaimingFullModeApp())
+            }
+        assert(thrown.message!!.contains("outside hosted app"))
+    }
+
+    private fun rootClaimingFullModeApp(): HostedApp =
+        object : HostedApp {
+            override val id = "root-claim"
+            override val appLabel = "Root Claim"
+            override val mode = PlatformMode.FullPlatformApp
+
+            override fun contribute(context: HostedAppContributionContext) {
+                val rootRoute =
+                    "/" meta
+                        {
+                            summary = "Root"
+                        } bindContract
+                        GET to
+                        { _: Request ->
+                            Response(Status.OK).body("should-not-work")
+                        }
+                context.routes.publicUi(rootRoute, "Root", "/")
+            }
+        }
+
+    private fun rootOwningApp(): HostedApp =
+        object : HostedApp {
+            override val id = "root-owner"
+            override val appLabel = "Root Owner"
+            override val mode = PlatformMode.PluginHostedApp
+
+            override fun contribute(context: HostedAppContributionContext) {
+                val rootRoute =
+                    "/" meta
+                        {
+                            summary = "Root"
+                        } bindContract
+                        GET to
+                        { _: Request ->
+                            Response(Status.OK).body("root-owned")
+                        }
+                context.routes.publicUi(rootRoute, "Root", "/")
+
+                val dashboardRoute =
+                    "/dashboard" meta
+                        {
+                            summary = "Dashboard"
+                        } bindContract
+                        GET to
+                        { _: Request ->
+                            Response(Status.OK).body("dashboard")
+                        }
+                context.routes.publicUi(dashboardRoute, "Dashboard", "/dashboard")
+
+                val aboutRoute =
+                    "/about" meta
+                        {
+                            summary = "About"
+                        } bindContract
+                        GET to
+                        { _: Request ->
+                            Response(Status.OK).body("about")
+                        }
+                context.routes.publicUi(aboutRoute, "About", "/about")
+            }
+        }
+
     private fun configProbeApp(): HostedApp =
         object : HostedApp {
             override val id = "config-probe"


### PR DESCRIPTION
## Summary

This recovers the Issue #407 follow-up work that was left only on the deleted `fix/issue-407-plugin-migration-followups` branch after PR #410 merged.

Changes included:

- Re-add safe deprecated overloads for `createPersistenceComponents(config, pluginMigrationSource: String?)` and `createSecurityComponents(...)` without an explicit `emailService`.
- Restore the migration-guide polish for checklist/imports, root-route ownership, route/migration before-after examples, deprecated overload docs, and Jackson/Flyway compatibility notes.
- Add `ServerComponentsIntegrationTest` coverage proving `PluginHostedApp` can own `/`, `/dashboard`, and `/about`, while `FullPlatformApp` still rejects root route ownership.
- Update `TODO.md` to reflect that PR #410 is merged and this is a recovery branch for the missing follow-up commit.

## Root Cause

PR #410 merged only the explicit-config `createServerComponents` work. The later local commit `3b7d327f` was still on the PR branch when the remote branch was deleted, so `origin/develop` never received those follow-ups.

## Validation

- `mvn -pl platform-web -am test -Dtest=ServerComponentsIntegrationTest "-Dexec.skip=true" "-Dsurefire.failIfNoSpecifiedTests=false"`
- `pwsh scripts/test.ps1`
- `pwsh scripts/test-desktop.ps1`