### PR TITLE
[codex] Add CSP nonces and fix extension route params

### DIFF
--- a/docs/features/extension-system.md
+++ b/docs/features/extension-system.md
@@ -75,6 +75,14 @@ Prefer the typed `contribute(context)` API for new code. It groups the extension
 The older override methods such as `routeRegistrations(context)` still work, but `contribute(context)` is easier to
 test and keeps route ownership metadata beside the route.
 
+Contributed script URLs from `context.assets.script(...)` are rendered by the platform shell with the current request's
+CSP nonce. If an extension replaces the shell layout or writes its own inline script tags, use `ShellView.cspNonce` as
+the nonce attribute value:
+
+```html
+<script nonce="${shell.cspNonce}">
+```
+
 ## Route Ownership
 
 Every contributed route must stay inside the prefixes declared by `ExtensionManifest.ownership`.

--- a/docs/features/security.md
+++ b/docs/features/security.md
@@ -34,10 +34,14 @@
 
 Default policy:
 ```
-default-src 'self'; script-src 'self' 'unsafe-inline';
+default-src 'self'; script-src 'self' {nonce};
 style-src 'self' 'unsafe-inline'; font-src 'self';
-connect-src 'self' ws: wss:; img-src 'self' data:;
+connect-src 'self' wss:; img-src 'self' data:;
+base-uri 'self'; form-action 'self'
 ```
+
+`{nonce}` is replaced per request with a cryptographically random `nonce-...` source. Platform layouts expose the same
+value as `ShellView.cspNonce` and render it on script tags.
 
 ## SSRF Protection
 

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
@@ -17,7 +17,7 @@ private const val DEFAULT_LOCKOUT_DURATION_SECONDS = 900L
 private const val DEFAULT_REGISTRATION_ENABLED = true
 private const val DEFAULT_SESSION_ABSOLUTE_TIMEOUT_MINUTES = 1440
 private const val DEFAULT_CSP_POLICY =
-    "default-src 'self'; script-src 'self'; " +
+    "default-src 'self'; script-src 'self' {nonce}; " +
         "style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self' wss:; img-src 'self' data:; " +
         "base-uri 'self'; form-action 'self'"
 

