### PR TITLE
release: prepare v3.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+---
+
+## [3.6.6] – 2026-06-01
+
 ### Changed
 
 - **Breaking extension vocabulary cleanup** — renamed the public SPI from plugin/hosted-app terminology to the extension model, including `platform-extension-api`, `PlatformExtension`, `ExtensionHostContext`, `ExtensionContributionContext`, and `PlatformMode` values `FullPlatform`, `ExtensionHost`, and `Headless`.
 - **Module and artifact consistency** — renamed the reactor and published coordinates to the new extension naming set, including `platform-testkit`, `platform-seeder`, and `outerstellar-platform-jte-extensions`.
+
+### Fixed
+
+- **JTE renderer mode split** — development resolves source templates explicitly, while production and tests use the precompiled JTE registry without a silent fallback.
+- **Packaged JVM template rendering** — containerized JVM startup now opts into precompiled JTE templates so packaged images render without source template directories.
+- **Validator Maven plugin build** — corrected the Maven plugin annotations dependency coordinates after moving the validator artifacts into this repository.
 
 ---
 

--- a/outerstellar-i18n-validator-maven-plugin/pom.xml
+++ b/outerstellar-i18n-validator-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.5</version>
+        <version>3.6.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n-validator/pom.xml
+++ b/outerstellar-i18n-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.5</version>
+        <version>3.6.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n/pom.xml
+++ b/outerstellar-i18n/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.5</version>
+        <version>3.6.6</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/platform-core/pom.xml
+++ b/platform-core/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.5</version>
+        <version>3.6.6</version>
 
     </parent>
 

--- a/platform-desktop-javafx/pom.xml
+++ b/platform-desktop-javafx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.5</version>
+        <version>3.6.6</version>
     </parent>
 
     <artifactId>outerstellar-platform-desktop-javafx</artifactId>

--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.5</version>
+        <version>3.6.6</version>
 
     </parent>
 

--- a/platform-extension-api/pom.xml
+++ b/platform-extension-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.5</version>
+        <version>3.6.6</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-api</artifactId>

--- a/platform-jte-extensions/pom.xml
+++ b/platform-jte-extensions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.5</version>
+        <version>3.6.6</version>
     </parent>
 
     <artifactId>outerstellar-platform-jte-extensions</artifactId>

--- a/platform-persistence-jdbi/pom.xml
+++ b/platform-persistence-jdbi/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.5</version>
+        <version>3.6.6</version>
 
     </parent>
 

--- a/platform-security/pom.xml
+++ b/platform-security/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.5</version>
+        <version>3.6.6</version>
 
     </parent>
 

--- a/platform-seeder/pom.xml
+++ b/platform-seeder/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.5</version>
+        <version>3.6.6</version>
 
     </parent>
 

--- a/platform-sync-client/pom.xml
+++ b/platform-sync-client/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.5</version>
+        <version>3.6.6</version>
 
     </parent>
 

--- a/platform-testkit/pom.xml
+++ b/platform-testkit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.5</version>
+        <version>3.6.6</version>
     </parent>
 
     <artifactId>outerstellar-platform-testkit</artifactId>

--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.5</version>
+        <version>3.6.6</version>
 
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.rygel</groupId>
     <artifactId>outerstellar-platform-parent</artifactId>
 
-    <version>3.6.5</version>
+    <version>3.6.6</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Summary
- bump all reactor POMs to 3.6.6
- move the extension rename and renderer/package-build fixes into the 3.6.6 changelog entry
- prepare metadata for a GitHub-only release without running the GitHub Packages publish workflow

## Validation
- mvn -N validate
- pwsh scripts/test.ps1
- pwsh scripts/test-desktop.ps1