### PR TITLE
[codex] Remove unused banner provider import

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -1,7 +1,6 @@
 package io.github.rygel.outerstellar.platform.web
 
 import io.github.rygel.outerstellar.platform.analytics.AnalyticsService
-import io.github.rygel.outerstellar.platform.banner.BannerProvider
 import io.github.rygel.outerstellar.platform.model.InsufficientPermissionException
 import io.github.rygel.outerstellar.platform.model.OuterstellarException
 import io.github.rygel.outerstellar.platform.model.ThemeCatalog


### PR DESCRIPTION
## Summary

Removes an unused `BannerProvider` import from `Filters.kt`.

## Context

This was the only tree delta left after recovering the interrupted local `main` merge to the promoted `v3.6.5` state. The PR is intentionally based directly on `origin/main` so it contains a single clean commit instead of the local recovery merge history.

## Validation

- `mvn -pl platform-web -am compile "-Ddetekt.skip=true" "-Dspotbugs.skip=true" "-Dspotless.check.skip=true" "-Dexec.skip=true"`

Prior recovery validation also passed locally before this branch was created:

- `pwsh scripts/test.ps1`
- `pwsh scripts/test-desktop.ps1`