--- a/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ShellView.kt
+++ b/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ShellView.kt
@@ -37,6 +37,7 @@ data class ShellView(
     val changePasswordLabel: String = "Change password",
     val signOutLabel: String = "Sign out",
     val csrfToken: String = "",
+    val cspNonce: String = "",
     val notificationsUrl: String? = null,
     val unreadNotificationCount: Int = 0,
     val searchUrl: String? = "/search",

--- a/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/layouts/LayoutHead.kte
+++ b/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/layouts/LayoutHead.kte
@@ -33,9 +33,9 @@
     @for(stylesheet in shell.extensionStylesheets)
     <link rel="stylesheet" href="${stylesheet}">
     @endfor
-    <script defer src="/vendor/htmx.min.js"></script>
-    <script defer src="/vendor/htmx-ext-ws.js"></script>
+    <script defer nonce="${shell.cspNonce}" src="/vendor/htmx.min.js"></script>
+    <script defer nonce="${shell.cspNonce}" src="/vendor/htmx-ext-ws.js"></script>
     @for(script in shell.extensionScripts)
-    <script defer src="${script}"></script>
+    <script defer nonce="${shell.cspNonce}" src="${script}"></script>
     @endfor
 </head>

--- a/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/layouts/SidebarLayout.kte
+++ b/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/layouts/SidebarLayout.kte
@@ -116,6 +116,6 @@
         </aside>
     </div>
 </div>
-<script src="/platform.js?v=${shell.version}"></script>
+<script nonce="${shell.cspNonce}" src="/platform.js?v=${shell.version}"></script>
 </body>
 </html>

--- a/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/layouts/TopbarLayout.kte
+++ b/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/layouts/TopbarLayout.kte
@@ -90,6 +90,6 @@
         </footer>
     </div>
 </div>
-<script src="/platform.js?v=${shell.version}"></script>
+<script nonce="${shell.cspNonce}" src="/platform.js?v=${shell.version}"></script>
 </body>
 </html>

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -12,7 +12,9 @@ import io.github.rygel.outerstellar.platform.security.SecurityRules
 import io.github.rygel.outerstellar.platform.security.SessionService
 import java.nio.ByteBuffer
 import java.security.MessageDigest
+import java.security.SecureRandom
 import java.time.Duration
+import java.util.Base64
 import java.util.UUID
 import org.http4k.core.Body
 import org.http4k.core.Filter
@@ -31,6 +33,7 @@ import org.http4k.filter.MicrometerMetrics
 import org.http4k.filter.OpenTelemetryTracing
 import org.http4k.filter.ServerFilters
 import org.http4k.format.KotlinxSerialization
+import org.http4k.lens.RequestKey
 import org.http4k.template.TemplateRenderer
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
@@ -41,9 +44,10 @@ private const val COOKIE_MAX_AGE_DAYS = 365L
 private const val REQUEST_ID_HEADER = "X-Request-Id"
 private const val LOG_ID_LENGTH = 8
 private const val STATIC_ASSET_MAX_AGE = 31536000L
+private const val CSP_NONCE_BYTES = 16
 private const val DEFAULT_CSP_POLICY =
     "default-src 'self'; " +
-        "script-src 'self'; " +
+        "script-src 'self' {nonce}; " +
         "style-src 'self' 'unsafe-inline'; " +
         "font-src 'self'; " +
         "connect-src 'self' wss:; " +
@@ -151,6 +155,8 @@ private fun persistUserPreferences(
 
 object Filters {
     private val logger = LoggerFactory.getLogger(Filters::class.java)
+    private val secureRandom = SecureRandom()
+    val CSP_NONCE_KEY = RequestKey.optional<String>("request.cspNonce")
 
     val correlationId: Filter = Filter { next: HttpHandler ->
         { request ->
@@ -187,7 +193,9 @@ object Filters {
 
     fun securityHeaders(cspPolicy: String = DEFAULT_CSP_POLICY): Filter = Filter { next: HttpHandler ->
         { request ->
-            next(request)
+            val cspNonce = generateCspNonce()
+            val requestWithNonce = request.with(CSP_NONCE_KEY of cspNonce)
+            next(requestWithNonce)
                 .header("X-Content-Type-Options", "nosniff")
                 .header("X-Frame-Options", "DENY")
                 .header("Referrer-Policy", "strict-origin-when-cross-origin")
@@ -195,13 +203,26 @@ object Filters {
                 .header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
                 .let { response ->
                     if (!request.uri.path.startsWith("/api/")) {
-                        response.header("Content-Security-Policy", cspPolicy)
+                        response.header("Content-Security-Policy", cspPolicy.withCspNonce(cspNonce))
                     } else {
                         response
                     }
                 }
         }
     }
+
+    private fun generateCspNonce(): String {
+        val bytes = ByteArray(CSP_NONCE_BYTES)
+        secureRandom.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    private fun String.withCspNonce(cspNonce: String): String =
+        if (contains("{nonce}")) {
+            replace("{nonce}", "'nonce-$cspNonce'")
+        } else {
+            this
+        }
 
     val requestLogging: Filter = Filter { next: HttpHandler ->
         { request ->

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RequestContext.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/RequestContext.kt
@@ -54,6 +54,8 @@ class RequestContext(
 
     val csrfToken: String by lazy { request.cookie(CSRF_COOKIE)?.value ?: java.util.UUID.randomUUID().toString() }
 
+    val cspNonce: String by lazy { Filters.CSP_NONCE_KEY(request).orEmpty() }
+
     val lang: String by lazy {
         request.query("lang")
             ?: request.cookie(LANG_COOKIE)?.value

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ShellRenderer.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ShellRenderer.kt
@@ -286,6 +286,7 @@ class ShellRenderer(
             changePasswordLabel = i18n.translate("web.layout.change.password"),
             signOutLabel = i18n.translate("web.layout.sign.out"),
             csrfToken = ctx.csrfToken,
+            cspNonce = ctx.cspNonce,
             searchUrl = searchUrl(),
             searchPlaceholder = i18n.translate("web.search.placeholder"),
             searchLabel = i18n.translate("web.search.label"),

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/HttpHandlerFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/HttpHandlerFactory.kt
@@ -86,7 +86,7 @@ internal class HttpHandlerFactory(
     }
 
     private fun RouteRegistry.handlers(group: RouteGroup): List<RoutingHttpHandler> =
-        byGroup(group).mapNotNull { it.httpRoute as? RoutingHttpHandler }
+        byGroup(group).mapNotNull { it.httpRoute as? RoutingHttpHandler }.distinct()
 
     private fun routesIfPresent(handlers: List<RoutingHttpHandler>): RoutingHttpHandler? =
         handlers.takeIf { it.isNotEmpty() }?.let(::routes)

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/RouteRegistrar.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/RouteRegistrar.kt
@@ -322,22 +322,38 @@ internal class RouteRegistrar(
     }
 
     private fun registerExtensionRoutes(registry: RouteRegistry) {
-        extensionContribution.routeRegistrations.forEach { registration ->
-            val httpRoute =
-                when (val route = registration.httpRoute) {
-                    is ContractRoute -> contract { routes += route }
-                    else -> route
-                }
-            registry.register(
-                RegisteredRoute(
-                    httpRoute,
-                    RouteOwner.Extension,
-                    registration.group,
-                    registration.pathPattern,
-                    registration.method,
-                    registration.description,
+        extensionContribution.routeRegistrations
+            .filter { it.staticRoute != null }
+            .forEach { registration ->
+                registry.register(
+                    RegisteredRoute(
+                        registration.staticRoute,
+                        RouteOwner.Extension,
+                        registration.group,
+                        registration.pathPattern,
+                        registration.method,
+                        registration.description,
+                    )
                 )
-            )
-        }
+            }
+
+        extensionContribution.routeRegistrations
+            .filter { it.route != null }
+            .groupBy { it.group }
+            .forEach { (_, registrations) ->
+                val extensionContract = contract { routes += registrations.mapNotNull { it.route } }
+                registrations.forEach { registration ->
+                    registry.register(
+                        RegisteredRoute(
+                            extensionContract,
+                            RouteOwner.Extension,
+                            registration.group,
+                            registration.pathPattern,
+                            registration.method,
+                            registration.description,
+                        )
+                    )
+                }
+            }
     }
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/ServerComponentsIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/ServerComponentsIntegrationTest.kt
@@ -8,12 +8,15 @@ import io.github.rygel.outerstellar.platform.extension.PlatformExtension
 import io.github.rygel.outerstellar.platform.web.WebTest
 import kotlin.test.Test
 import org.http4k.contract.bindContract
+import org.http4k.contract.div
 import org.http4k.contract.meta
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.hamkrest.hasStatus
+import org.http4k.lens.Path
+import org.http4k.lens.string
 
 class ServerComponentsIntegrationTest : WebTest() {
     @Test
@@ -50,6 +53,21 @@ class ServerComponentsIntegrationTest : WebTest() {
             val aboutResponse = components.app.http!!(Request(GET, "/about"))
             assertThat(aboutResponse, hasStatus(Status.OK))
             assertThat(aboutResponse.bodyString(), equalTo("about"))
+        } finally {
+            components.persistence.close()
+        }
+    }
+
+    @Test
+    fun `extension contract routes with path parameters match requests`() {
+        val config = testConfig.copy(platformMode = PlatformMode.ExtensionHost)
+        val components = createServerComponents(config = config, extension = pathParameterApp())
+
+        try {
+            val response = components.app.http!!(Request(GET, "/projects/outerstellar"))
+
+            assertThat(response, hasStatus(Status.OK))
+            assertThat(response.bodyString(), equalTo("project=outerstellar"))
         } finally {
             components.persistence.close()
         }
@@ -145,6 +163,28 @@ class ServerComponentsIntegrationTest : WebTest() {
                         }
 
                 context.routes.publicUi(route, "Config probe", "/probe/config")
+            }
+        }
+
+    private fun pathParameterApp(): PlatformExtension =
+        object : PlatformExtension {
+            override val id = "path-params"
+            override val appLabel = "Path Params"
+            override val mode = PlatformMode.ExtensionHost
+
+            override fun contribute(context: ExtensionContributionContext) {
+                val slugPath = Path.string().of("slug")
+                val route =
+                    "/projects" / slugPath meta
+                        {
+                            summary = "Project detail"
+                        } bindContract
+                        GET to
+                        { slug ->
+                            { _: Request -> Response(Status.OK).body("project=$slug") }
+                        }
+
+                context.routes.publicUi(route, "Project detail", "/projects/{slug}")
             }
         }
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ExtensionRenderShellTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ExtensionRenderShellTest.kt
@@ -107,11 +107,16 @@ class ExtensionRenderShellTest {
                 .copy(
                     extensionStylesheets = listOf("/extensions/reports/assets/reports.css"),
                     extensionScripts = listOf("/extensions/reports/assets/reports.js"),
+                    cspNonce = "test-nonce",
                 )
 
         val result = ctx.renderShell(shell, "<p>content</p>")
 
         assertTrue(result.contains("""<link rel="stylesheet" href="/extensions/reports/assets/reports.css">"""))
-        assertTrue(result.contains("""<script defer src="/extensions/reports/assets/reports.js"></script>"""))
+        assertTrue(
+            result.contains(
+                """<script defer nonce="test-nonce" src="/extensions/reports/assets/reports.js"></script>"""
+            )
+        )
     }
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SecurityHeadersIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SecurityHeadersIntegrationTest.kt
@@ -125,6 +125,21 @@ class SecurityHeadersIntegrationTest : WebTest() {
     }
 
     @Test
+    fun `HTML route CSP nonce matches rendered script nonces`() {
+        val response = app(Request(GET, "/auth"))
+        val csp = response.header("Content-Security-Policy")
+        assertNotNull(csp, "CSP should be present on HTML routes")
+
+        val nonce = Regex("""'nonce-([^']+)'""").find(csp)?.groupValues?.get(1)
+        assertNotNull(nonce, "CSP should include a script nonce, got: $csp")
+        assertTrue(nonce.length >= 20, "Nonce should have enough entropy, got: $nonce")
+        assertTrue(
+            response.bodyString().contains("""<script defer nonce="$nonce" src="/vendor/htmx.min.js"></script>""")
+        )
+        assertTrue(response.bodyString().contains("""<script nonce="$nonce" src="/platform.js"""))
+    }
+
+    @Test
     fun `API route does NOT have Content-Security-Policy`() {
         val response = app(Request(GET, "/api/v1/sync").header("Authorization", "Bearer $sessionToken"))
         val csp = response.header("Content-Security-Policy")

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.kt
@@ -15,6 +15,7 @@ class ErrorPagesApprovalTest : WebTest() {
     private val app by lazy { buildApp() }
 
     private val csrfTokenPattern = Regex("""name="csrf-token" content="[^"]+"""")
+    private val cspNoncePattern = Regex("""nonce="[^"]+"""")
     private val cacheBusterPattern = Regex("""\?v=[A-Za-z0-9._-]+""")
 
     private fun normalize(response: Response): Response {
@@ -22,6 +23,7 @@ class ErrorPagesApprovalTest : WebTest() {
             response
                 .bodyString()
                 .replace(csrfTokenPattern, """name="csrf-token" content="[CSRF-TOKEN]"""")
+                .replace(cspNoncePattern, """nonce="[CSP-NONCE]"""")
                 .replace(cacheBusterPattern, "?v=[CACHE-BUSTER]")
         return response.body(normalized)
     }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/fuzz/WebFuzzTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/fuzz/WebFuzzTest.kt
@@ -78,7 +78,14 @@ class WebFuzzTest {
         val filter = Filters.securityHeaders(cspPolicy = input).then { _: Request -> Response(Status.OK).body("ok") }
 
         val uiResponse = filter(Request(Method.GET, "/"))
-        assertEquals(input, uiResponse.header("Content-Security-Policy"))
+        val actualPolicy = uiResponse.header("Content-Security-Policy").orEmpty()
+        if (input.contains("{nonce}")) {
+            val expectedPolicy =
+                Regex(Regex.escape(input).replace(Regex.escape("{nonce}"), """'nonce-[A-Za-z0-9_-]+'"""))
+            assertTrue(expectedPolicy.matches(actualPolicy))
+        } else {
+            assertEquals(input, actualPolicy)
+        }
 
         val apiResponse = filter(Request(Method.GET, "/api/v1/health"))
         assertNull(apiResponse.header("Content-Security-Policy"))

--- a/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.forbidden page.approved
+++ b/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.forbidden page.approved
@@ -27,8 +27,8 @@
     <link href="/vendor/remixicon/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="/site.css?v=[CACHE-BUSTER]">
     
-    <script defer src="/vendor/htmx.min.js"></script>
-    <script defer src="/vendor/htmx-ext-ws.js"></script>
+    <script defer nonce="[CSP-NONCE]" src="/vendor/htmx.min.js"></script>
+    <script defer nonce="[CSP-NONCE]" src="/vendor/htmx-ext-ws.js"></script>
     
 </head>
 
@@ -278,6 +278,9 @@
         </aside>
     </div>
 </div>
-<script src="/platform.js?v=[CACHE-BUSTER]"></script>
+<script nonce="[CSP-NONCE]" src="/platform.js?v=[CACHE-BUSTER]"></script>
 </body>
 </html>
+
+
+

--- a/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.not-found error page.approved
+++ b/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.not-found error page.approved
@@ -27,8 +27,8 @@
     <link href="/vendor/remixicon/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="/site.css?v=[CACHE-BUSTER]">
     
-    <script defer src="/vendor/htmx.min.js"></script>
-    <script defer src="/vendor/htmx-ext-ws.js"></script>
+    <script defer nonce="[CSP-NONCE]" src="/vendor/htmx.min.js"></script>
+    <script defer nonce="[CSP-NONCE]" src="/vendor/htmx-ext-ws.js"></script>
     
 </head>
 
@@ -278,8 +278,9 @@
         </aside>
     </div>
 </div>
-<script src="/platform.js?v=[CACHE-BUSTER]"></script>
+<script nonce="[CSP-NONCE]" src="/platform.js?v=[CACHE-BUSTER]"></script>
 </body>
 </html>
+
 
 

--- a/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.server-error page.approved
+++ b/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.server-error page.approved
@@ -27,8 +27,8 @@
     <link href="/vendor/remixicon/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="/site.css?v=[CACHE-BUSTER]">
     
-    <script defer src="/vendor/htmx.min.js"></script>
-    <script defer src="/vendor/htmx-ext-ws.js"></script>
+    <script defer nonce="[CSP-NONCE]" src="/vendor/htmx.min.js"></script>
+    <script defer nonce="[CSP-NONCE]" src="/vendor/htmx-ext-ws.js"></script>
     
 </head>
 
@@ -278,8 +278,9 @@
         </aside>
     </div>
 </div>
-<script src="/platform.js?v=[CACHE-BUSTER]"></script>
+<script nonce="[CSP-NONCE]" src="/platform.js?v=[CACHE-BUSTER]"></script>
 </body>
 </html>
+
 
 


### PR DESCRIPTION
## Summary

Adds nonce-based Content Security Policy support for platform-rendered pages and extension shell scripts, then fixes extension contract route mounting so path-parameter routes match at runtime.

## What changed

- Generate a cryptographic CSP nonce per request and expand `{nonce}` in configured CSP policies.
- Expose the nonce as `ShellView.cspNonce` and render it on platform and extension script tags.
- Update the default CSP docs and extension author guidance for nonce usage.
- Group extension `ContractRoute` registrations into a shared contract per route group, preserving route-table metadata while fixing path-parameter matching.
- Add regression coverage for CSP/header-to-template nonce consistency, extension script nonce rendering, extension path-parameter routes, and error-page approval output with normalized nonces.

## Why

The previous default `script-src 'self'` blocked inline scripts unless deployments weakened CSP with `unsafe-inline`. Extension path-parameter routes were also registered but could return 404 because each contributed `ContractRoute` was wrapped in an isolated contract.

## Validation

- `mvn -pl platform-web -am test "-Dtest=SecurityHeadersIntegrationTest,ExtensionRenderShellTest,ServerComponentsIntegrationTest,GlobalErrorHandlerTest" "-DfailIfNoTests=false" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dexec.skip=true"`
- `mvn -pl platform-web -am test "-Dtest=ErrorPagesApprovalTest" "-DfailIfNoTests=false" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dexec.skip=true"`
- `mvn -pl platform-web -am test "-DfailIfNoTests=false" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dexec.skip=true"`

## Issues

Covers #472 and #471. Also verified #467 was already fixed by existing error-handler behavior and regression tests.