### PR TITLE
release: v3.6.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [3.6.13] – 2026-06-08
+
+### Fixed
+
+- **Global error handler fallback response** — when an exception occurs and rendering the normal error page also fails, the platform now returns a plain-text 500 response containing the original exception message instead of replacing it with a generic emergency HTML page.
+
+---
+
 ## [3.6.12] – 2026-06-07
 
 ### Added

--- a/outerstellar-i18n-validator-maven-plugin/pom.xml
+++ b/outerstellar-i18n-validator-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.12</version>
+        <version>3.6.13</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n-validator/pom.xml
+++ b/outerstellar-i18n-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.12</version>
+        <version>3.6.13</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n/pom.xml
+++ b/outerstellar-i18n/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.12</version>
+        <version>3.6.13</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-platform-extension-archetype/pom.xml
+++ b/outerstellar-platform-extension-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.12</version>
+        <version>3.6.13</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-archetype</artifactId>

--- a/outerstellar-platform-extension-parent/pom.xml
+++ b/outerstellar-platform-extension-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.12</version>
+        <version>3.6.13</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-parent</artifactId>

--- a/platform-core/pom.xml
+++ b/platform-core/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.12</version>
+        <version>3.6.13</version>
 
     </parent>
 

--- a/platform-desktop-javafx/pom.xml
+++ b/platform-desktop-javafx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.12</version>
+        <version>3.6.13</version>
     </parent>
 
     <artifactId>outerstellar-platform-desktop-javafx</artifactId>

--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.12</version>
+        <version>3.6.13</version>
 
     </parent>
 

--- a/platform-extension-api/pom.xml
+++ b/platform-extension-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.12</version>
+        <version>3.6.13</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-api</artifactId>

--- a/platform-jte-extensions/pom.xml
+++ b/platform-jte-extensions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.12</version>
+        <version>3.6.13</version>
     </parent>
 
     <artifactId>outerstellar-platform-jte-extensions</artifactId>

--- a/platform-persistence-jdbi/pom.xml
+++ b/platform-persistence-jdbi/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.12</version>
+        <version>3.6.13</version>
 
     </parent>
 

--- a/platform-security/pom.xml
+++ b/platform-security/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.12</version>
+        <version>3.6.13</version>
 
     </parent>
 

--- a/platform-seeder/pom.xml
+++ b/platform-seeder/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.12</version>
+        <version>3.6.13</version>
 
     </parent>
 

--- a/platform-sync-client/pom.xml
+++ b/platform-sync-client/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.12</version>
+        <version>3.6.13</version>
 
     </parent>
 

--- a/platform-testkit/pom.xml
+++ b/platform-testkit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.12</version>
+        <version>3.6.13</version>
     </parent>
 
     <artifactId>outerstellar-platform-testkit</artifactId>

--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.12</version>
+        <version>3.6.13</version>
 
     </parent>
 

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -520,14 +520,16 @@ object Filters {
                 Response(status).header("content-type", "text/html; charset=utf-8").body(renderer(errorPage))
             } catch (renderEx: Exception) {
                 logErrorPageRenderFailure(request, status, originalException = e, renderException = renderEx)
-                emergencyErrorResponse(
-                    status = status,
-                    title = status.description,
-                    message = "The error has been logged.",
-                    request = request,
-                )
+                plainTextOriginalErrorResponse(status, e)
             }
         }
+    }
+
+    private fun plainTextOriginalErrorResponse(status: Status, originalException: Exception): Response {
+        val message = originalException.message ?: "An unexpected error occurred"
+        return Response(status)
+            .header("content-type", "text/plain; charset=utf-8")
+            .body("Internal Server Error: $message")
     }
 
     private fun logErrorPageRenderFailure(

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/GlobalErrorHandlerTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/GlobalErrorHandlerTest.kt
@@ -21,7 +21,7 @@ class GlobalErrorHandlerTest {
     private val errorPageFactory = ErrorPageFactory()
 
     @Test
-    fun `error handler returns emergency error page when template rendering fails`() {
+    fun `error handler returns plain text with original exception when template rendering fails`() {
         val handler =
             Filters.globalErrorHandler(errorPageFactory, brokenRenderer).then {
                 throw HandlerTestException("something broke in the handler")
@@ -30,23 +30,19 @@ class GlobalErrorHandlerTest {
         val response = handler(pageRequest("/test-page", "request-123"))
 
         assertThat(response, hasStatus(Status.INTERNAL_SERVER_ERROR))
-        assertThat(response, hasHeader("content-type", "text/html; charset=utf-8"))
-        assertThat(response, hasBody(containsSubstring("<h1>Internal Server Error</h1>")))
-        assertThat(response, hasBody(containsSubstring("The error has been logged.")))
-        assertThat(response, hasBody(containsSubstring("Reference: request-123")))
-        assertThat(response, hasBody(!containsSubstring("something broke in the handler")))
+        assertThat(response, hasHeader("content-type", "text/plain; charset=utf-8"))
+        assertThat(response, hasBody("Internal Server Error: something broke in the handler"))
     }
 
     @Test
-    fun `error handler returns emergency error page with request reference when exception has no message`() {
+    fun `error handler returns plain text with generic message when exception has no message`() {
         val handler = Filters.globalErrorHandler(errorPageFactory, brokenRenderer).then { throw HandlerTestException() }
 
         val response = handler(pageRequest("/test-page", "request-456"))
 
         assertThat(response, hasStatus(Status.INTERNAL_SERVER_ERROR))
-        assertThat(response, hasBody(containsSubstring("<h1>Internal Server Error</h1>")))
-        assertThat(response, hasBody(containsSubstring("The error has been logged.")))
-        assertThat(response, hasBody(containsSubstring("Reference: request-456")))
+        assertThat(response, hasHeader("content-type", "text/plain; charset=utf-8"))
+        assertThat(response, hasBody("Internal Server Error: An unexpected error occurred"))
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.rygel</groupId>
     <artifactId>outerstellar-platform-parent</artifactId>
 
-    <version>3.6.12</version>
+    <version>3.6.13</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Summary
- Prepare platform release `3.6.13`
- Add `CHANGELOG.md` entry for `3.6.13`
- Preserve the original handler exception message in the plain-text fallback when error-page rendering fails

## Validation
- `mvn -pl platform-web -am test -Dtest=GlobalErrorHandlerTest "-Dsurefire.failIfNoSpecifiedTests=false" "-Dexec.skip=true"`
- `mvn install -T 1C -DskipTests "-Djacoco.skip=true" "-Denforcer.skip=true"`
- `mvn --% clean verify -T4 -pl !platform-desktop,!platform-desktop-javafx`
- `pwsh scripts/test-desktop.ps1`