### PR TITLE
Move i18n into platform

### DIFF
--- a/.github/workflows/ci-docker-e2e.yml
+++ b/.github/workflows/ci-docker-e2e.yml
@@ -7,6 +7,7 @@ on:
       - 'docker/**'
       - 'platform-jte-extensions/**'
       - 'platform-plugin-api/**'
+      - 'outerstellar-i18n/**'
       - 'platform-web/**'
       - 'pom.xml'
   pull_request:
@@ -15,6 +16,7 @@ on:
       - 'docker/**'
       - 'platform-jte-extensions/**'
       - 'platform-plugin-api/**'
+      - 'outerstellar-i18n/**'
       - 'platform-web/**'
       - 'pom.xml'
   workflow_dispatch:
@@ -121,7 +123,7 @@ jobs:
         run: |
           mvn install -N -q
           mvn install \
-            -pl platform-jte-extensions,platform-core,platform-plugin-api,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web \
+            -pl platform-jte-extensions,outerstellar-i18n,platform-core,platform-plugin-api,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web \
             -DskipTests -Dexec.skip=true -q \
             -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true \
             -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true \

--- a/.github/workflows/ci-native-image.yml
+++ b/.github/workflows/ci-native-image.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'docker/Dockerfile.build'
       - 'platform-web/**'
+      - 'outerstellar-i18n/**'
       - 'platform-core/**'
       - 'platform-security/**'
       - 'platform-persistence-jdbi/**'
@@ -17,6 +18,7 @@ on:
     paths:
       - 'docker/Dockerfile.build'
       - 'platform-web/**'
+      - 'outerstellar-i18n/**'
       - 'platform-core/**'
       - 'platform-security/**'
       - 'platform-persistence-jdbi/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
         with:
           path: |
             platform-jte-extensions/target/
+            outerstellar-i18n/target/
             platform-core/target/
             platform-plugin-api/target/
             platform-test-infrastructure/target/
@@ -94,7 +95,7 @@ jobs:
       matrix:
         include:
           - modules: core+security+sync
-            pl: platform-core,platform-security,platform-sync-client
+            pl: outerstellar-i18n,platform-core,platform-security,platform-sync-client
           - modules: persistence
             pl: platform-persistence-jdbi
           - modules: web
@@ -124,6 +125,7 @@ jobs:
         with:
           path: |
             platform-jte-extensions/target/
+            outerstellar-i18n/target/
             platform-core/target/
             platform-plugin-api/target/
             platform-test-infrastructure/target/
@@ -136,7 +138,7 @@ jobs:
       - name: Install parent POM and dependencies
         run: >
           mvn install -N -q
-          && mvn install -pl platform-jte-extensions,platform-core,platform-plugin-api,platform-security,platform-test-infrastructure,platform-sync-client,platform-persistence-jdbi
+          && mvn install -pl platform-jte-extensions,outerstellar-i18n,platform-core,platform-plugin-api,platform-security,platform-test-infrastructure,platform-sync-client,platform-persistence-jdbi
           -DskipTests -q
           -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true
           -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true
@@ -190,6 +192,7 @@ jobs:
         with:
           path: |
             platform-jte-extensions/target/
+            outerstellar-i18n/target/
             platform-core/target/
             platform-plugin-api/target/
             platform-test-infrastructure/target/
@@ -206,7 +209,7 @@ jobs:
         run: >
           mvn install -N -q
           && mvn install
-          -pl outerstellar-i18n-validator,outerstellar-i18n-validator-maven-plugin,platform-core,platform-plugin-api,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-security
+          -pl outerstellar-i18n,outerstellar-i18n-validator,outerstellar-i18n-validator-maven-plugin,platform-core,platform-plugin-api,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-security
           -DskipTests -q
           -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true
           -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true
@@ -253,6 +256,7 @@ jobs:
         with:
           path: |
             platform-jte-extensions/target/
+            outerstellar-i18n/target/
             platform-core/target/
             platform-plugin-api/target/
             platform-test-infrastructure/target/
@@ -266,7 +270,7 @@ jobs:
         run: >
           mvn install -N -q
           && mvn install
-          -pl platform-jte-extensions,platform-core,platform-plugin-api,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-security,platform-web
+          -pl platform-jte-extensions,outerstellar-i18n,platform-core,platform-plugin-api,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-security,platform-web
           -DskipTests -Dexec.skip=true -q
           -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true
           -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true
@@ -339,6 +343,7 @@ jobs:
         with:
           path: |
             platform-jte-extensions/target/
+            outerstellar-i18n/target/
             platform-core/target/
             platform-plugin-api/target/
             platform-test-infrastructure/target/
@@ -351,7 +356,7 @@ jobs:
       - name: Install parent POM and dependencies
         run: >
           mvn install -N -q
