### PR TITLE
refactor: consolidate DI wiring into shared SyncModules factory

### DIFF
--- a/config/spotbugs-exclude.xml
+++ b/config/spotbugs-exclude.xml
@@ -164,18 +164,6 @@
         <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD"/>
     </Match>
     <Match>
-        <Class name="~io\.github\.rygel\.outerstellar\.platform\.di\.SyncClientComponents.*"/>
-        <Bug pattern="NP_NULL_ON_SOME_PATH"/>
-    </Match>
-    <Match>
-        <Class name="~io\.github\.rygel\.outerstellar\.platform\.di\.SyncClientComponents.*"/>
-        <Bug pattern="NP_NULL_PARAM_DEREF"/>
-    </Match>
-    <Match>
-        <Class name="io.github.rygel.outerstellar.platform.di.SyncClientComponents"/>
-        <Bug pattern="EI_EXPOSE_REP"/>
-    </Match>
-    <Match>
         <Class name="~io\.github\.rygel\.outerstellar\.platform\.di\.DesktopComponentsKt"/>
         <Bug pattern="NP_NULL_ON_SOME_PATH"/>
     </Match>

--- a/platform-desktop-javafx/src/main/kotlin/io/github/rygel/outerstellar/platform/fx/app/JavaFxApp.kt
+++ b/platform-desktop-javafx/src/main/kotlin/io/github/rygel/outerstellar/platform/fx/app/JavaFxApp.kt
@@ -2,6 +2,7 @@ package io.github.rygel.outerstellar.platform.fx.app
 
 import io.github.rygel.outerstellar.i18n.I18nService
 import io.github.rygel.outerstellar.platform.analytics.NoOpAnalyticsService
+import io.github.rygel.outerstellar.platform.di.createSyncModules
 import io.github.rygel.outerstellar.platform.fx.FxAppContext
 import io.github.rygel.outerstellar.platform.fx.controller.MainController
 import io.github.rygel.outerstellar.platform.fx.service.FxStateProvider
@@ -31,13 +32,7 @@ import io.github.rygel.outerstellar.platform.sync.client.HttpSyncClient
 import io.github.rygel.outerstellar.platform.sync.client.NotificationClient
 import io.github.rygel.outerstellar.platform.sync.client.ProfileClient
 import io.github.rygel.outerstellar.platform.sync.client.SyncClient
-import io.github.rygel.outerstellar.platform.sync.engine.DefaultSessionLifecycle
 import io.github.rygel.outerstellar.platform.sync.engine.HttpConnectivityChecker
-import io.github.rygel.outerstellar.platform.sync.engine.module.AdminModuleImpl
-import io.github.rygel.outerstellar.platform.sync.engine.module.AuthModuleImpl
-import io.github.rygel.outerstellar.platform.sync.engine.module.NotificationModuleImpl
-import io.github.rygel.outerstellar.platform.sync.engine.module.ProfileModuleImpl
-import io.github.rygel.outerstellar.platform.sync.engine.module.SyncDataModuleImpl
 import io.micrometer.core.instrument.Metrics
 import java.awt.Desktop
 import java.net.URI
@@ -68,14 +63,6 @@ private class Repositories(
     val contactService: ContactService,
 )
 
