### PR TITLE
fix: make release publish retries idempotent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,36 +30,6 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
 
-      - name: Extract version from pom.xml
-        id: version
-        run: |
-          VERSION=$(grep -m1 '<version>' pom.xml | sed 's/.*<version>\(.*\)<\/version>.*/\1/')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Check if release already exists
-        id: check
-        run: |
-          if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-
-      - name: Create GitHub release
-        if: steps.check.outputs.exists == 'false'
-        run: |
-          gh release create "$RELEASE_TAG" \
-            --target main \
-            --title "$RELEASE_TAG" \
-            --generate-notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-
       - name: Set up JDK 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -111,11 +81,6 @@ jobs:
             exit 1
           fi
 
-          if gh release view "v${PROJECT_VERSION}" > /dev/null 2>&1; then
-            echo "::error::GitHub release v${PROJECT_VERSION} already exists."
-            exit 1
-          fi
-
           echo "version=${PROJECT_VERSION}" >> "$GITHUB_OUTPUT"
           echo "tag=v${PROJECT_VERSION}" >> "$GITHUB_OUTPUT"
         env:
@@ -148,25 +113,26 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install Node dependencies
-        if: steps.check.outputs.exists == 'false'
         run: npm ci --no-audit --no-fund
 
       - name: Build and test
-        if: steps.check.outputs.exists == 'false'
         run: mvn clean verify -Pfast
 
       - name: Publish to GitHub Packages
-        if: steps.check.outputs.exists == 'false'
         run: mvn deploy -DskipTests -Denforcer.skip=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create GitHub release
+      - name: Create or verify GitHub release
         run: |
-          gh release create "${RELEASE_TAG}" \
-            --target main \
-            --title "${RELEASE_TAG}" \
-            --generate-notes
+          if gh release view "${RELEASE_TAG}" > /dev/null 2>&1; then
+            echo "GitHub release ${RELEASE_TAG} already exists; leaving it unchanged."
+          else
+            gh release create "${RELEASE_TAG}" \
+              --target main \
+              --title "${RELEASE_TAG}" \
+              --generate-notes
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.guard.outputs.tag }}


### PR DESCRIPTION
## Summary
- remove the early GitHub release creation step from the release workflow
- allow reruns to continue publishing packages when the GitHub release already exists
- keep GitHub release creation at the end as an idempotent verify-or-create step

## Why
The 3.6.5 release tag exists, but GitHub Packages are still on 3.6.4 because the workflow created the release first and then blocked retries once that release already existed.