### PR TITLE
[codex] Improve hosted app authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 A Kotlin application platform for building plugin-hosted web and desktop products. The platform provides configuration, database migrations, authentication, session management, routing, and template rendering — plugins provide the product UI and business logic.
 
-If you are upgrading an existing hosted app, see **[MIGRATION.md](MIGRATION.md)** for the 1.6.x -> 3.6.4 migration path.
+If you are building a hosted app, start with the **[Plugin Author Guide](docs/features/plugin-system.md)**. If you are
+upgrading an existing hosted app, see **[MIGRATION.md](MIGRATION.md)** for the 1.6.x -> 3.6.4 migration path.
 
 ---
 
@@ -129,25 +130,30 @@ enum class PlatformMode {
 }
 ```
 
-#### Creating a Plugin
+#### Creating a Hosted App
 
 ```kotlin
-class MyPlugin : PlatformPlugin {
+class MyHostedApp : HostedApp {
     override val id = "my-app"
     override val mode = PlatformMode.PluginHostedApp
 
-    override fun includePlatformPages() = setOf(
-        PlatformPageSets.SETTINGS,
-        PlatformPageSets.SEARCH,
-    )
+    override fun contribute(context: HostedAppContributionContext) {
+        context.platformPages.include(PlatformPageSets.SETTINGS, PlatformPageSets.SEARCH)
+        context.routes.publicUi(myHomeRoute, "Home page", "/")
+        context.navigation.item("Home", "/", "home-line")
+    }
+}
 
-    override fun routeRegistrations(context: HostedAppContext) = listOf(
-        PluginRouteRegistration(myHomeRoute, RouteGroup.PublicUi, "Home page"),
-    )
+class MyHostedAppContractTest {
+    @Test
+    fun `contribution is valid`() {
+        val diagnostics = HostedAppContract.diagnostics(MyHostedApp(), testHostedAppContext())
+        assertEquals(listOf("/"), diagnostics.routes.map { it.pathPattern })
+    }
 }
 
 // Start the server
-val components = createServerComponents(plugin = MyPlugin())
+val components = createServerComponents(plugin = MyHostedApp())
 ```
 
 At startup, the route registry logs a table showing all routes, their owners, and any conflicts. If two owners claim the same path, the server fails fast with a descriptive error.

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -115,12 +115,12 @@ The platform uses JDBI as its persistence layer, implementing repository interfa
 
 ## Plugin Development
 
-### PlatformPlugin Interface
+### HostedApp Interface
 
 Hosted app integrations should depend on `outerstellar-platform-plugin-api`. That module contains `HostedApp`,
 `HostedAppContext`, `HostedAppContributionContext`, and the compatibility aliases under `io.github...platform.web`.
 
-Plugins implement `PlatformPlugin` and register as a Koin `single`:
+Plugins implement `HostedApp` and are passed to the platform launcher or tests through `createServerComponents`:
 
 ```kotlin
 class MyPlugin : HostedApp {
@@ -132,7 +132,12 @@ class MyPlugin : HostedApp {
         context.routes.protectedUi(myDashboardRoute(), "Dashboard", "/dashboard")
     }
 }
+
+val components = createServerComponents(plugin = MyPlugin())
 ```
+
+See the [Plugin Author Guide](features/plugin-system.md) for route ownership rules, `HostedAppContract` tests,
+full-stack hosted-app tests, and diagnostics.
 
 ### What Plugins Can Do
 

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -12,7 +12,7 @@ Outerstellar is a full-stack web + desktop platform for team communication and c
 | [Desktop Client](desktop-client.md) | Swing UI, two-way sync, offline support |
 | [Configuration](configuration.md) | AppConfig, RuntimeConfig, env vars, profiles |
 | [SEO & Metadata](seo-metadata.md) | Open Graph, Twitter Card, JSON-LD, sitemap |
-| [Plugin System](plugin-system.md) | PlatformPlugin interface, migrations, templates |
+| [Plugin System](plugin-system.md) | HostedApp author guide, ownership, migrations, contract tests |
 | [Security](security.md) | Auth, CSRF, rate limiting, CSP, SSRF protection |
 | [API Reference](api-reference.md) | REST endpoints, WebSocket, sync protocol |
 | [Deployment](deployment.md) | JVM tuning, Docker, native-image, profiles |

--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -1,87 +1,191 @@
-# Plugin System
+# Plugin Author Guide
 
-## Overview
+Hosted apps extend the platform through the `outerstellar-platform-plugin-api` module. New plugins should implement
+`HostedApp`; `PlatformPlugin` remains only as a compatibility alias for older integrations.
 
-Hosted apps extend the platform via the `HostedApp` interface. `PlatformPlugin` remains as a compatibility alias for older integrations, but `HostedApp` and `HostedAppContext` are the primary API names. The public SPI now ships in the `outerstellar-platform-plugin-api` module so hosted apps do not need to depend on `platform-web`.
+For upgrade notes from the older plugin model, see [MIGRATION.md](../../MIGRATION.md).
 
-For step-by-step upgrade notes, see the repository's [migration guide](../../MIGRATION.md).
+## Dependency
 
-Hosted apps can contribute:
-- routes and filters
-- shell navigation, admin sections, banners, layout replacement, and assets
-- i18n/text overrides and template overrides
-- database migrations through `HostedApp.migrations`
+Plugin modules should depend on the public SPI instead of `platform-web`:
 
-## HostedApp Interface
+```xml
+<dependency>
+    <groupId>io.github.rygel</groupId>
+    <artifactId>outerstellar-platform-plugin-api</artifactId>
+    <version>${outerstellar-platform.version}</version>
+</dependency>
+```
+
+Only use `platform-web` in an application launcher or integration-test module that boots the real host with
+`createServerComponents`.
+
+## Minimal Hosted App
 
 ```kotlin
-interface HostedApp {
-    val id: String
-    val appLabel: String
-    val manifest: HostedAppManifest
-    val mode: PlatformMode
-    val migrations: PluginMigrations?
+import io.github.rygel.outerstellar.platform.composition.PlatformMode
+import io.github.rygel.outerstellar.platform.plugin.HostedApp
+import io.github.rygel.outerstellar.platform.plugin.HostedAppContributionContext
+import org.http4k.contract.bindContract
+import org.http4k.contract.meta
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status
 
-    fun contribute(context: HostedAppContributionContext) {}
-    fun routeRegistrations(context: HostedAppContext): List<PluginRouteRegistration> = emptyList()
-    fun filters(context: HostedAppContext): List<Filter> = emptyList()
-    fun adminSections(context: HostedAppContext): List<AdminSection> = emptyList()
-    fun bannerProviders(context: HostedAppContext): List<BannerProvider> = emptyList()
-    fun includePlatformPages(): Set<PlatformPageSets> = emptySet()
-    fun layoutRenderer(context: HostedAppContext): PluginLayoutRenderer? = null
+class ReportsApp : HostedApp {
+    override val id = "reports"
+    override val appLabel = "Reports"
+    override val mode = PlatformMode.PluginHostedApp
+
+    override fun contribute(context: HostedAppContributionContext) {
+        val home =
+            "/" meta { summary = "Reports home" } bindContract GET to
+                { _: Request -> Response(Status.OK).body("Reports") }
+
+        context.routes.publicUi(home, "Reports home", "/")
+        context.navigation.item("Reports", "/", "bar-chart")
+    }
 }
 ```
 
-## Plugin Context
+Prefer the typed `contribute(context)` API for new code. It groups the extension points in one place:
 
-`HostedAppContext` is the primary SPI context. `PluginContext` remains a compatibility alias to the same type and provides access to stable plugin-facing facades:
-- `app` (`config` compatibility alias) — safe app info only: `version`, `appBaseUrl`, `devMode`, `registrationEnabled`
-- `users` (`userRepository` alias) — `currentUser(request)`, `findById`, `findByUsername`, `findByEmail`
-- `analytics` — `identify`, `track`, `page`
-- `notifications` (`notificationService` alias) — create/list/count/mark/delete user notifications
-- `rendering` (`renderer` alias) — template renderer plus `renderShell(shell, bodyHtml)`
-- `security` (`apiKeyService` / `oauthService` aliases) — API key CRUD and OAuth user resolution
+| Need | Use |
+|---|---|
+| UI/API/admin routes | `context.routes.publicUi`, `protectedUi`, `api`, `admin` |
+| Static files | `context.routes.staticAssets`, `context.assets.stylesheet`, `context.assets.script` |
+| Shell navigation | `context.navigation.item` |
+| Platform pages | `context.platformPages.include(...)` |
+| Admin pages | `context.admin.section(...)` |
+| Banners | `context.banners.provider(...)` |
+| Layout replacement | `context.layout.replaceWith(...)` |
 
-Convenience helpers remain on the context itself:
-- `currentUser(request)` — authenticated user
-- `renderShell(shell, bodyHtml)` — wrap plugin HTML in the platform shell
+The older override methods such as `routeRegistrations(context)` still work, but `contribute(context)` is easier to
+test and keeps route ownership metadata beside the route.
 
-## Template Overrides
+## Route Ownership
 
-Plugins can override JTE templates by providing a `templateOverrides()` map. The key is the template name (e.g. `"LayoutHead.kte"`), the value is the full classpath to the replacement. A `PluginTemplateRenderer` composites the base renderer with overrides.
+Every contributed route must stay inside the prefixes declared by `HostedAppManifest.ownership`.
 
-## Database Migrations
+By default, plugin `reports` owns:
 
-Plugins declare migrations with `HostedApp.migrations`:
-- `location: String` — classpath location for Flyway migrations
-- `historyTable: String` — defaults to `flyway_plugin_history`
-- `migrationNames: List<String>` — optional explicit filenames for native-image classpath extraction
+| Group | Default prefixes |
+|---|---|
+| UI | `/reports`, `/plugin/reports` |
+| API | `/api/reports`, `/api/plugin/reports`, `/api/v1/reports`, `/api/v1/plugin/reports` |
+| Admin | `/admin/reports` |
+| Static assets | `/plugins/reports/assets` |
 
-Plugin migrations run after host migrations in a separate Flyway instance. Baseline version is 0 so V1 migrations execute on fresh databases.
+`PluginHostedApp` mode additionally grants `/` to UI routes only. That lets the hosted app own `/`, `/dashboard`, and
+other product UI routes. API, admin, and static asset routes do not get root ownership automatically.
+
+Use custom ownership only when the defaults do not match your product:
+
+```kotlin
+override val manifest =
+    HostedAppManifest(
+        id = id,
+        appLabel = appLabel,
+        ownership =
+            HostedAppOwnership(
+                uiPrefixes = listOf("/"),
+                apiPrefixes = listOf("/api/reports"),
+                adminPrefixes = listOf("/admin/reports"),
+                assetPrefixes = listOf("/assets/reports"),
+            ),
+    )
+```
+
+## Migrations
+
+Plugins with database tables declare isolated Flyway migrations:
 
 ```kotlin
 override val migrations =
     PluginMigrations(
-        location = "classpath:db/migration/my-plugin",
-        historyTable = "flyway_my_plugin_history",
+        location = "classpath:db/migration/reports",
+        historyTable = "flyway_reports_history",
         migrationNames = listOf("V1__init", "V2__seed"),
     )
 ```
 
-Older plugins can keep overriding `migrationLocation`, `migrationHistoryTable`, and `migrationNames` for now, but those compatibility properties are deprecated in favor of `migrations`.
+Plugin migrations run after platform migrations in a separate Flyway instance. Version numbers do not conflict with
+platform migrations because the history table is separate.
 
-## Route ownership in PluginHostedApp
+## SPI Contract Tests
 
-`HostedAppManifest.ownership` still defines the hosted app's declared route prefixes, but in `PlatformMode.PluginHostedApp` the platform grants `/` as a default UI ownership prefix. That lets a hosted app own root-facing UI routes such as `/`, `/dashboard`, and `/about` without forcing everything under `/<plugin-id>`.
+Use `HostedAppContract` for fast plugin tests that do not boot the full platform. This catches ownership mistakes and
+returns the same diagnostics shown by the host.
 
-API, admin, and asset ownership remain explicit and continue to use their declared prefixes unless the manifest overrides them.
+```kotlin
+class ReportsAppContractTest {
+    @Test
+    fun `plugin contribution is valid`() {
+        val diagnostics = HostedAppContract.diagnostics(ReportsApp(), testHostedAppContext())
 
-## Testing hosted apps
+        assertEquals("reports", diagnostics.hostedAppId)
+        assertEquals(listOf("/"), diagnostics.routes.map { it.pathPattern })
+        assertEquals(1, diagnostics.capabilities.single { it.id == "navigation" }.count)
+    }
+}
+```
 
-For SPI-only tests, use `HostedAppContext.forTesting(...)` from the plugin API module.
+Build the test context with `HostedAppContext.forTesting(rendering = ..., users = ..., security = ...)`. Stub only the
+facades your plugin uses. The in-repo `HostedAppContractTest` is the canonical copyable example.
 
-For full-stack integration coverage, prefer the platform test harnesses such as `WebTest`, or boot the real app through `createServerComponents(plugin = ...)` instead of manually wiring each lower-level `createXxxComponents(...)` helper. Tests that own their config or database can use `createServerComponents(config = testConfig, plugin = ...)` so hosted-app migrations, route contribution, filters, and shell context all use the production assembly path.
+Recommended contract assertions:
 
-## Registration
+- route path patterns are the paths you expect
+- diagnostics show the expected capabilities
+- invalid routes fail with a useful ownership message
+- migration metadata uses a plugin-specific history table
 
-The server wires a single hosted app into application startup and collects its contributions once. Ownership validation ensures hosted-app routes and assets stay inside the prefixes declared by `HostedAppManifest.ownership`.
+## Full-Stack Hosted-App Tests
+
+Use full-stack tests when you need real routing, filters, persistence, migrations, auth, or shell rendering:
+
+```kotlin
+val components =
+    createServerComponents(
+        config = testConfig.copy(platformMode = PlatformMode.PluginHostedApp),
+        plugin = ReportsApp(),
+    )
+
+try {
+    val response = components.app.http!!(Request(GET, "/"))
+    assertThat(response, hasStatus(Status.OK))
+} finally {
+    components.persistence.close()
+}
+```
+
+Do not manually call lower-level factories such as `createPersistenceComponents`, `createSecurityComponents`, and
+`createWebComponents` in plugin tests unless the test is specifically about those internals. `createServerComponents`
+is the production assembly path and keeps migrations, filters, routes, shell options, and hosted-app context aligned.
+
+## Diagnostics
+
+Startup validates plugin ownership before routes are mounted. Common failures:
+
+| Message | Meaning | Fix |
+|---|---|---|
+| `pathPattern starting with '/'` | The route metadata is not an absolute path | Pass an absolute `pathPattern` to the route helper |
+| `outside hosted app ... ownership` | The route or asset is outside manifest prefixes | Move the path, update `HostedAppManifest.ownership`, or use the matching route group |
+| `Route conflicts detected` | A plugin route has the same method/path as a mounted platform route | Move the plugin route or exclude the colliding platform page set |
+
+The plugin admin dashboard also exposes `HostedAppDiagnostics`: routes, capabilities, ownership prefixes, included
+platform pages, stylesheets, and scripts.
+
+## Public APIs To Prefer
+
+To keep plugins isolated from platform internals, prefer:
+
+- `HostedApp`, `HostedAppContributionContext`, `HostedAppContext`
+- `HostedAppContract` for SPI-only tests
+- `PluginMigrations` for plugin schema changes
+- `createServerComponents(config, plugin)` for full-stack tests and launchers
+- plugin-facing facades on `HostedAppContext`: `users`, `analytics`, `notifications`, `rendering`, `security`
+
+Avoid depending on internal page factories, route registrars, repository implementations, `WebTest`, or low-level
+component factories from plugin modules.

--- a/platform-plugin-api/src/main/kotlin/io/github/rygel/outerstellar/platform/plugin/HostedAppContract.kt
+++ b/platform-plugin-api/src/main/kotlin/io/github/rygel/outerstellar/platform/plugin/HostedAppContract.kt
@@ -1,0 +1,24 @@
+package io.github.rygel.outerstellar.platform.plugin
+
+import io.github.rygel.outerstellar.platform.composition.PlatformMode
+
+/**
+ * Small test-facing helper for hosted-app authors.
+ *
+ * Use this from plugin tests when you want to verify the SPI contract without booting the full platform: routes/assets
+ * must stay inside manifest ownership, contribution hooks are collected once, and diagnostics are available for
+ * assertions.
+ */
+object HostedAppContract {
+    fun collect(
+        hostedApp: HostedApp,
+        context: HostedAppContext,
+        fallbackMode: PlatformMode = hostedApp.mode,
+    ): HostedAppContribution = HostedAppContribution.from(hostedApp, fallbackMode, context)
+
+    fun diagnostics(
+        hostedApp: HostedApp,
+        context: HostedAppContext,
+        fallbackMode: PlatformMode = hostedApp.mode,
+    ): HostedAppDiagnostics = collect(hostedApp, context, fallbackMode).diagnostics()
+}

--- a/platform-plugin-api/src/main/kotlin/io/github/rygel/outerstellar/platform/plugin/HostedAppContribution.kt
+++ b/platform-plugin-api/src/main/kotlin/io/github/rygel/outerstellar/platform/plugin/HostedAppContribution.kt
@@ -134,13 +134,15 @@ data class HostedAppContribution(
                         RouteGroup.Static -> effectiveOwnership.assetPrefixes
                         else -> effectiveOwnership.uiPrefixes
                     }
-                requirePathOwnedByManifest(manifest, registration.pathPattern, prefixes) {
+                requirePathOwnedByManifest(manifest, registration.pathPattern, prefixes, registration.group) {
                     "Route ${registration.method} ${registration.pathPattern} (${registration.description})"
                 }
             }
 
             (assets.stylesheets + assets.scripts).forEach { asset ->
-                requirePathOwnedByManifest(manifest, asset, effectiveOwnership.assetPrefixes) { "Asset $asset" }
+                requirePathOwnedByManifest(manifest, asset, effectiveOwnership.assetPrefixes, RouteGroup.Static) {
+                    "Asset $asset"
+                }
             }
         }
 
@@ -148,17 +150,28 @@ data class HostedAppContribution(
             manifest: HostedAppManifest,
             path: String,
             prefixes: List<String>,
+            group: RouteGroup,
             subject: () -> String,
         ) {
             require(path.startsWith("/")) {
-                "${subject()} must provide a pathPattern starting with '/' so hosted app ownership can be validated."
+                "${subject()} must provide an absolute pathPattern starting with '/' so hosted app ownership can be " +
+                    "validated. Example: context.routes.publicUi(route, \"Page\", \"/${manifest.id}/page\")."
             }
             require(
                 prefixes.any { prefix ->
                     prefix == "/" || path == prefix || path.startsWith("$prefix/") || path.startsWith("$prefix/*")
                 }
             ) {
-                "${subject()} is outside hosted app '${manifest.id}' ownership. Allowed prefixes: ${prefixes.joinToString()}"
+                val rootHint =
+                    if (group == RouteGroup.PublicUi || group == RouteGroup.ProtectedUi) {
+                        " In PluginHostedApp mode, UI routes also get '/' ownership automatically."
+                    } else {
+                        " Root '/' ownership is only granted to UI routes in PluginHostedApp mode; API, admin, and " +
+                            "static asset routes must use their explicit manifest prefixes."
+                    }
+                "${subject()} is outside hosted app '${manifest.id}' ownership for ${group.name}. " +
+                    "Allowed prefixes: ${prefixes.joinToString()}. Fix the pathPattern, update " +
+                    "HostedAppManifest.ownership, or register the route in the matching route group.$rootHint"
             }
         }
     }

--- a/platform-plugin-api/src/test/kotlin/io/github/rygel/outerstellar/platform/plugin/HostedAppContractTest.kt
+++ b/platform-plugin-api/src/test/kotlin/io/github/rygel/outerstellar/platform/plugin/HostedAppContractTest.kt
@@ -1,0 +1,117 @@
+package io.github.rygel.outerstellar.platform.plugin
+
+import io.github.rygel.outerstellar.platform.composition.PlatformMode
+import io.github.rygel.outerstellar.platform.model.ApiKeySummary
+import io.github.rygel.outerstellar.platform.model.CreateApiKeyResponse
+import io.github.rygel.outerstellar.platform.model.User
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.http4k.contract.bindContract
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.template.TemplateRenderer
+import org.http4k.template.ViewModel
+
+class HostedAppContractTest {
+    @Test
+    fun `contract helper collects diagnostics for a valid hosted app`() {
+        val hostedApp =
+            object : HostedApp {
+                override val id = "reports"
+                override val appLabel = "Reports"
+                override val mode = PlatformMode.PluginHostedApp
+
+                override fun contribute(context: HostedAppContributionContext) {
+                    context.routes.publicUi(
+                        ("/" bindContract GET).to { _: Request -> Response(Status.OK).body("reports") },
+                        "Reports home",
+                        "/",
+                    )
+                    context.navigation.item("Reports", "/", "bar-chart")
+                }
+            }
+
+        val diagnostics = HostedAppContract.diagnostics(hostedApp, hostedAppTestContext())
+
+        assertEquals("reports", diagnostics.hostedAppId)
+        assertEquals("Reports", diagnostics.appLabel)
+        assertEquals("PluginHostedApp", diagnostics.mode)
+        assertEquals(listOf("/"), diagnostics.routes.map { it.pathPattern })
+        assertEquals(1, diagnostics.capabilities.single { it.id == "routes" }.count)
+        assertEquals(1, diagnostics.capabilities.single { it.id == "navigation" }.count)
+    }
+
+    @Test
+    fun `contract helper reports ownership mistakes before full platform boot`() {
+        val hostedApp =
+            object : HostedApp {
+                override val id = "reports"
+
+                override fun contribute(context: HostedAppContributionContext) {
+                    context.routes.publicUi(
+                        ("/wrong" bindContract GET).to { _: Request -> Response(Status.OK) },
+                        "Wrong page",
+                        "/wrong",
+                    )
+                }
+            }
+
+        val error =
+            assertFailsWith<IllegalArgumentException> { HostedAppContract.collect(hostedApp, hostedAppTestContext()) }
+
+        val message = error.message.orEmpty()
+        assert(message.contains("Route * /wrong (Wrong page) is outside hosted app 'reports' ownership")) { message }
+        assert(message.contains("Allowed prefixes: /reports, /plugin/reports")) { message }
+        assert(message.contains("Fix the pathPattern, update HostedAppManifest.ownership")) { message }
+    }
+
+    private fun hostedAppTestContext(): HostedAppContext =
+        HostedAppContext.forTesting(
+            rendering =
+                object : PluginRendering {
+                    override val renderer: TemplateRenderer =
+                        object : TemplateRenderer {
+                            override fun invoke(viewModel: ViewModel): String = ""
+                        }
+
+                    override fun renderShell(
+                        shell: io.github.rygel.outerstellar.platform.web.ShellView,
+                        bodyHtml: String,
+                    ) = bodyHtml
+                },
+            users =
+                object : PluginUsers {
+                    override fun currentUser(request: Request): User? = null
+
+                    override fun findById(id: UUID): User? = null
+
+                    override fun findByUsername(username: String): User? = null
+
+                    override fun findByEmail(email: String): User? = null
+                },
+            security =
+                PluginSecurity(
+                    apiKeys =
+                        object : PluginApiKeys {
+                            override fun createApiKey(userId: UUID, name: String): CreateApiKeyResponse =
+                                error("Not used")
+
+                            override fun listApiKeys(userId: UUID): List<ApiKeySummary> = emptyList()
+
+                            override fun deleteApiKey(userId: UUID, keyId: Long) = Unit
+                        },
+                    oauth =
+                        object : PluginOAuth {
+                            override fun findOrCreateOAuthUser(
+                                providerName: String,
+                                oauthSubject: String,
+                                email: String?,
+                            ): User = error("Not used")
+                        },
+                ),
+        )
+}

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PluginContributionTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PluginContributionTest.kt
@@ -297,11 +297,10 @@ class PluginContributionTest {
                 HostedAppContribution.from(plugin, PlatformMode.FullPlatformApp, pluginContext())
             }
 
-        assertEquals(
-            "Route * /other (Other route) is outside hosted app 'reports' ownership. " +
-                "Allowed prefixes: /reports, /plugin/reports",
-            error.message,
-        )
+        val message = error.message.orEmpty()
+        assert(message.contains("Route * /other (Other route) is outside hosted app 'reports' ownership")) { message }
+        assert(message.contains("Allowed prefixes: /reports, /plugin/reports")) { message }
+        assert(message.contains("Fix the pathPattern, update HostedAppManifest.ownership")) { message }
     }
 
     @Test
@@ -325,11 +324,10 @@ class PluginContributionTest {
                 HostedAppContribution.from(plugin, PlatformMode.FullPlatformApp, pluginContext())
             }
 
-        assertEquals(
-            "Route * / (Reports home) is outside hosted app 'reports' ownership. " +
-                "Allowed prefixes: /reports, /plugin/reports",
-            error.message,
-        )
+        val message = error.message.orEmpty()
+        assert(message.contains("Route * / (Reports home) is outside hosted app 'reports' ownership")) { message }
+        assert(message.contains("Allowed prefixes: /reports, /plugin/reports")) { message }
+        assert(message.contains("In PluginHostedApp mode, UI routes also get '/' ownership automatically")) { message }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add `HostedAppContract` so plugin authors can collect contributions and diagnostics from SPI-only tests.
- Improve hosted-app ownership validation messages with route group context, prefix guidance, and root UI ownership hints.
- Expand plugin author documentation around dependencies, `contribute(context)`, route ownership, migrations, contract tests, full-stack tests, diagnostics, and public APIs.

## Validation

- `mvn -pl platform-plugin-api -am test`
- `mvn -pl platform-web -am test -Dtest=PluginContributionTest "-Dsurefire.failIfNoSpecifiedTests=false" "-Dexec.skip=true" "-Ddetekt.skip=true" "-Dspotbugs.skip=true" "-Dspotless.check.skip=true"`
- `pwsh scripts/test.ps1`
- `pwsh scripts/test-desktop.ps1`
- `git diff --check`