-private class SyncModules(
-    val auth: AuthModuleImpl,
-    val syncData: SyncDataModuleImpl,
-    val profile: ProfileModuleImpl,
-    val admin: AdminModuleImpl,
-    val notification: NotificationModuleImpl,
-)
-
 class JavaFxApp : Application() {
 
     private lateinit var viewModel: FxSyncViewModel
@@ -85,7 +72,20 @@ class JavaFxApp : Application() {
         val clients = createHttpClients(fxConfig)
         val repositories = createRepositories(fxConfig)
         val analytics = NoOpAnalyticsService()
-        val modules = createModules(clients, repositories, analytics)
+        val modules =
+            createSyncModules(
+                syncClient = clients.sync,
+                authClient = clients.auth,
+                profileClient = clients.profile,
+                adminClient = clients.admin,
+                notificationClient = clients.notification,
+                messageService = repositories.messageService,
+                contactService = repositories.contactService,
+                analytics = analytics,
+                repository = repositories.messageRepository,
+                transactionManager = repositories.transactionManager,
+                notifier = FxTrayNotifier,
+            )
         val i18nService = I18nService.create("messages")
 
         viewModel =
@@ -140,43 +140,6 @@ class JavaFxApp : Application() {
         val messageService = MessageService(messageRepository, outboxRepository, transactionManager, NoOpMessageCache)
         val contactService = ContactService(contactRepository, NoOpEventPublisher, transactionManager)
         return Repositories(messageRepository, transactionManager, messageService, contactService)
-    }
-
-    private fun createModules(clients: HttpClients, repos: Repositories, analytics: NoOpAnalyticsService): SyncModules {
-        val lifecycle = DefaultSessionLifecycle()
-
-        val syncDataModule =
-            SyncDataModuleImpl(
-                syncClient = clients.sync,
-                messageService = repos.messageService,
-                contactService = repos.contactService,
-                analytics = analytics,
-                repository = repos.messageRepository,
-                transactionManager = repos.transactionManager,
-                lifecycle = lifecycle,
-                notifier = FxTrayNotifier,
-            )
-        val authModule =
-            AuthModuleImpl(
-                authClient = clients.auth,
-                analytics = analytics,
-                lifecycle = lifecycle,
-                notifier = FxTrayNotifier,
-            )
-        val profileModule =
-            ProfileModuleImpl(
-                profileClient = clients.profile,
-                analytics = analytics,
-                lifecycle = lifecycle,
-                notifier = FxTrayNotifier,
-            )
-        val adminModule = AdminModuleImpl(adminClient = clients.admin, analytics = analytics, lifecycle = lifecycle)
-        val notificationModule =
-            NotificationModuleImpl(notificationClient = clients.notification, lifecycle = lifecycle)
-
-        lifecycle.initialize(syncDataModule = syncDataModule, authModule = authModule, authClient = clients.auth)
-
-        return SyncModules(authModule, syncDataModule, profileModule, adminModule, notificationModule)
     }
 
     override fun start(primaryStage: Stage) {

--- a/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/di/DesktopComponents.kt
+++ b/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/di/DesktopComponents.kt
@@ -19,18 +19,7 @@ import io.github.rygel.outerstellar.platform.sync.client.HttpSyncClient
 import io.github.rygel.outerstellar.platform.sync.client.NotificationClient
 import io.github.rygel.outerstellar.platform.sync.client.ProfileClient
 import io.github.rygel.outerstellar.platform.sync.client.SyncClient
-import io.github.rygel.outerstellar.platform.sync.engine.DefaultSessionLifecycle
 import io.github.rygel.outerstellar.platform.sync.engine.DesktopAppConfig
-import io.github.rygel.outerstellar.platform.sync.engine.module.AdminModule
-import io.github.rygel.outerstellar.platform.sync.engine.module.AdminModuleImpl
-import io.github.rygel.outerstellar.platform.sync.engine.module.AuthModule
-import io.github.rygel.outerstellar.platform.sync.engine.module.AuthModuleImpl
-import io.github.rygel.outerstellar.platform.sync.engine.module.NotificationModule
-import io.github.rygel.outerstellar.platform.sync.engine.module.NotificationModuleImpl
-import io.github.rygel.outerstellar.platform.sync.engine.module.ProfileModule
-import io.github.rygel.outerstellar.platform.sync.engine.module.ProfileModuleImpl
-import io.github.rygel.outerstellar.platform.sync.engine.module.SyncDataModule
-import io.github.rygel.outerstellar.platform.sync.engine.module.SyncDataModuleImpl
 import java.nio.file.Path
 import org.http4k.client.JavaHttpClient
 import org.http4k.core.HttpHandler
@@ -43,14 +32,6 @@ class HttpClients(
     val profile: ProfileClient,
     val admin: AdminClient,
     val notification: NotificationClient,
-)
-
-class SyncModules(
-    val auth: AuthModule,
-    val syncData: SyncDataModule,
-    val profile: ProfileModule,
-    val admin: AdminModule,
-    val notification: NotificationModule,
 )
 
 class DesktopComponents(
@@ -78,38 +59,6 @@ private fun createHttpClients(appConfig: DesktopAppConfig): HttpClients {
         admin = HttpAdminClient(appConfig.serverBaseUrl, session, handler),
         notification = HttpNotificationClient(appConfig.serverBaseUrl, session, handler),
     )
-}
-
-private fun createSyncModules(
-    clients: HttpClients,
-    persistence: PersistenceComponents,
-    core: CoreComponents,
-    analyticsService: AnalyticsService,
-): SyncModules {
-    val lifecycle = DefaultSessionLifecycle()
-
-    val authModule: AuthModule =
-        AuthModuleImpl(authClient = clients.auth, analytics = analyticsService, lifecycle = lifecycle)
-    val syncDataModule: SyncDataModule =
-        SyncDataModuleImpl(
-            syncClient = clients.sync,
-            messageService = core.messageService,
-            contactService = core.contactService,
-            analytics = analyticsService,
-            repository = persistence.messageRepository,
-            transactionManager = persistence.transactionManager,
-            lifecycle = lifecycle,
-        )
-    val profileModule: ProfileModule =
-        ProfileModuleImpl(profileClient = clients.profile, analytics = analyticsService, lifecycle = lifecycle)
-    val adminModule: AdminModule =
-        AdminModuleImpl(adminClient = clients.admin, analytics = analyticsService, lifecycle = lifecycle)
-    val notificationModule: NotificationModule =
-        NotificationModuleImpl(notificationClient = clients.notification, lifecycle = lifecycle)
-
-    lifecycle.initialize(syncDataModule = syncDataModule, authModule = authModule, authClient = clients.auth)
-
-    return SyncModules(authModule, syncDataModule, profileModule, adminModule, notificationModule)
 }
 
 private fun createAnalyticsService(appConfig: DesktopAppConfig): AnalyticsService =
@@ -140,7 +89,19 @@ fun createDesktopComponents(): DesktopComponents {
     val i18nService = I18nService.create("messages")
     val analyticsService = createAnalyticsService(appConfig)
     val clients = createHttpClients(appConfig)
-    val modules = createSyncModules(clients, persistence, core, analyticsService)
+    val modules =
+        createSyncModules(
+            syncClient = clients.sync,
+            authClient = clients.auth,
+            profileClient = clients.profile,
+            adminClient = clients.admin,
+            notificationClient = clients.notification,
+            messageService = core.messageService,
+            contactService = core.contactService,
+            analytics = analyticsService,
+            repository = persistence.messageRepository,
+            transactionManager = persistence.transactionManager,
+        )
 
     val syncViewModel =
         SyncViewModel(

--- a/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/di/SyncModules.kt
+++ b/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/di/SyncModules.kt
@@ -6,13 +6,7 @@ import io.github.rygel.outerstellar.platform.persistence.TransactionManager
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
 import io.github.rygel.outerstellar.platform.sync.client.AdminClient
-import io.github.rygel.outerstellar.platform.sync.client.ApiSession
 import io.github.rygel.outerstellar.platform.sync.client.AuthClient
-import io.github.rygel.outerstellar.platform.sync.client.HttpAdminClient
-import io.github.rygel.outerstellar.platform.sync.client.HttpAuthClient
-import io.github.rygel.outerstellar.platform.sync.client.HttpNotificationClient
-import io.github.rygel.outerstellar.platform.sync.client.HttpProfileClient
-import io.github.rygel.outerstellar.platform.sync.client.HttpSyncClient
 import io.github.rygel.outerstellar.platform.sync.client.NotificationClient
 import io.github.rygel.outerstellar.platform.sync.client.ProfileClient
 import io.github.rygel.outerstellar.platform.sync.client.SyncClient
@@ -29,42 +23,29 @@ import io.github.rygel.outerstellar.platform.sync.engine.module.ProfileModule
 import io.github.rygel.outerstellar.platform.sync.engine.module.ProfileModuleImpl
 import io.github.rygel.outerstellar.platform.sync.engine.module.SyncDataModule
 import io.github.rygel.outerstellar.platform.sync.engine.module.SyncDataModuleImpl
-import org.http4k.client.JavaHttpClient
-import org.http4k.core.HttpHandler
 
-class SyncClientComponents(
-    val session: ApiSession,
-    val authClient: AuthClient,
-    val syncClient: SyncClient,
-    val profileClient: ProfileClient,
-    val adminClient: AdminClient,
-    val notificationClient: NotificationClient,
-    val authModule: AuthModule,
-    val syncDataModule: SyncDataModule,
-    val profileModule: ProfileModule,
-    val adminModule: AdminModule,
-    val notificationModule: NotificationModule,
+class SyncModules(
+    val auth: AuthModule,
+    val syncData: SyncDataModule,
+    val profile: ProfileModule,
+    val admin: AdminModule,
+    val notification: NotificationModule,
 )
 
-fun createSyncClientComponents(
-    baseUrl: String,
-    analytics: AnalyticsService,
+fun createSyncModules(
+    syncClient: SyncClient,
+    authClient: AuthClient,
+    profileClient: ProfileClient,
+    adminClient: AdminClient,
+    notificationClient: NotificationClient,
     messageService: MessageService,
     contactService: ContactService?,
+    analytics: AnalyticsService,
     repository: MessageRepository,
     transactionManager: TransactionManager,
     notifier: ModuleNotifier? = null,
     connectivityChecker: ConnectivityChecker? = null,
-): SyncClientComponents {
-    val session = ApiSession()
-    val httpClient: HttpHandler = JavaHttpClient()
-
-    val authClient = HttpAuthClient(baseUrl, session, httpClient)
-    val syncClient = HttpSyncClient(baseUrl, session, httpClient)
-    val profileClient = HttpProfileClient(baseUrl, session, httpClient)
-    val adminClient = HttpAdminClient(baseUrl, session, httpClient)
-    val notificationClient = HttpNotificationClient(baseUrl, session, httpClient)
-
+): SyncModules {
     val lifecycle = DefaultSessionLifecycle()
 
     val syncDataModule: SyncDataModule =
@@ -79,10 +60,8 @@ fun createSyncClientComponents(
             notifier = notifier,
             connectivityChecker = connectivityChecker,
         )
-
     val authModule: AuthModule =
         AuthModuleImpl(authClient = authClient, analytics = analytics, lifecycle = lifecycle, notifier = notifier)
-
     val profileModule: ProfileModule =
         ProfileModuleImpl(
             profileClient = profileClient,
@@ -90,26 +69,12 @@ fun createSyncClientComponents(
             lifecycle = lifecycle,
             notifier = notifier,
         )
-
     val adminModule: AdminModule =
         AdminModuleImpl(adminClient = adminClient, analytics = analytics, lifecycle = lifecycle)
-
     val notificationModule: NotificationModule =
         NotificationModuleImpl(notificationClient = notificationClient, lifecycle = lifecycle)
 
     lifecycle.initialize(syncDataModule = syncDataModule, authModule = authModule, authClient = authClient)
 
-    return SyncClientComponents(
-        session = session,
-        authClient = authClient,
-        syncClient = syncClient,
-        profileClient = profileClient,
-        adminClient = adminClient,
-        notificationClient = notificationClient,
-        authModule = authModule,
-        syncDataModule = syncDataModule,
-        profileModule = profileModule,
-        adminModule = adminModule,
-        notificationModule = notificationModule,
-    )
+    return SyncModules(authModule, syncDataModule, profileModule, adminModule, notificationModule)
 }

--- a/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/di/SyncModules.kt
+++ b/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/di/SyncModules.kt
@@ -32,6 +32,7 @@ class SyncModules(
     val notification: NotificationModule,
 )
 
+@Suppress("LongParameterList")
 fun createSyncModules(
     syncClient: SyncClient,
     authClient: AuthClient,


### PR DESCRIPTION
## Summary

- Created shared `SyncModules` data class and `createSyncModules()` factory in `platform-sync-client/.../di/SyncModules.kt`
- Wired `DesktopComponents.kt` to call shared factory instead of its private copy
- Wired `JavaFxApp.kt` to call shared factory instead of its private copy
- Deleted dead `SyncClientComponents.kt` + its 3 SpotBugs exclusions from `config/spotbugs-exclude.xml`

This eliminates the third copy of module wiring and removes 9 SpotBugs suppressions total (3 explicit + 6 transitive from the deleted class).

## Test plan
- [x] Full reactor compile + SpotBugs: 0 bugs, 0 errors
- [x] 95/95 sync client tests pass
- [x] JavaFX module SpotBugs clean
