### PR TITLE
release: prepare v3.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [3.6.7] – 2026-06-01
+
+### Changed
+
+- **Dependency refresh** — Updated npm, GitHub Actions, http4k, logging, persistence, MockK, and Maven plugin dependencies from the develop branch maintenance queue.
+
+### Fixed
+
+- **Native extension template rendering** — Production JTE rendering now discovers precompiled template registries from extensions through `ServiceLoader`, so native-image hosts can resolve both platform and extension templates.
+
+---
+
 ## [3.6.6] – 2026-06-01
 
 ### Changed

--- a/outerstellar-i18n-validator-maven-plugin/pom.xml
+++ b/outerstellar-i18n-validator-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.6</version>
+        <version>3.6.7</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n-validator/pom.xml
+++ b/outerstellar-i18n-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.6</version>
+        <version>3.6.7</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n/pom.xml
+++ b/outerstellar-i18n/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.6</version>
+        <version>3.6.7</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/platform-core/pom.xml
+++ b/platform-core/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.6</version>
+        <version>3.6.7</version>
 
     </parent>
 

--- a/platform-desktop-javafx/pom.xml
+++ b/platform-desktop-javafx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.6</version>
+        <version>3.6.7</version>
     </parent>
 
     <artifactId>outerstellar-platform-desktop-javafx</artifactId>

--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.6</version>
+        <version>3.6.7</version>
 
     </parent>
 

--- a/platform-extension-api/pom.xml
+++ b/platform-extension-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.6</version>
+        <version>3.6.7</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-api</artifactId>

--- a/platform-jte-extensions/pom.xml
+++ b/platform-jte-extensions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.6</version>
+        <version>3.6.7</version>
     </parent>
 
     <artifactId>outerstellar-platform-jte-extensions</artifactId>

--- a/platform-persistence-jdbi/pom.xml
+++ b/platform-persistence-jdbi/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.6</version>
+        <version>3.6.7</version>
 
     </parent>
 

--- a/platform-security/pom.xml
+++ b/platform-security/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.6</version>
+        <version>3.6.7</version>
 
     </parent>
 

--- a/platform-seeder/pom.xml
+++ b/platform-seeder/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.6</version>
+        <version>3.6.7</version>
 
     </parent>
 

--- a/platform-sync-client/pom.xml
+++ b/platform-sync-client/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.6</version>
+        <version>3.6.7</version>
 
     </parent>
 

--- a/platform-testkit/pom.xml
+++ b/platform-testkit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.6</version>
+        <version>3.6.7</version>
     </parent>
 
     <artifactId>outerstellar-platform-testkit</artifactId>

--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.6</version>
+        <version>3.6.7</version>
 
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.rygel</groupId>
     <artifactId>outerstellar-platform-parent</artifactId>
 
-    <version>3.6.6</version>
+    <version>3.6.7</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Summary
- Bump the platform release version from `3.6.6` to `3.6.7` across the parent POM and module parent references.
- Add `CHANGELOG.md` entry for `3.6.7`, covering the native extension JTE registry fix and dependency refresh since `3.6.6`.

## Validation
- `mvn -q -N help:evaluate "-Dexpression=project.version" "-DforceStdout"` -> `3.6.7`
- Confirmed `CHANGELOG.md` contains `## [3.6.7]`
- Confirmed GitHub release `v3.6.7` does not already exist
- `mvn clean verify -T4 -pl platform-jte-extensions,outerstellar-i18n,outerstellar-i18n-validator,outerstellar-i18n-validator-maven-plugin,platform-core,platform-extension-api,platform-security,platform-testkit,platform-persistence-jdbi,platform-sync-client,platform-web,platform-seeder`

## Release channel
This prepares the GitHub Packages-only release path. Do not run `Publish to Maven Central` for this version.

After this release prep reaches `main` and CI succeeds on that exact `main` commit, manually dispatch `Release and Publish` from `main` with:

- `release_version`: `3.6.7`
- `confirm_release_version`: `3.6.7`