### PR TITLE
[codex] Clarify plugin checks and release channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,23 @@ mvn test
 
 Releases are now **manual and version-confirmed** to avoid publishing the wrong version.
 
-1. Merge the release commit to `main` with the exact target version in `pom.xml` and a matching `CHANGELOG.md` section like `## [1.6.4]`.
-2. Run **Release and Publish** from `main`, enter `release_version`, then type the exact same version again in `confirm_release_version`.
-3. After that succeeds, run **Publish to Maven Central** from `main` with the same two inputs.
+The normal sequence is **GitHub first, Maven Central later**:
 
-Both workflows now fail unless they run from `main`, the entered version exactly matches the root Maven version, the version is not a `-SNAPSHOT`, the changelog contains that exact release heading, and CI has already succeeded on that exact commit. Maven Central also refuses to run until the matching GitHub release tag already exists.
+1. Merge the release commit to `main` with the exact target version in `pom.xml` and a matching `CHANGELOG.md` section
+   like `## [3.6.5]`.
+2. Run **Release and Publish** from `main`, enter `release_version`, then type the exact same version again in
+   `confirm_release_version`.
+   This creates the GitHub release and publishes the GitHub Packages artifacts.
+3. Stop here when the intent is a GitHub-only release.
+4. Run **Publish to Maven Central** from `main` later, only when the release should be promoted to Maven Central, using
+   the same two version inputs.
+
+Both workflows fail unless they run from `main`, the entered version exactly matches the root Maven version, the version
+is not a `-SNAPSHOT`, the changelog contains that exact release heading, and CI has already succeeded on that exact
+commit. Maven Central also refuses to run until the matching GitHub release tag already exists.
+
+A failed manual dispatch with the wrong version is a successful guardrail, not a broken release. For example, if the
+root `pom.xml` says `3.6.5` and the workflow is dispatched with `1.6.5`, the guard must fail before publishing.
 
 ---
 

--- a/docs/features/deployment.md
+++ b/docs/features/deployment.md
@@ -20,6 +20,19 @@ mvn clean install -DskipTests
 mvn clean verify -T4 -pl outerstellar-i18n,platform-core,platform-security,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seed
 ```
 
+## Release Channels
+
+Releases are intentionally staged.
+
+1. **GitHub release and GitHub Packages first**: run the **Release and Publish** workflow from `main` with matching
+   `release_version` and `confirm_release_version` inputs. This is the normal first publication step.
+2. **Maven Central later**: run **Publish to Maven Central** only when the same release is ready for Central
+   distribution.
+
+The two workflows have separate guards. A GitHub-first release can be complete even when Maven Central has not been
+run yet. If a manually dispatched workflow fails because the requested version does not match the root `pom.xml`
+version, treat that as the release safety check doing its job.
+
 ## Run
 
 ### Web Server

--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -118,6 +118,21 @@ platform migrations because the history table is separate.
 Use `HostedAppContract` for fast plugin tests that do not boot the full platform. This catches ownership mistakes and
 returns the same diagnostics shown by the host.
 
+### Verify My Plugin Pattern
+
+Every hosted app should keep one cheap SPI contract test next to the plugin module. The test should collect
+`HostedAppDiagnostics` through `HostedAppContract`, then assert the externally visible contract the platform will
+mount:
+
+- expected route path patterns and route groups
+- expected shell navigation entries or other capabilities
+- expected platform page sets
+- plugin migration metadata, when the plugin owns tables
+- at least one invalid-route assertion when the plugin uses custom ownership
+
+This test does not need PostgreSQL, JTE templates, or the web server. It should depend only on
+`outerstellar-platform-plugin-api` plus the test libraries the plugin already uses.
+
 ```kotlin
 class ReportsAppContractTest {
     @Test
@@ -128,11 +143,37 @@ class ReportsAppContractTest {
         assertEquals(listOf("/"), diagnostics.routes.map { it.pathPattern })
         assertEquals(1, diagnostics.capabilities.single { it.id == "navigation" }.count)
     }
+
+    @Test
+    fun `plugin rejects routes outside its ownership`() {
+        val app = ReportsAppWithBadRoute(pathPattern = "/wrong")
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            HostedAppContract.collect(app, testHostedAppContext())
+        }
+
+        assertTrue(error.message.orEmpty().contains("outside hosted app 'reports' ownership"))
+    }
 }
 ```
 
 Build the test context with `HostedAppContext.forTesting(rendering = ..., users = ..., security = ...)`. Stub only the
-facades your plugin uses. The in-repo `HostedAppContractTest` is the canonical copyable example.
+facades your plugin uses. If the plugin only registers routes and navigation, the stubs can return empty values or
+`error("Not used")` for methods that should not be reached.
+
+Keep the helper local to the plugin test source set:
+
+```kotlin
+private fun testHostedAppContext(): HostedAppContext =
+    HostedAppContext.forTesting(
+        rendering = testRendering(),
+        users = testUsers(),
+        security = testSecurity(),
+    )
+```
+
+The in-repo `HostedAppContractTest` is the canonical copyable example when the stubs need to implement every facade
+method explicitly.
 
 Recommended contract assertions:
 


### PR DESCRIPTION
## Summary

- Document a copyable `HostedAppContract` verify-my-plugin test pattern.
- Clarify that releases are staged as GitHub release/GitHub Packages first, Maven Central later.
- Explain that version-mismatch workflow failures are successful release guardrail catches.

## Validation

- `git diff --check`
- `pwsh scripts/test.ps1`
- `pwsh scripts/test-desktop.ps1`