-          && mvn install -pl platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi
+          && mvn install -pl outerstellar-i18n,platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi
           -DskipTests -q
           -Ddetekt.skip=true -Dcheckstyle.skip=true -Dpmd.skip=true
           -Dcpd.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ This project uses **synchronous blocking I/O** with a planned migration to **Jav
 
 ```
 platform-core              Domain models, services, configuration (AppConfig, RuntimeConfig), composition model types
+outerstellar-i18n          ResourceBundle-backed I18nService runtime module
 platform-plugin-api        Hosted-app SPI, plugin-facing DTOs, contribution contexts, facades
 platform-security          Auth, permissions, User/UserRepository, OAuth, API keys, JWT
 platform-persistence-jdbi  JDBI repositories + Flyway migrations
@@ -132,7 +133,7 @@ pwsh scripts/test.ps1 -TimeoutMinutes 10 -Modules platform-core
 # Full build excluding desktop modules (PowerShell)
 # NOTE: `-pl,!platform-desktop,!platform-desktop-javafx` does NOT work via PowerShell + cmd.exe
 # Use explicit module list instead:
-mvn clean verify -T4 -pl platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
+mvn clean verify -T4 -pl outerstellar-i18n,platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
 
 # Run a specific test in a specific module (ALWAYS use -am to rebuild upstream modules)
 mvn -pl platform-web -am test -Dtest=HealthCheckIntegrationTest
@@ -158,7 +159,7 @@ mvn -pl platform-web test
 mvn -pl platform-web -am test
 
 # Full reactor build (always safe, no -am needed)
-mvn clean verify -T4 -pl platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
+mvn clean verify -T4 -pl outerstellar-i18n,platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
 ```
 
 ### Desktop Tests in Podman
@@ -182,6 +183,15 @@ podman run --rm --network host `
   outerstellar-test-desktop
 ```
 
+### Dockerfile module list maintenance
+
+`docker/Dockerfile.build` has dependency-cache stages that copy only `pom.xml` files before the full source tree. Whenever the parent `pom.xml` module list changes, update **both** partial-POM copy lists in `Dockerfile.build`:
+
+- `deps` stage for web/JVM/native builds
+- `desktop-deps` stage for desktop test builds
+
+If a declared child module is missing from these partial copy lists, Maven fails during the cache warmup stage with `Child module /app/<module> does not exist`. Do not ignore that as harmless cache noise; fix the Dockerfile so the wrapper scripts stay clean and future builds use the intended dependency cache.
+
 ### Common Issue: Stale Bytecode
 
 After any `mvn clean install -DskipTests` that changes compiled production code in a dependency module, the dependent module's test classpath may hold stale classes. Always do `mvn clean test` when cross-module changes are involved.
@@ -190,9 +200,17 @@ After any `mvn clean install -DskipTests` that changes compiled production code 
 
 There are TWO `UserRole` enums — one in `platform-core` (model package) and one in `platform-security` (security package). Module dependencies cause `platform-web` and `platform-desktop` to sometimes resolve the wrong one during incremental compilation. Clean build (`mvn clean compile`) resolves this.
 
-### Modules that depend on external GitHub Packages
+### Common Issue: Kotlin companion SpotBugs false positives
 
-Only the external `outerstellar-i18n` artifact still resolves from GitHub Packages (`maven.pkg.github.com/rygel/outerstellar-framework`). CI keeps `GH_PACKAGES_TOKEN` for that remaining dependency, and local machines still need a `github-rygel` server entry in `~/.m2/settings.xml`. The validator library and validator Maven plugin now live in this repository, so they should not be treated as external package dependencies anymore.
+SpotBugs can report `MS_EXPOSE_REP` on Kotlin `Companion` classes even when a method returns a defensive copy. First fix the API if it really exposes mutable state. If the warning remains attached to a generated `...$Companion` class, add a narrow class-specific match to `config/spotbugs-exclude.xml`, following the existing `WebContext$Companion`, `RequestContext$Companion`, and `PasswordResetService$Companion` examples. Do not add package-wide SpotBugs exclusions for new code.
+
+### Common Issue: PowerShell UTF8NoBOM
+
+Windows PowerShell 5 does not support `Set-Content -Encoding UTF8NoBOM`. Scripts that need UTF-8 without BOM must use `[System.Text.UTF8Encoding]::new($false)` with `System.IO.File` APIs so they work in both Windows PowerShell and PowerShell 7.
+
+### External GitHub Packages
+
+All Outerstellar-owned runtime artifacts now build from this repository, including `outerstellar-i18n`, the validator library, and the validator Maven plugin. GitHub Packages credentials are only needed for publish workflows, not for normal local dependency resolution.
 
 ## Maven profile conventions
 
