### PR TITLE
release: v3.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [3.6.5] – 2026-05-31
+
+### Added
+
+- **Hosted app authoring improvements** — Improved developer experience for plugin-hosted app configuration and authoring.
+- **Config-driven hosted app server tests** — Support for configuration-driven integration tests for hosted app servers (#410).
+- **Plugin-hosted app service separation** — Platform services separated from default UI for plugin-hosted apps, allowing finer-grained control over which platform capabilities are exposed (#376, #409).
+- **I18n module moved into platform** — Migrated `outerstellar-i18n` into the platform monorepo for unified versioning and releases (#412).
+- **Validator migrated in-repo** — Migrated the i18n validator library and Maven plugin into the repository, cleaning stale external dependencies (#405).
+
+### Changed
+
+- **Plugin-hosted app composition** — Plugin-hosted apps can now selectively include platform UI pages independent of platform services (#409).
+- **Release version safeguards** — CI release workflow now validates CHANGELOG entry, SNAPSHOT status, duplicate tag, and CI success before publishing (#406).
+
+### Fixed
+
+- **Issue 407 follow-up** — Recovered follow-up changes for issue 407 (#411).
+
+---
+
+## [3.6.4] – 2026-05-28
+
+---
+
 ## [1.6.3] – 2026-05-28
 
 ### Added

--- a/outerstellar-i18n-validator-maven-plugin/pom.xml
+++ b/outerstellar-i18n-validator-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.4</version>
+        <version>3.6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n-validator/pom.xml
+++ b/outerstellar-i18n-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.4</version>
+        <version>3.6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n/pom.xml
+++ b/outerstellar-i18n/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.4</version>
+        <version>3.6.5</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/platform-core/pom.xml
+++ b/platform-core/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.4</version>
+        <version>3.6.5</version>
 
     </parent>
 

--- a/platform-desktop-javafx/pom.xml
+++ b/platform-desktop-javafx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.4</version>
+        <version>3.6.5</version>
     </parent>
 
     <artifactId>outerstellar-platform-desktop-javafx</artifactId>

--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.4</version>
+        <version>3.6.5</version>
 
     </parent>
 

--- a/platform-jte-extensions/pom.xml
+++ b/platform-jte-extensions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.4</version>
+        <version>3.6.5</version>
     </parent>
 
     <artifactId>platform-jte-extensions</artifactId>

--- a/platform-persistence-jdbi/pom.xml
+++ b/platform-persistence-jdbi/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.4</version>
+        <version>3.6.5</version>
 
     </parent>
 

--- a/platform-plugin-api/pom.xml
+++ b/platform-plugin-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.4</version>
+        <version>3.6.5</version>
     </parent>
 
     <artifactId>outerstellar-platform-plugin-api</artifactId>

--- a/platform-security/pom.xml
+++ b/platform-security/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.4</version>
+        <version>3.6.5</version>
 
     </parent>
 

--- a/platform-seed/pom.xml
+++ b/platform-seed/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.4</version>
+        <version>3.6.5</version>
 
     </parent>
 

--- a/platform-sync-client/pom.xml
+++ b/platform-sync-client/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.4</version>
+        <version>3.6.5</version>
 
     </parent>
 

--- a/platform-test-infrastructure/pom.xml
+++ b/platform-test-infrastructure/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.4</version>
+        <version>3.6.5</version>
     </parent>
 
     <artifactId>outerstellar-platform-test-infrastructure</artifactId>

--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.4</version>
+        <version>3.6.5</version>
 
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.rygel</groupId>
     <artifactId>outerstellar-platform-parent</artifactId>
 
-    <version>3.6.4</version>
+    <version>3.6.5</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Summary

Release preparation for **v3.6.5** (GitHub-only release).

- Bump version from 3.6.4 to 3.6.5 in all 16 pom.xml files
- Add ## [3.6.5] CHANGELOG entry covering post-v3.6.4 changes

## Changes included
- Hosted app authoring improvements
- Config-driven hosted app server tests
- Plugin-hosted app service/UI separation
- I18n module moved into platform monorepo
- Validator migrated in-repo
- Release version safeguards in CI
- Issue 407 follow-up fix

## Post-merge steps
1. Wait for CI to pass on main
2. Trigger publish.yml workflow from main with version 3.6.5
3. Skip publish-central.yml (GitHub-only release)
4. After release, sync main back to develop

## Test plan
- [x] mvn install -DskipTests passes locally with version 3.6.5
- [ ] CI passes on this PR
- [ ] Release workflow guard validates CHANGELOG + version match