### PR TITLE
[codex] Fix dev-mode platform error page rendering

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfra.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfra.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.infra
 
+import gg.jte.CodeResolver
 import gg.jte.TemplateEngine
 import gg.jte.html.OwaspHtmlTemplateOutput
 import gg.jte.output.StringOutput
@@ -40,32 +41,47 @@ fun createRenderer(runtime: RuntimeConfig = RuntimeConfig()): TemplateRenderer {
             val sourceDir =
                 System.getProperty("jte.sourceDir") ?: System.getenv("JTE_SOURCE_DIR") ?: System.getProperty("user.dir")
             val projectDirectory = Path.of(sourceDir)
-            val sourceTemplates = projectDirectory.resolve(Path.of("web", "src", "main", "jte"))
-            val generatedTemplateClasses = projectDirectory.resolve(Path.of("web", "target", "jte-classes"))
+            val sourceTemplates = findSourceTemplateDirectory(projectDirectory)
+            val generatedTemplateClasses = findGeneratedTemplateDirectory(projectDirectory, sourceTemplates)
 
-            if (Files.isDirectory(sourceTemplates)) {
-                val directoryResolver = DirectoryCodeResolver(sourceTemplates)
-                val classpathFallback = ResourceCodeResolver(".")
-                val resolver = CompositeCodeResolver(directoryResolver, classpathFallback)
-                TemplateEngine.create(
-                    resolver,
-                    generatedTemplateClasses,
-                    gg.jte.ContentType.Html,
-                    applicationClassLoader,
-                )
-            } else {
-                TemplateEngine.create(
-                    ResourceCodeResolver("."),
-                    generatedTemplateClasses,
-                    gg.jte.ContentType.Html,
-                    applicationClassLoader,
-                )
-            }
+            val resolver =
+                if (sourceTemplates != null) {
+                    val directoryResolver = DirectoryCodeResolver(sourceTemplates)
+                    val classpathFallback = ResourceCodeResolver(".")
+                    CompositeCodeResolver(directoryResolver, classpathFallback)
+                } else {
+                    ResourceCodeResolver(".")
+                }
+
+            TemplateEngine.create(
+                resolver,
+                generatedTemplateClasses,
+                gg.jte.ContentType.Html,
+                applicationClassLoader,
+            ) to resolver
         } else {
             null
         }
 
-    return if (isProduction) renderUsingPrecompiledRegistry() else renderUsing { requireNotNull(templateEngine) }
+    return if (isProduction) {
+        renderUsingPrecompiledRegistry()
+    } else {
+        val (engine, resolver) = requireNotNull(templateEngine)
+        renderUsingDevEngineWithPrecompiledFallback(engine, resolver)
+    }
+}
+
+private fun findSourceTemplateDirectory(projectDirectory: Path): Path? =
+    listOf(
+            projectDirectory.resolve(Path.of("src", "main", "jte")),
+            projectDirectory.resolve(Path.of("platform-web", "src", "main", "jte")),
+            projectDirectory.resolve(Path.of("web", "src", "main", "jte")),
+        )
+        .firstOrNull(Files::isDirectory)
+
+private fun findGeneratedTemplateDirectory(projectDirectory: Path, sourceTemplates: Path?): Path {
+    val templateProjectDirectory = sourceTemplates?.parent?.parent?.parent
+    return (templateProjectDirectory ?: projectDirectory).resolve(Path.of("target", "jte-classes"))
 }
 
 private fun ensureTemplateClassesLoaded() {
@@ -94,6 +110,19 @@ private fun renderUsing(engineProvider: () -> TemplateEngine): TemplateRenderer 
     } catch (e: IllegalStateException) {
         logger.error("JTE render failed for template {}: {}", templateName, e.message)
         throw ViewNotFound(viewModel)
+    }
+}
+
+internal fun renderUsingDevEngineWithPrecompiledFallback(
+    templateEngine: TemplateEngine,
+    resolver: CodeResolver,
+): TemplateRenderer = { viewModel: ViewModel ->
+    val templateName = "${viewModel.template()}.kte"
+
+    if (!resolver.exists(templateName) && JteClassRegistry.getTemplateClass(viewModel.template()) != null) {
+        renderUsingPrecompiledRegistry()(viewModel)
+    } else {
+        renderUsing { templateEngine }(viewModel)
     }
 }
 

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfraTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfraTest.kt
@@ -1,0 +1,66 @@
+package io.github.rygel.outerstellar.platform.infra
+
+import gg.jte.CodeResolver
+import gg.jte.TemplateEngine
+import gg.jte.resolve.ResourceCodeResolver
+import io.github.rygel.outerstellar.platform.web.ErrorPage
+import io.github.rygel.outerstellar.platform.web.Page
+import io.github.rygel.outerstellar.platform.web.RequestContext
+import io.github.rygel.outerstellar.platform.web.ShellRenderer
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.junit.jupiter.api.io.TempDir
+
+class JteInfraTest {
+
+    @TempDir lateinit var generatedTemplates: Path
+
+    @Test
+    fun `dev renderer falls back to precompiled platform template when source is absent`() {
+        val renderer =
+            renderUsingDevEngineWithPrecompiledFallback(
+                TemplateEngine.create(
+                    ResourceCodeResolver("."),
+                    generatedTemplates,
+                    gg.jte.ContentType.Html,
+                    Thread.currentThread().contextClassLoader,
+                ),
+                MissingTemplateSourceResolver,
+            )
+        val shell = ShellRenderer(RequestContext(Request(GET, "/broken"))).shell("Error", "/errors")
+        val page =
+            Page(
+                shell = shell,
+                data =
+                    ErrorPage(
+                        statusCode = 500,
+                        heading = "Server down",
+                        message = "The original error should stay visible in logs.",
+                        primaryActionLabel = "Home",
+                        primaryActionUrl = "/",
+                        secondaryActionLabel = "Sign in",
+                        secondaryActionUrl = "/auth",
+                        helpButtonLabel = "Help",
+                        helpUrl = "/errors/components/help/server-error",
+                        errorLabel = "Error",
+                    ),
+            )
+
+        val html = renderer(page)
+
+        assertTrue(html.contains("Server down"), "Expected precompiled ErrorPage.kte to render, got: $html")
+    }
+
+    private object MissingTemplateSourceResolver : CodeResolver {
+        override fun resolve(name: String): String = error("No source template should be resolved for $name")
+
+        override fun exists(name: String): Boolean = false
+
+        override fun getLastModified(name: String): Long = 0
+
+        override fun resolveAllTemplateNames(): MutableList<String> = mutableListOf()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #419 by allowing the dev-mode JTE renderer to fall back to the generated platform template registry when a platform template source file is not present on disk.

## Root cause

In dev mode the renderer built a source-compiling `TemplateEngine` only. When the platform is consumed from a packaged artifact, templates such as `ErrorPage.kte` may only exist as generated/precompiled classes, so the global error handler could fail while trying to render the error page and hide the original exception.

## Changes

- Detect source template directories for repo-root, module-root, and hosted `web/` layouts.
- Preserve source-template rendering when source exists.
- Fall back to the precompiled registry only when the requested template has no source resolver entry but does exist in `JteClassRegistry`.
- Add a regression test for rendering `ErrorPage.kte` through the dev fallback path.

## Validation

- `mvn -pl platform-web -am test-compile "-Ddetekt.skip=true" "-Dspotbugs.skip=true" "-Dspotless.check.skip=true"`
- `mvn -pl platform-web -am test "-Dtest=JteInfraTest" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dexec.skip=true"`
- `mvn -pl platform-web -am test "-Dexec.skip=true"`