@@ -301,7 +319,7 @@ Full test architecture and patterns: **[docs/testing.md](docs/testing.md)**.
   - `mvn -pl platform-web test -Dexec.skip=true`
 - **Full reactor must exclude desktop modules** when running locally:
   ```bash
-  mvn clean verify -T4 -pl platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
+  mvn clean verify -T4 -pl outerstellar-i18n,platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
   ```
 - Desktop tests via Podman (see Podman section above).
 - Playwright E2E tests are tagged `@Tag("e2e")` and run in CI via Docker E2E workflow.
@@ -401,7 +419,7 @@ Before every commit, the following MUST be true:
 
 1. **All non-desktop tests pass locally.** Run the full reactor build:
    ```powershell
-   mvn clean verify -T4 -pl platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
+   mvn clean verify -T4 -pl outerstellar-i18n,platform-core,platform-security,platform-test-infrastructure,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
    ```
    If any test fails, fix it before committing. Do not commit failing tests.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you are upgrading an existing hosted app, see **[MIGRATION.md](MIGRATION.md)*
 ### Key Architectural Features
 
 - **Plugin Composition Model**: Plugins control what platform UI to include via `PlatformMode` (`FullPlatformApp`, `PluginHostedApp`, `HeadlessKernel`). Route ownership, conflict detection, and startup diagnostics come built-in.
-- **Multi-Module Architecture**: `platform-core`, `platform-plugin-api`, `platform-persistence-jdbi`, `platform-sync-client`, `platform-security`, `platform-web`, `platform-desktop`, and `platform-seed` for clear separation of concerns.
+- **Multi-Module Architecture**: `outerstellar-i18n`, `platform-core`, `platform-plugin-api`, `platform-persistence-jdbi`, `platform-sync-client`, `platform-security`, `platform-web`, `platform-desktop`, and `platform-seed` for clear separation of concerns.
 - **Transactional Outbox Pattern**: Ensures atomicity and reliability for background tasks and data synchronization.
 - **Observability**: Integrated with **OpenTelemetry** for distributed tracing and **Micrometer** for real-time metrics.
 - **Type-Safe Configuration**: Uses **Hoplite** for multi-environment configuration from YAML + env vars.
@@ -23,6 +23,7 @@ If you are upgrading an existing hosted app, see **[MIGRATION.md](MIGRATION.md)*
 ### Project Structure
 
 - `platform-core`: Domain models, service interfaces, shared business logic, composition model types.
+- `outerstellar-i18n`: ResourceBundle-backed runtime translation service.
 - `platform-plugin-api`: Hosted-app SPI and plugin-facing DTOs for the composition model.
 - `platform-persistence-jdbi`: Database implementation using JDBI and Flyway migrations.
 - `platform-sync-client`: Shared DTOs and client logic for synchronization between components.

--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -34,6 +34,10 @@
         <Bug pattern="MS_EXPOSE_REP"/>
     </Match>
     <Match>
+        <Class name="io.github.rygel.outerstellar.i18n.Language$Companion"/>
+        <Bug pattern="MS_EXPOSE_REP"/>
+    </Match>
+    <Match>
         <Package name="~io\.github\.rygel\.outerstellar\.platform\.model(\..*)?"/>
         <Bug pattern="EI_EXPOSE_REP"/>
     </Match>

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -29,6 +29,9 @@ RUN apt-get update && \
 
 COPY pom.xml .
 COPY platform-jte-extensions/pom.xml platform-jte-extensions/
+COPY outerstellar-i18n/pom.xml outerstellar-i18n/
+COPY outerstellar-i18n-validator/pom.xml outerstellar-i18n-validator/
+COPY outerstellar-i18n-validator-maven-plugin/pom.xml outerstellar-i18n-validator-maven-plugin/
 COPY platform-core/pom.xml platform-core/
 COPY platform-plugin-api/pom.xml platform-plugin-api/
 COPY platform-security/pom.xml platform-security/
@@ -122,6 +125,9 @@ RUN apt-get update && \
 WORKDIR /app
 COPY pom.xml .
 COPY platform-jte-extensions/pom.xml platform-jte-extensions/
+COPY outerstellar-i18n/pom.xml outerstellar-i18n/
+COPY outerstellar-i18n-validator/pom.xml outerstellar-i18n-validator/
+COPY outerstellar-i18n-validator-maven-plugin/pom.xml outerstellar-i18n-validator-maven-plugin/
 COPY platform-core/pom.xml platform-core/
 COPY platform-plugin-api/pom.xml platform-plugin-api/
 COPY platform-security/pom.xml platform-security/

