### PR TITLE
feat: support external static assets

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -463,6 +463,7 @@ runtime:
 | `maxFailedLoginAttempts` | `MAX_FAILED_LOGIN_ATTEMPTS` | 10 | Account lockout threshold |
 | `lockoutDurationSeconds` | `LOCKOUT_DURATION_SECONDS` | 900 | Account lockout duration |
 | `cspPolicy` | `CSP_POLICY` | (default CSP string) | Content-Security-Policy header |
+| `staticDir` | `STATIC_DIR` (`ASSETS_DIR` alias) | "" | Filesystem directory for static assets before classpath fallback |
 | `version` | `VERSION` | `dev` | Application version label |
 
 ---

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -39,6 +39,7 @@ Usage: `APP_PROFILE=small mvn exec:java`
 | `maxFailedLoginAttempts` | `MAX_FAILED_LOGIN_ATTEMPTS` | 10 | Account lockout threshold |
 | `lockoutDurationSeconds` | `LOCKOUT_DURATION_SECONDS` | 900 | Lockout duration (seconds) |
 | `cspPolicy` | `CSP_POLICY` | (default policy) | Content-Security-Policy |
+| `staticDir` | `STATIC_DIR` (`ASSETS_DIR` alias) | "" | Filesystem directory for static assets before classpath fallback |
 | `version` | `VERSION` | `dev` | Version label |
 
 ### Runtime Sizing

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
@@ -80,6 +80,7 @@ data class AppConfig(
     val sessionAbsoluteTimeoutMinutes: Int = DEFAULT_SESSION_ABSOLUTE_TIMEOUT_MINUTES,
     val jwt: JwtConfig = JwtConfig(),
     val cspPolicy: String = DEFAULT_CSP_POLICY,
+    val staticDir: String = "",
     val trustedProxies: String = "",
     val appleOAuth: AppleOAuthConfig = AppleOAuthConfig(),
     val pushNotifications: PushNotificationConfig = PushNotificationConfig(),
@@ -171,6 +172,7 @@ data class AppConfig(
                     ),
                 jwt = buildJwtConfig(yaml["jwt"] as? Map<String, Any>, env),
                 cspPolicy = yaml.str("cspPolicy", env, "CSP_POLICY", DEFAULT_CSP_POLICY),
+                staticDir = yaml.staticDir(env),
                 trustedProxies = yaml.str("trustedProxies", env, "TRUSTED_PROXIES", ""),
                 appleOAuth = buildAppleOAuthConfig(yaml["appleOAuth"] as? Map<String, Any>, env),
                 pushNotifications = buildPushNotificationConfig(yaml["pushNotifications"] as? Map<String, Any>, env),
@@ -329,6 +331,9 @@ data class AppConfig(
 
 private fun Map<String, Any>.str(key: String, env: Map<String, String>, envKey: String, default: String): String =
     env[envKey] ?: (this[key] as? String) ?: default
+
+private fun Map<String, Any>.staticDir(env: Map<String, String>): String =
+    env["STATIC_DIR"] ?: env["ASSETS_DIR"] ?: (this["staticDir"] as? String) ?: (this["assetsDir"] as? String) ?: ""
 
 private fun Map<String, Any>.int(key: String, env: Map<String, String>, envKey: String, default: Int): Int =
     env[envKey]?.toInt() ?: (this[key] as? Int) ?: default

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/AppConfigTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/AppConfigTest.kt
@@ -40,6 +40,24 @@ class AppConfigTest {
     }
 
     @Test
+    fun `static dir is set from STATIC_DIR env var`() {
+        val config = AppConfig.fromEnvironment(mapOf("STATIC_DIR" to "C:\\outerstellar\\assets"))
+
+        assert(config.staticDir == "C:\\outerstellar\\assets") {
+            "Expected STATIC_DIR value but was ${config.staticDir}"
+        }
+    }
+
+    @Test
+    fun `static dir is set from ASSETS_DIR env var`() {
+        val config = AppConfig.fromEnvironment(mapOf("ASSETS_DIR" to "C:\\outerstellar\\assets"))
+
+        assert(config.staticDir == "C:\\outerstellar\\assets") {
+            "Expected ASSETS_DIR value but was ${config.staticDir}"
+        }
+    }
+
+    @Test
     fun `accepts valid config without warnings`() {
         val env =
             mapOf(

--- a/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContributionContext.kt
+++ b/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContributionContext.kt
@@ -82,6 +82,8 @@ class ExtensionRouteContributionRegistry internal constructor(private val host: 
         registrations +=
             ExtensionRouteRegistration.staticAssets(
                 route = pathPrefix bind static(loader),
+                pathPrefix = pathPrefix,
+                loader = loader,
                 description = description,
                 pathPattern = "$pathPrefix/*",
             )

--- a/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/PlatformExtensionApi.kt
+++ b/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/PlatformExtensionApi.kt
@@ -13,6 +13,7 @@ import io.github.rygel.outerstellar.platform.web.ShellView
 import java.util.UUID
 import org.http4k.contract.ContractRoute
 import org.http4k.core.Request
+import org.http4k.routing.ResourceLoader
 import org.http4k.routing.RoutingHttpHandler
 import org.http4k.template.TemplateRenderer
 
@@ -63,6 +64,8 @@ data class ExtensionRouteRegistration(
     val pathPattern: String = description,
     val method: String = "*",
     val staticRoute: RoutingHttpHandler? = null,
+    val staticPathPrefix: String? = null,
+    val staticLoader: ResourceLoader? = null,
 ) {
     val httpRoute: Any?
         get() = route ?: staticRoute
@@ -70,6 +73,8 @@ data class ExtensionRouteRegistration(
     companion object {
         fun staticAssets(
             route: RoutingHttpHandler,
+            pathPrefix: String,
+            loader: ResourceLoader,
             description: String,
             pathPattern: String,
             method: String = "GET",
@@ -81,6 +86,8 @@ data class ExtensionRouteRegistration(
                 pathPattern = pathPattern,
                 method = method,
                 staticRoute = route,
+                staticPathPrefix = pathPrefix,
+                staticLoader = loader,
             )
     }
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/FilesystemFirstResourceLoader.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/FilesystemFirstResourceLoader.kt
@@ -1,0 +1,19 @@
+package io.github.rygel.outerstellar.platform.web.assembly
+
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Path
+import org.http4k.routing.ResourceLoader
+
+internal class FilesystemFirstResourceLoader(directory: Path, private val fallback: ResourceLoader) : ResourceLoader {
+    private val root = directory.toAbsolutePath().normalize()
+
+    override fun load(path: String): URL? {
+        val relativeName = path.trimStart('/')
+        val candidate = root.resolve(relativeName).normalize()
+        if (candidate.startsWith(root) && Files.isRegularFile(candidate)) {
+            return candidate.toUri().toURL()
+        }
+        return fallback.load(path)
+    }
+}

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/HttpHandlerFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/HttpHandlerFactory.kt
@@ -12,6 +12,7 @@ import io.github.rygel.outerstellar.platform.security.SecurityRules
 import io.github.rygel.outerstellar.platform.web.Metrics
 import io.github.rygel.outerstellar.platform.web.TOTPApiRoutes
 import io.github.rygel.outerstellar.platform.web.TOTPRoutes
+import java.nio.file.Path
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
@@ -48,7 +49,7 @@ internal class HttpHandlerFactory(
 
         val unfiltered =
             mutableListOf(
-                static(ResourceLoader.Classpath("static")),
+                static(staticResourceLoader()),
                 "/health" bind
                     GET to
                     {
@@ -90,4 +91,10 @@ internal class HttpHandlerFactory(
 
     private fun routesIfPresent(handlers: List<RoutingHttpHandler>): RoutingHttpHandler? =
         handlers.takeIf { it.isNotEmpty() }?.let(::routes)
+
+    private fun staticResourceLoader(): ResourceLoader {
+        val fallback = ResourceLoader.Classpath("static")
+        val staticDir = config.staticDir.takeIf { it.isNotBlank() } ?: return fallback
+        return FilesystemFirstResourceLoader(Path.of(staticDir), fallback)
+    }
 }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/RouteRegistrar.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/RouteRegistrar.kt
@@ -35,6 +35,7 @@ import io.github.rygel.outerstellar.platform.web.UserAdminApi
 import io.github.rygel.outerstellar.platform.web.UserAdminRoutes
 import io.github.rygel.outerstellar.platform.web.VoteApi
 import io.github.rygel.outerstellar.platform.web.composition.PlatformPageSets
+import java.nio.file.Path
 import org.http4k.contract.ContractRoute
 import org.http4k.contract.contract
 import org.http4k.contract.openapi.ApiInfo
@@ -48,6 +49,7 @@ import org.http4k.format.KotlinxSerialization
 import org.http4k.routing.RoutingHttpHandler
 import org.http4k.routing.bind
 import org.http4k.routing.routes
+import org.http4k.routing.static
 import org.http4k.security.Security
 
 @Suppress("LongParameterList")
@@ -325,9 +327,10 @@ internal class RouteRegistrar(
         extensionContribution.routeRegistrations
             .filter { it.staticRoute != null }
             .forEach { registration ->
+                val staticRoute = externalStaticRoute(registration) ?: registration.staticRoute
                 registry.register(
                     RegisteredRoute(
-                        registration.staticRoute,
+                        staticRoute,
                         RouteOwner.Extension,
                         registration.group,
                         registration.pathPattern,
@@ -355,5 +358,14 @@ internal class RouteRegistrar(
                     )
                 }
             }
+    }
+
+    private fun externalStaticRoute(
+        registration: io.github.rygel.outerstellar.platform.extension.ExtensionRouteRegistration
+    ): RoutingHttpHandler? {
+        val staticDir = config.staticDir.takeIf { it.isNotBlank() } ?: return null
+        val pathPrefix = registration.staticPathPrefix ?: return null
+        val fallbackLoader = registration.staticLoader ?: return null
+        return pathPrefix bind static(FilesystemFirstResourceLoader(Path.of(staticDir), fallbackLoader))
     }
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/StaticAssetIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/StaticAssetIntegrationTest.kt
@@ -2,6 +2,8 @@ package io.github.rygel.outerstellar.platform.web
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.containsSubstring
+import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import org.http4k.core.Method.GET
@@ -65,16 +67,45 @@ class StaticAssetIntegrationTest : WebTest() {
     }
 
     @Test
-    fun `extension static files are served without authentication`() {
-        val extension =
-            object : PlatformExtension {
-                override val id = "reports"
+    fun `platform static files prefer configured filesystem directory`() {
+        val staticDir = createStaticDir()
+        Files.writeString(staticDir.resolve("site.css"), "body { color: seagreen; }")
 
-                override fun contribute(context: ExtensionContributionContext) {
-                    context.routes.staticAssets("/extensions/reports/assets", ResourceLoader.Classpath("static"))
-                }
-            }
-        val response = buildApp(extension = extension)(Request(GET, "/extensions/reports/assets/site.css"))
+        val response = buildApp(config = testConfig.copy(staticDir = staticDir.toString()))(Request(GET, "/site.css"))
+
+        assertThat(response, hasStatus(Status.OK))
+        assertThat(response, hasBody(containsSubstring("seagreen")))
+    }
+
+    @Test
+    fun `extension static files are served without authentication`() {
+        val response = buildApp(extension = reportsExtension())(Request(GET, "/extensions/reports/assets/site.css"))
+
+        assertThat(response, hasStatus(Status.OK))
+        assertThat(response, hasBody(containsSubstring(".")))
+    }
+
+    @Test
+    fun `extension static files prefer configured filesystem directory`() {
+        val staticDir = createStaticDir()
+        Files.writeString(staticDir.resolve("site.css"), "body { color: hotpink; }")
+
+        val response =
+            buildApp(config = testConfig.copy(staticDir = staticDir.toString()), extension = reportsExtension())(
+                Request(GET, "/extensions/reports/assets/site.css")
+            )
+
+        assertThat(response, hasStatus(Status.OK))
+        assertThat(response, hasBody(containsSubstring("hotpink")))
+    }
+
+    @Test
+    fun `extension static files fall back to classpath when configured filesystem file is absent`() {
+        val staticDir = createStaticDir()
+        val response =
+            buildApp(config = testConfig.copy(staticDir = staticDir.toString()), extension = reportsExtension())(
+                Request(GET, "/extensions/reports/assets/site.css")
+            )
 
         assertThat(response, hasStatus(Status.OK))
         assertThat(response, hasBody(containsSubstring(".")))
@@ -106,5 +137,20 @@ class StaticAssetIntegrationTest : WebTest() {
             response.header("ETag") == null,
             "JSON responses should not have ETag, got: ${response.header("ETag")}",
         )
+    }
+
+    private fun reportsExtension(): PlatformExtension =
+        object : PlatformExtension {
+            override val id = "reports"
+
+            override fun contribute(context: ExtensionContributionContext) {
+                context.routes.staticAssets("/extensions/reports/assets", ResourceLoader.Classpath("static"))
+            }
+        }
+
+    private fun createStaticDir(): Path {
+        val root = Path.of("target", "test-static-assets")
+        Files.createDirectories(root)
+        return Files.createTempDirectory(root, "static-")
     }
 }


### PR DESCRIPTION
## Summary
- add `STATIC_DIR` / `ASSETS_DIR` config for filesystem-first static asset lookup
- apply the fallback chain to platform static assets and extension static asset routes
- document the new config and cover platform + extension static behavior with integration tests

Closes #479.

## Validation
- `mvn -pl platform-core -am test "-Dtest=AppConfigTest" "-Dsurefire.failIfNoSpecifiedTests=false"`
- `mvn -pl platform-web -am test "-Dtest=StaticAssetIntegrationTest" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dexec.skip=true"`
- `mvn install -T 1C -DskipTests "-Djacoco.skip=true" "-Denforcer.skip=true"`
- `mvn --% clean verify -T4 -pl !platform-desktop,!platform-desktop-javafx`