--- a/docker/run-desktop-tests.sh
+++ b/docker/run-desktop-tests.sh
@@ -21,7 +21,7 @@ echo "Using container runtime: $RUNTIME"
 # Prevent Git Bash from mangling paths on Windows
 export MSYS_NO_PATHCONV=1
 
-# Find Maven settings.xml for the remaining GitHub Packages dependency (`outerstellar-i18n`).
+# Mount Maven settings.xml when available so publish credentials and private mirrors still work.
 # Do NOT mount the full .m2/repository — Windows-to-Linux volume mounts hang Podman.
 SETTINGS_FILE=""
 MOUNT_SOURCE=""
@@ -49,7 +49,7 @@ if [ -n "$SETTINGS_FILE" ]; then
     MOUNT_ARGS+=("-v" "$MOUNT_SOURCE:/root/.m2/settings.xml:ro")
     echo "Mounting Maven settings from: $SETTINGS_FILE"
 else
-    echo "WARNING: No settings.xml found — resolving the remaining outerstellar-i18n GitHub Packages dependency will fail inside container"
+    echo "No settings.xml found; continuing with public Maven repositories only"
 fi
 
 CONTAINER_ARGS=(

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -7,7 +7,7 @@
 - **PostgreSQL 18** (via Podman/Docker or local install)
 - **Node.js** (for Tailwind CSS build)
 
-The build still resolves the external `outerstellar-i18n` artifact from GitHub Packages. Ensure your `settings.xml` includes the `github-rygel` server entry with a Personal Access Token until that remaining dependency is migrated. The validator library and Maven plugin now build from this repository.
+All Outerstellar-owned runtime modules, including `outerstellar-i18n`, build from this repository. GitHub Packages credentials are only needed for publishing workflows, not for normal local dependency resolution.
 
 ## Quick Start
 
@@ -31,6 +31,7 @@ The web app starts on `http://localhost:8080`. A first-boot admin user is create
 
 ```
 platform-core              Domain models, services, configuration
+outerstellar-i18n          ResourceBundle-backed runtime translation service
 platform-plugin-api        Hosted-app SPI and plugin-facing shell/admin DTOs
 platform-persistence-jdbi  JDBI repositories + Flyway migrations
 platform-security          Auth, permissions, OAuth, API keys
@@ -223,7 +224,7 @@ Message bundles in `platform-core/src/main/resources/`:
 
 Key convention: `web.*` for web UI, `swing.*` for desktop UI. Use `{0}` or `{name}` for parameter injection.
 
-The `i18n-validator-maven-plugin` validates key consistency across bundles at build time.
+The `outerstellar-i18n` module provides the runtime `I18nService`. The `i18n-validator-maven-plugin` validates key consistency across bundles at build time.
 
 ## Theming
 
@@ -333,6 +334,8 @@ All enforced at `verify` phase:
 | SpotBugs | Bug detection |
 | Detekt | Kotlin static analysis |
 | Maven Enforcer | Dependency convergence, Java version |
+
+Kotlin companion objects can produce SpotBugs `MS_EXPOSE_REP` false positives on generated `...$Companion` classes. Fix real representation exposure first. If the warning remains on generated companion bytecode, add a narrow class-specific entry to `config/spotbugs-exclude.xml`; do not add package-wide exclusions for new code.
 
 Run all checks:
 

--- a/docs/adr/0003-move-i18n-into-platform.md
+++ b/docs/adr/0003-move-i18n-into-platform.md
@@ -1,0 +1,27 @@
+# ADR-0003: Move i18n Into Platform
+
+## Status: Accepted
+
+## Context
+
+`outerstellar-i18n` was the last runtime dependency resolved from the old `outerstellar-framework` GitHub Packages feed. The validator library and validator Maven plugin already live in this repository, while the translation bundles themselves live in `platform-core/src/main/resources`.
+
+The remaining i18n runtime API is small: `I18nService`, `Language`, `ParameterInjector`, and `Translatable`. It is used by platform core text resolution, the web shell, Swing, JavaFX, and tests. There is no evidence in this repository that it is independently reused outside the platform, and keeping it external forces every local and CI build to keep access to the old framework package feed.
+
+## Decision
+
+Move `outerstellar-i18n` into `outerstellar-platform` as a first-class Maven module and publish it from this repository.
+
+The artifact coordinates remain `io.github.rygel:outerstellar-i18n`, and the package remains `io.github.rygel.outerstellar.i18n`, so existing source imports do not change. Versioning now follows the platform release version instead of the old framework version line.
+
+The platform build no longer declares the `outerstellar-framework` GitHub Packages repository for runtime dependencies.
+
+## Consequences
+
+Platform builds become self-contained with respect to Outerstellar-owned runtime libraries. Local contributors no longer need a GitHub Packages token for `outerstellar-framework` just to resolve i18n.
+
+The old framework repository no longer owns active platform runtime code. Any future i18n change is reviewed, tested, versioned, and released with the platform.
+
+Consumers that rely on platform dependency management get the migrated i18n artifact automatically. Consumers that depend on `outerstellar-i18n` directly should move to the platform-published version line.
+
+Keeping the existing package name preserves source compatibility for callers, but it means `io.github.rygel.outerstellar.i18n` remains an intentional exception to the platform package-root convention.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,8 @@ Decisions that are **expensive to reverse** or that **constrain future work**. T
 | ADR | Title | Status |
 |-----|-------|--------|
 | 0001 | UTC-only timestamps in the database | Accepted |
+| 0002 | Native image Docker build layering | Accepted |
+| 0003 | Move i18n into platform | Accepted |
 
 ## Format
 

--- a/docs/architecture-review.md
+++ b/docs/architecture-review.md
@@ -33,11 +33,11 @@ PostgreSQL is the sole database engine for this platform. It provides robust pro
 The project uses:
 
 - `io.github.rygel.outerstellar.platform` — the project's own code
-- `io.github.rygel.outerstellar.i18n` — the remaining external Outerstellar library package, consumed as a Maven dependency
+- `io.github.rygel.outerstellar.i18n` — the i18n runtime API package, preserved for compatibility after moving the artifact into this repository
 
-The `io.github.rygel.outerstellar.i18n` classes are external dependencies declared in the POM and resolved from Maven. They are not vendored — no source copies exist in this project.
+The `io.github.rygel.outerstellar.i18n` classes now live in the local `outerstellar-i18n` module. This package root is an intentional compatibility exception documented in ADR-0003.
 
-**Rule:** all project-owned code uses `io.github.rygel.outerstellar.platform`. The `io.github.rygel.outerstellar.i18n` namespace belongs to the external i18n library and must not be used for project-owned classes.
+**Rule:** all new project-owned code uses `io.github.rygel.outerstellar.platform`, except for source that intentionally belongs to the compatibility-preserving `outerstellar-i18n` module.
 
 ## Areas for improvement
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -215,7 +215,7 @@ This is meant to act as the default application shell for future pages.
 
 ### i18n
 
-The platform uses `outerstellar-i18n` for localization.
+The platform uses the in-repository `outerstellar-i18n` module for localization.
 
 Current bundles include:
 

--- a/docs/features/deployment.md
+++ b/docs/features/deployment.md
@@ -17,7 +17,7 @@ Production: Use a managed PostgreSQL service. Set `JDBC_URL`, `JDBC_USER`, `JDBC
 mvn clean install -DskipTests
 
 # Build with quality checks
-mvn clean verify -T4 -pl platform-core,platform-security,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
+mvn clean verify -T4 -pl outerstellar-i18n,platform-core,platform-security,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
 ```
 
 ## Run

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -266,6 +266,12 @@ podman run --rm --network host `
     outerstellar-test-desktop
 ```
 
+### Dockerfile dependency-cache stages
+
+The desktop wrapper builds `docker/Dockerfile.build --target desktop-test`. That Dockerfile has partial-POM dependency-cache stages which copy `pom.xml` files before the full source tree.
+
+When the Maven module list in the parent `pom.xml` changes, update every partial-POM copy list in `docker/Dockerfile.build`, including the `desktop-deps` stage. Otherwise the cache warmup command can fail with `Child module /app/<module> does not exist` before the real test stage runs. Treat that as a Dockerfile maintenance bug, even if the later full-source stage still passes.
+
 ## http4k Testing Modules
 
 The project uses four http4k testing modules for assertion quality and template verification:
@@ -341,32 +347,32 @@ See [Desktop Testing](#desktop-testing). Use Podman containers exclusively.
 ### Full reactor (non-desktop modules)
 
 ```powershell
-mvn clean verify -T4 -pl platform-core,platform-security,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
+mvn clean verify -T4 -pl outerstellar-i18n,platform-core,platform-security,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
 ```
 
 ### Single module
 
 ```powershell
-mvn -pl platform-web test
-mvn -pl platform-persistence-jdbi test
+mvn -pl platform-web -am test
+mvn -pl platform-persistence-jdbi -am test
 ```
 
 ### Specific test class
 
 ```powershell
-mvn -pl platform-web test -Dtest=HealthCheckIntegrationTest
+mvn -pl platform-web -am test -Dtest=HealthCheckIntegrationTest
 ```
 
 ### Skip CSS build (when npm hangs)
 
 ```powershell
-mvn -pl platform-web test -Dexec.skip=true
+mvn -pl platform-web -am test -Dexec.skip=true
 ```
 
 ### Fast compile (skip quality checks)
 
 ```powershell
-mvn -pl platform-web compile -Ddetekt.skip=true -Dspotbugs.skip=true -Dspotless.check.skip=true
+mvn -pl platform-web -am compile -Ddetekt.skip=true -Dspotbugs.skip=true -Dspotless.check.skip=true
 ```
 
 ### Desktop tests in Podman

--- a/outerstellar-i18n/pom.xml
+++ b/outerstellar-i18n/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.rygel</groupId>
+        <artifactId>outerstellar-platform-parent</artifactId>
+        <version>3.6.4</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>outerstellar-i18n</artifactId>
+    <name>Outerstellar i18n</name>
+    <description>ResourceBundle-backed translation engine used by Outerstellar Platform</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/outerstellar-i18n/src/main/kotlin/io/github/rygel/outerstellar/i18n/I18nService.kt
+++ b/outerstellar-i18n/src/main/kotlin/io/github/rygel/outerstellar/i18n/I18nService.kt
@@ -1,0 +1,124 @@
+package io.github.rygel.outerstellar.i18n
+
+import java.io.InputStream
+import java.net.URL
+import java.util.Locale
+import java.util.MissingResourceException
+import java.util.PropertyResourceBundle
+import java.util.ResourceBundle
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+
+class I18nService private constructor(private val baseName: String, private val classLoader: ClassLoader) {
+    private val bundleCache = ConcurrentHashMap<String, ResourceBundle>()
+    private val dynamicBundles = ConcurrentHashMap<String, ResourceBundle>()
+    private val listeners = CopyOnWriteArrayList<Translatable>()
+
+    @Volatile private var currentLocale: Locale = Locale.getDefault()
+
+    companion object {
+        @JvmStatic
+        @JvmName("create")
+        fun create(baseName: String): I18nService = I18nService(baseName, Thread.currentThread().contextClassLoader)
+
+        @JvmStatic
+        @JvmName("createWithClassLoader")
+        fun create(baseName: String, classLoader: ClassLoader): I18nService = I18nService(baseName, classLoader)
+
+        @JvmStatic
+        @JvmName("createWithLocale")
+        @JvmOverloads
+        fun create(
+            baseName: String,
+            locale: Locale,
+            classLoader: ClassLoader = Thread.currentThread().contextClassLoader,
+        ): I18nService {
+            val service = I18nService(baseName, classLoader)
+            service.setLocale(locale)
+            return service
+        }
+    }
+
+    fun setLocale(locale: Locale) {
+        currentLocale = locale
+        bundleCache.clear()
+        listeners.forEach { it.updateTexts() }
+    }
+
+    fun getLocale(): Locale = currentLocale
+
+    fun addListener(listener: Translatable) {
+        if (listener !in listeners) listeners.add(listener)
+    }
+
+    fun removeListener(listener: Translatable) {
+        listeners.remove(listener)
+    }
+
+    fun translate(key: String, vararg params: Any): String {
+        val template = findTemplate(key) ?: return key
+        return if (params.isEmpty()) template else ParameterInjector.inject(template, *params)
+    }
+
+    fun translateOrDefault(key: String, default: String, vararg params: Any): String {
+        val template = findTemplate(key) ?: return default
+        return if (params.isEmpty()) template else ParameterInjector.inject(template, *params)
+    }
+
+    fun hasKey(key: String): Boolean = findTemplate(key) != null
+
+    fun getKeys(): Set<String> {
+        val keys = mutableSetOf<String>()
+        dynamicBundles.values.forEach { keys.addAll(it.keySet()) }
+        try {
+            keys.addAll(getBundle().keySet())
+        } catch (_: Exception) {
+            // Missing bundles simply contribute no keys.
+        }
+        return keys
+    }
+
+    fun reload() {
+        bundleCache.clear()
+    }
+
+    fun loadFromStream(inputStream: InputStream, key: String = "dynamic") {
+        dynamicBundles[key] = PropertyResourceBundle(inputStream)
+    }
+
+    fun loadFromUrl(url: URL, key: String = "dynamic") {
+        url.openStream().use { inputStream -> loadFromStream(inputStream, key) }
+    }
+
+    fun loadFromClasspath(path: String, key: String = "dynamic") {
+        val inputStream =
+            classLoader.getResourceAsStream(path) ?: throw IllegalArgumentException("Resource not found: $path")
+        inputStream.use { stream -> loadFromStream(stream, key) }
+    }
+
+    private fun findTemplate(key: String): String? {
+        for (bundle in dynamicBundles.values) {
+            try {
+                return bundle.getString(key)
+            } catch (_: MissingResourceException) {
+                // Try the next overlay bundle.
+            }
+        }
+        return try {
+            getBundle().getString(key)
+        } catch (_: MissingResourceException) {
+            null
+        }
+    }
+
+    private fun getBundle(): ResourceBundle {
+        val key = "${currentLocale}_$baseName"
+        return bundleCache.getOrPut(key) {
+            try {
+                ResourceBundle.getBundle(baseName, currentLocale, classLoader)
+            } catch (_: MissingResourceException) {
+                ResourceBundle.getBundle(baseName, Locale.getDefault(), classLoader)
+            }
+        }
+    }
+}

--- a/outerstellar-i18n/src/main/kotlin/io/github/rygel/outerstellar/i18n/Language.kt
+++ b/outerstellar-i18n/src/main/kotlin/io/github/rygel/outerstellar/i18n/Language.kt
@@ -1,0 +1,22 @@
+package io.github.rygel.outerstellar.i18n
+
+import java.util.Locale
+
+data class Language(val displayName: String, val locale: Locale, val nativeName: String) {
+    override fun toString(): String = displayName
+
+    companion object {
+        private val languages =
+            listOf(
+                Language("English", Locale.ENGLISH, "English"),
+                Language("Deutsch", Locale.GERMAN, "Deutsch"),
+                Language("Français", Locale.FRENCH, "Français"),
+            )
+
+        @JvmStatic fun availableLanguages(): List<Language> = ArrayList(languages)
+
+        @JvmStatic fun isSupported(locale: Locale): Boolean = languages.any { it.locale.language == locale.language }
+
+        @JvmStatic fun forLocale(locale: Locale): Language? = languages.find { it.locale.language == locale.language }
+    }
+}

--- a/outerstellar-i18n/src/main/kotlin/io/github/rygel/outerstellar/i18n/ParameterInjector.kt
+++ b/outerstellar-i18n/src/main/kotlin/io/github/rygel/outerstellar/i18n/ParameterInjector.kt
@@ -1,0 +1,25 @@
+package io.github.rygel.outerstellar.i18n
+
+object ParameterInjector {
+    private val placeholder = Regex("\\{(\\d+)}")
+
+    @JvmStatic
+    @JvmName("inject")
+    fun inject(template: String, vararg params: Any): String {
+        if (params.isEmpty()) return template
+        return placeholder.replace(template) { match ->
+            val index = match.groupValues[1].toInt()
+            if (index in params.indices) params[index].toString() else match.value
+        }
+    }
+
+    @JvmStatic
+    @JvmName("injectToList")
+    fun inject(template: String, params: List<Any>): String {
+        if (params.isEmpty()) return template
+        return placeholder.replace(template) { match ->
+            val index = match.groupValues[1].toInt()
+            if (index in params.indices) params[index].toString() else match.value
+        }
+    }
+}

--- a/outerstellar-i18n/src/main/kotlin/io/github/rygel/outerstellar/i18n/Translatable.kt
+++ b/outerstellar-i18n/src/main/kotlin/io/github/rygel/outerstellar/i18n/Translatable.kt
@@ -1,0 +1,5 @@
+package io.github.rygel.outerstellar.i18n
+
+fun interface Translatable {
+    fun updateTexts()
+}

--- a/outerstellar-i18n/src/test/kotlin/io/github/rygel/outerstellar/i18n/I18nServiceTest.kt
+++ b/outerstellar-i18n/src/test/kotlin/io/github/rygel/outerstellar/i18n/I18nServiceTest.kt
@@ -1,0 +1,60 @@
+package io.github.rygel.outerstellar.i18n
+
+import java.util.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class I18nServiceTest {
+    @Test
+    fun `translates resource bundle keys and injects parameters`() {
+        val i18n = I18nService.create("test-messages", Locale.ENGLISH)
+
+        assertEquals("Hello Alice", i18n.translate("greeting", "Alice"))
+        assertEquals("missing.key", i18n.translate("missing.key"))
+        assertEquals("Fallback", i18n.translateOrDefault("missing.key", "Fallback"))
+    }
+
+    @Test
+    fun `locale switching clears cache and notifies listeners`() {
+        val i18n = I18nService.create("test-messages", Locale.ENGLISH)
+        var calls = 0
+        val listener = Translatable { calls++ }
+        i18n.addListener(listener)
+
+        i18n.setLocale(Locale.FRENCH)
+
+        assertEquals(Locale.FRENCH, i18n.getLocale())
+        assertEquals("Bonjour Alice", i18n.translate("greeting", "Alice"))
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `dynamic bundles override resource bundle values`() {
+        val i18n = I18nService.create("test-messages", Locale.ENGLISH)
+        val override = "greeting=Override {0}\nextra=Extra value\n".byteInputStream()
+
+        i18n.loadFromStream(override)
+
+        assertEquals("Override Alice", i18n.translate("greeting", "Alice"))
+        assertEquals("Extra value", i18n.translate("extra"))
+        assertTrue(i18n.hasKey("extra"))
+        assertTrue("extra" in i18n.getKeys())
+    }
+
+    @Test
+    fun `parameter injector leaves missing indexes intact`() {
+        assertEquals("A one {1}", ParameterInjector.inject("A {0} {1}", "one"))
+        assertEquals("A one two", ParameterInjector.inject("A {0} {1}", listOf("one", "two")))
+    }
+
+    @Test
+    fun `language lookup is based on locale language`() {
+        assertTrue(Language.isSupported(Locale.CANADA_FRENCH))
+        assertEquals("English", Language.forLocale(Locale.US)?.displayName)
+        assertNull(Language.forLocale(Locale.of("es")))
+        assertFalse(Language.availableLanguages().isEmpty())
+    }
+}

--- a/outerstellar-i18n/src/test/resources/test-messages.properties
+++ b/outerstellar-i18n/src/test/resources/test-messages.properties
@@ -1,0 +1,2 @@
+greeting=Hello {0}
+only.default=Default

--- a/outerstellar-i18n/src/test/resources/test-messages_fr.properties
+++ b/outerstellar-i18n/src/test/resources/test-messages_fr.properties
@@ -1,0 +1,1 @@
+greeting=Bonjour {0}

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
 
     <modules>
         <module>platform-jte-extensions</module>
+        <module>outerstellar-i18n</module>
         <module>outerstellar-i18n-validator</module>
         <module>outerstellar-i18n-validator-maven-plugin</module>
         <module>platform-core</module>
@@ -57,7 +58,6 @@
         <java.version>21</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <kotlin.version>2.3.10</kotlin.version>
-        <outerstellar.version>1.0.14</outerstellar.version>
         <http4k.version>6.48.0.0</http4k.version>
         <netty.version>4.2.14.Final</netty.version>
         <flyway.version>11.20.3</flyway.version>
@@ -132,26 +132,6 @@
         <runtime.dev.mode>false</runtime.dev.mode>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>central</id>
-            <name>Maven Central</name>
-            <url>https://repo.maven.apache.org/maven2</url>
-        </repository>
-        <repository>
-            <id>github-rygel</id>
-            <name>Rygel GitHub Packages</name>
-            <url>https://maven.pkg.github.com/rygel/outerstellar-framework</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <layout>default</layout>
-        </repository>
-    </repositories>
-
     <distributionManagement>
         <repository>
             <id>github-rygel</id>
@@ -184,6 +164,11 @@
             <dependency>
                 <groupId>io.github.rygel</groupId>
                 <artifactId>outerstellar-i18n-validator</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.rygel</groupId>
+                <artifactId>outerstellar-i18n</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -339,11 +324,6 @@
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-database-postgresql</artifactId>
                 <version>${flyway.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.github.rygel</groupId>
-                <artifactId>outerstellar-i18n</artifactId>
-                <version>${outerstellar.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>

--- a/scripts/generate-migration-manifest.ps1
+++ b/scripts/generate-migration-manifest.ps1
@@ -21,5 +21,6 @@ if ($parentDir -and -not (Test-Path -LiteralPath $parentDir)) {
     New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
 }
 
-$names | Set-Content -LiteralPath $OutputFile -Encoding UTF8NoBOM
+$utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+[System.IO.File]::WriteAllLines([System.IO.Path]::GetFullPath($OutputFile), [string[]]$names, $utf8NoBom)
 Write-Host "Generated manifest with $($names.Count) migrations -> $OutputFile"

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -29,7 +29,7 @@ pwsh scripts/test.ps1 -ExtraArgs "-DskipTests"
 
 param(
     [int]$TimeoutMinutes = 20,
-    [string]$Modules = "platform-core,platform-security,platform-test-infrastructure,platform-plugin-api,platform-persistence-jdbi,platform-sync-client,platform-jte-extensions,platform-web,platform-seed",
+    [string]$Modules = "outerstellar-i18n,platform-core,platform-security,platform-test-infrastructure,platform-plugin-api,platform-persistence-jdbi,platform-sync-client,platform-jte-extensions,platform-web,platform-seed",
     [switch]$SkipQuality,
     [string]$ExtraArgs = ""
 )


### PR DESCRIPTION
## Summary
- move `outerstellar-i18n` into this repository as a first-class Maven module while preserving artifact coordinates and package compatibility
- remove the old `outerstellar-framework` GitHub Packages dependency from normal local builds and update CI/module docs
- document ADR-0003, Dockerfile partial-POM maintenance, Kotlin companion SpotBugs handling, and PowerShell UTF-8 script compatibility

## Validation
- `mvn -pl outerstellar-i18n test`
- `pwsh scripts/test-desktop.ps1` (92 run, 0 failures, 1 skipped)
- `pwsh scripts/test.ps1`
- `git diff --check`

Closes #384