### PR TITLE
feat: improve platform diagnostics

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -394,6 +394,15 @@ mvn spotless:check checkstyle:check pmd:check spotbugs:check detekt:check
 | `scripts/stop-web.ps1` | Kill web dev stack |
 | `scripts/start-swing.ps1` | Start Swing desktop client |
 
+The web and test scripts mark their Maven-launched JVMs with `-Dagent.owner=...` and `-Dagent.task=...`.
+On a shared Windows machine, identify marked processes with:
+
+```powershell
+Get-CimInstance Win32_Process |
+  Where-Object { $_.CommandLine -match 'agent.owner=' -or $_.CommandLine -match 'AGENT_OWNER=' } |
+  Select-Object ProcessId, CommandLine
+```
+
 ---
 
 ## Configuration Reference
@@ -489,6 +498,21 @@ For large deployments (2 GB+ heap), enable parallel GC and preload:
 
 ```bash
 java -Xms2g -Xmx4g -XX:+UseParallelGC -Djte.production=true -DJTE_PRELOAD_ENABLED=true -jar platform-web/target/platform-web-*.jar
+```
+
+When launching manually on a shared machine, add process markers to JVM commands:
+
+```bash
+java -Dagent.owner=outerstellar -Dagent.task=web-prod -Xms256m -Xmx1g -jar platform-web/target/platform-web-*.jar
+```
+
+For native-image binaries, record the owner by the supervisor or wrapper command and by the listening port:
+
+```powershell
+$env:AGENT_OWNER = "outerstellar"
+$env:AGENT_TASK = "native-web"
+.\platform-web.exe
+Get-NetTCPConnection -LocalPort 8080 -State Listen | Select-Object OwningProcess, LocalPort
 ```
 
 > **JVM vs Native Image (item #17):** Native image (GraalVM) can reduce cold start time from ~3-5s to <1s and idle RSS from ~150 MB to ~50 MB. However, peak throughput is typically comparable or slightly lower than JVM due to the absence of JIT optimizations. The best deployment strategy is: use JVM for steady-state workloads (servers), use native-image for short-lived or auto-scaling workloads (serverless, batch jobs). Run your own benchmark with `APP_PROFILE=small` on both runtimes before choosing.

--- a/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContribution.kt
+++ b/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContribution.kt
@@ -18,6 +18,7 @@ data class ExtensionContribution(
     val adminSections: List<AdminSection> = emptyList(),
     val bannerProviders: List<BannerProvider> = emptyList(),
     val templateOverrides: Set<String> = emptySet(),
+    val readinessChecks: List<ExtensionReadinessCheck> = emptyList(),
     val options: ExtensionOptions = ExtensionOptions(),
 ) {
     fun diagnostics(): ExtensionDiagnostics =
@@ -71,6 +72,7 @@ data class ExtensionContribution(
             includedPlatformPages = includedPlatformPages.map { it.pageSet.id }.sorted(),
             stylesheets = options.assets.stylesheets,
             scripts = options.assets.scripts,
+            readiness = readinessChecks,
             ownership = effectiveOwnership?.toDiagnostics(),
         )
 
@@ -107,6 +109,7 @@ data class ExtensionContribution(
                 adminSections = adminSections,
                 bannerProviders = contributionContext.bannerRegistry.snapshot(),
                 templateOverrides = contributionContext.templateOverrideRegistry.snapshot(),
+                readinessChecks = contributionContext.readinessRegistry.snapshot(),
                 options =
                     ExtensionOptions(
                         navItems = contributionContext.navigationRegistry.snapshot(),
@@ -189,6 +192,7 @@ data class ExtensionDiagnostics(
     val includedPlatformPages: List<String>,
     val stylesheets: List<String>,
     val scripts: List<String>,
+    val readiness: List<ExtensionReadinessCheck>,
     val ownership: ExtensionOwnershipDiagnostics?,
 )
 

--- a/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContributionContext.kt
+++ b/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContributionContext.kt
@@ -31,6 +31,7 @@ internal constructor(
         ExtensionNavigationContributionRegistry(),
     internal val layoutRegistry: ExtensionLayoutContributionRegistry = ExtensionLayoutContributionRegistry(),
     internal val assetRegistry: ExtensionAssetContributionRegistry = ExtensionAssetContributionRegistry(),
+    internal val readinessRegistry: ExtensionReadinessContributionRegistry = ExtensionReadinessContributionRegistry(),
     internal val templateOverrideRegistry: ExtensionTemplateContributionRegistry =
         ExtensionTemplateContributionRegistry(),
 ) {
@@ -42,6 +43,7 @@ internal constructor(
     val navigation: ExtensionNavigationContributionRegistry = navigationRegistry
     val layout: ExtensionLayoutContributionRegistry = layoutRegistry
     val assets: ExtensionAssetContributionRegistry = assetRegistry
+    val readiness: ExtensionReadinessContributionRegistry = readinessRegistry
     val templates: ExtensionTemplateContributionRegistry = templateOverrideRegistry
 }
 
@@ -102,7 +104,7 @@ class ExtensionRouteContributionRegistry internal constructor(private val host: 
                 { req: Request ->
                     val viewModel = model(req)
                     val html = host.rendering.renderer(viewModel)
-                    Response(OK).header("content-type", "text/html; charset=utf-8").body(html as String)
+                    Response(OK).header("content-type", "text/html; charset=utf-8").body(html)
                 }
         register(route, group, description, path, "GET")
     }
@@ -237,6 +239,30 @@ class ExtensionAssetContributionRegistry internal constructor() {
 
     internal fun snapshot(): ExtensionAssets =
         ExtensionAssets(stylesheets = stylesheets.toList(), scripts = scripts.toList())
+}
+
+class ExtensionReadinessContributionRegistry internal constructor() {
+    private val checks = mutableListOf<ExtensionReadinessCheck>()
+
+    fun up(name: String, message: String, required: Boolean = true) {
+        check(ExtensionReadinessCheck(name, ExtensionReadinessStatus.UP, message, required))
+    }
+
+    fun warn(name: String, message: String, required: Boolean = false) {
+        check(ExtensionReadinessCheck(name, ExtensionReadinessStatus.WARN, message, required))
+    }
+
+    fun down(name: String, message: String, required: Boolean = true) {
+        check(ExtensionReadinessCheck(name, ExtensionReadinessStatus.DOWN, message, required))
+    }
+
+    fun check(check: ExtensionReadinessCheck) {
+        require(check.name.isNotBlank()) { "Extension readiness check name must not be blank." }
+        require(check.message.isNotBlank()) { "Extension readiness check message must not be blank." }
+        checks += check
+    }
+
+    internal fun snapshot(): List<ExtensionReadinessCheck> = checks.toList()
 }
 
 class ExtensionTemplateContributionRegistry internal constructor() {

--- a/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/PlatformExtensionApi.kt
+++ b/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/PlatformExtensionApi.kt
@@ -87,6 +87,19 @@ data class ExtensionRouteRegistration(
 
 data class ExtensionAssets(val stylesheets: List<String> = emptyList(), val scripts: List<String> = emptyList())
 
+enum class ExtensionReadinessStatus {
+    UP,
+    WARN,
+    DOWN,
+}
+
+data class ExtensionReadinessCheck(
+    val name: String,
+    val status: ExtensionReadinessStatus,
+    val message: String,
+    val required: Boolean = true,
+)
+
 fun interface ExtensionLayoutRenderer {
     fun render(shell: ShellView, content: Content): Content
 }

--- a/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ExtensionContributionContext.kt
+++ b/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ExtensionContributionContext.kt
@@ -26,5 +26,12 @@ typealias ExtensionLayoutContributionRegistry =
 typealias ExtensionAssetContributionRegistry =
     io.github.rygel.outerstellar.platform.extension.ExtensionAssetContributionRegistry
 
+typealias ExtensionReadinessContributionRegistry =
+    io.github.rygel.outerstellar.platform.extension.ExtensionReadinessContributionRegistry
+
+typealias ExtensionReadinessCheck = io.github.rygel.outerstellar.platform.extension.ExtensionReadinessCheck
+
+typealias ExtensionReadinessStatus = io.github.rygel.outerstellar.platform.extension.ExtensionReadinessStatus
+
 typealias ExtensionTemplateContributionRegistry =
     io.github.rygel.outerstellar.platform.extension.ExtensionTemplateContributionRegistry

--- a/platform-extension-api/src/test/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContractTest.kt
+++ b/platform-extension-api/src/test/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContractTest.kt
@@ -46,6 +46,27 @@ class ExtensionContractTest {
     }
 
     @Test
+    fun `contract helper collects extension readiness checks`() {
+        val extension =
+            object : PlatformExtension {
+                override val id = "reports"
+                override val appLabel = "Reports"
+
+                override fun contribute(context: ExtensionContributionContext) {
+                    context.readiness.down("content-dir", "Set CONTENT_DIR to an existing directory")
+                    context.readiness.warn("preview-cache", "Preview cache is disabled")
+                }
+            }
+
+        val diagnostics = ExtensionContract.diagnostics(extension, extensionTestContext())
+
+        assertEquals(listOf("content-dir", "preview-cache"), diagnostics.readiness.map { it.name })
+        assertEquals(ExtensionReadinessStatus.DOWN, diagnostics.readiness.first().status)
+        assertEquals(true, diagnostics.readiness.first().required)
+        assertEquals(false, diagnostics.readiness.last().required)
+    }
+
+    @Test
     fun `contract helper reports ownership mistakes before full platform boot`() {
         val extension =
             object : PlatformExtension {

--- a/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/layouts/LayoutHead.kte
+++ b/platform-web/src/main/jte/io/github/rygel/outerstellar/platform/web/layouts/LayoutHead.kte
@@ -27,7 +27,6 @@
     ${SeoMetadata.forPage(shell.pageTitle, shell.pageDescription, shell.canonicalUrl, shell.ogImage, shell.localeTag.substringBefore("-"), if (shell.noIndex) "noindex, nofollow" else "index, follow").generateAllMetaTags()}
     @endif
     <link rel="preload" href="/site.css?v=${shell.version}" as="style">
-    <link rel="preload" href="/vendor/remixicon/remixicon.woff2" as="font" type="font/woff2" crossorigin>
     <link href="/vendor/remixicon/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="/site.css?v=${shell.version}">
     @for(stylesheet in shell.extensionStylesheets)

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ComponentRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ComponentRoutes.kt
@@ -27,6 +27,7 @@ private const val VOTE_PATH_SUFFIX = "/vote"
 class ComponentRoutes(
     private val sidebarFactory: SidebarFactory,
     private val homePageFactory: HomePageFactory,
+    private val infraPageFactory: InfraPageFactory,
     private val renderer: TemplateRenderer,
     private val voteService: VoteService? = null,
     private val pollService: PollService? = null,
@@ -38,8 +39,19 @@ class ComponentRoutes(
     private val optionIdLens = Query.string().required("optionId")
     private val pollSyncIdPath = Path.string().of("syncId")
 
+    val footerStatusRoute =
+        "/components/footer-status" meta
+            {
+                summary = "Footer status fragment"
+            } bindContract
+            GET to
+            { request: org.http4k.core.Request ->
+                renderer.render(infraPageFactory.buildFooterStatus(request.shellRenderer))
+            }
+
     val publicRoutes =
         listOf(
+            footerStatusRoute,
             "/components/navigation/page" meta
                 {
                     summary = "Theme/Lang/Layout refresh"

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/HomeRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/HomeRoutes.kt
@@ -3,6 +3,7 @@ package io.github.rygel.outerstellar.platform.web
 import io.github.rygel.outerstellar.platform.infra.render
 import io.github.rygel.outerstellar.platform.model.ConflictStrategy
 import io.github.rygel.outerstellar.platform.service.MessageService
+import org.http4k.contract.ContractRoute
 import org.http4k.contract.bindContract
 import org.http4k.contract.div
 import org.http4k.contract.meta
@@ -33,17 +34,7 @@ class HomeRoutes(
     private val yearLens = Query.int().optional("year")
     private val syncIdPath = Path.string().of("syncId")
 
-    val publicRoutes =
-        listOf(
-            "/components/footer-status" meta
-                {
-                    summary = "Footer status fragment"
-                } bindContract
-                GET to
-                { request ->
-                    renderer.render(infraPageFactory.buildFooterStatus(request.shellRenderer))
-                }
-        )
+    val publicRoutes = emptyList<ContractRoute>()
 
     val protectedRoutes =
         listOf(

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/HttpHandlerFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/HttpHandlerFactory.kt
@@ -52,7 +52,16 @@ internal class HttpHandlerFactory(
                 "/health" bind
                     GET to
                     {
-                        StaticRoutes.localhostOnly.then { StaticRoutes.buildHealthResponse(userRepository) }(it)
+                        StaticRoutes.localhostOnly.then {
+                            StaticRoutes.buildHealthResponse(userRepository, extensionContribution)
+                        }(it)
+                    },
+                "/debug/routes" bind
+                    GET to
+                    {
+                        StaticRoutes.localhostOnly.then {
+                            StaticRoutes.buildRouteDiagnostics(registry, extensionContribution)
+                        }(it)
                     },
                 "/metrics" bind GET to metricsHandler,
                 "/robots.txt" bind GET to { StaticRoutes.buildRobotsTxtResponse() },

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/RouteRegistrar.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/RouteRegistrar.kt
@@ -166,6 +166,7 @@ internal class RouteRegistrar(
             ComponentRoutes(
                 web.pages.sidebarFactory,
                 web.pages.homePageFactory,
+                web.pages.infraPageFactory,
                 web.runtime.templateRenderer,
                 web.voteService,
                 web.pollService,
@@ -183,6 +184,16 @@ internal class RouteRegistrar(
                 "/components/openapi.json",
                 "GET",
                 "Public components",
+            )
+        )
+        registry.register(
+            RegisteredRoute(
+                componentRoutes.footerStatusRoute,
+                RouteOwner.PlatformKernel,
+                RouteGroup.PublicUi,
+                "/components/footer-status",
+                "GET",
+                "Footer status component",
             )
         )
         val protectedContract = contract {
@@ -303,6 +314,16 @@ internal class RouteRegistrar(
         )
         registry.register(
             RegisteredRoute(null, RouteOwner.PlatformKernel, RouteGroup.Health, "/metrics", "GET", "Metrics")
+        )
+        registry.register(
+            RegisteredRoute(
+                null,
+                RouteOwner.PlatformKernel,
+                RouteGroup.Health,
+                "/debug/routes",
+                "GET",
+                "Local route diagnostics",
+            )
         )
         registry.register(
             RegisteredRoute(null, RouteOwner.PlatformKernel, RouteGroup.Static, "/robots.txt", "GET", "Robots.txt")

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/StaticRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/StaticRoutes.kt
@@ -1,12 +1,18 @@
 package io.github.rygel.outerstellar.platform.web.assembly
 
+import io.github.rygel.outerstellar.platform.composition.RegisteredRoute
+import io.github.rygel.outerstellar.platform.composition.RouteRegistry
+import io.github.rygel.outerstellar.platform.extension.ExtensionContribution
+import io.github.rygel.outerstellar.platform.extension.ExtensionReadinessStatus
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import java.time.Instant
 import java.time.LocalDate
+import org.http4k.contract.ContractRoute
 import org.http4k.core.Filter
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.format.KotlinxSerialization
+import org.http4k.routing.RoutingHttpHandler
 
 internal object StaticRoutes {
     val localhostOnly = Filter { next ->
@@ -76,7 +82,7 @@ internal object StaticRoutes {
     }
 
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
-    fun buildHealthResponse(userRepository: UserRepository): Response {
+    fun buildHealthResponse(userRepository: UserRepository, extensionContribution: ExtensionContribution): Response {
         val checks = mutableMapOf<String, Any>("status" to "UP")
         try {
             userRepository.countAll()
@@ -85,11 +91,69 @@ internal object StaticRoutes {
             checks["status"] = "DOWN"
             checks["database"] = mapOf("status" to "DOWN", "error" to "Database connection failed")
         }
+        val readiness = extensionReadiness(extensionContribution)
+        if (readiness.isNotEmpty()) {
+            checks["extensions"] = readiness
+            if (
+                extensionContribution.readinessChecks.any { it.required && it.status == ExtensionReadinessStatus.DOWN }
+            ) {
+                checks["status"] = "DOWN"
+            }
+        }
         checks["timestamp"] = Instant.now().toString()
         val status = if (checks["status"] == "UP") Status.OK else Status.SERVICE_UNAVAILABLE
         return Response(status)
             .header("content-type", "application/json; charset=utf-8")
             .body(KotlinxSerialization.asJsonObject(checks).toString())
+    }
+
+    fun buildRouteDiagnostics(registry: RouteRegistry, extensionContribution: ExtensionContribution): Response {
+        val payload =
+            mapOf(
+                "routes" to registry.all().map(::routeDiagnostic),
+                "excludedPageSets" to registry.excludedPageSets(),
+                "extensionReadiness" to extensionReadiness(extensionContribution),
+                "timestamp" to Instant.now().toString(),
+            )
+        return Response(Status.OK)
+            .header("content-type", "application/json; charset=utf-8")
+            .body(KotlinxSerialization.asJsonObject(payload).toString())
+    }
+
+    private fun routeDiagnostic(route: RegisteredRoute): Map<String, String> =
+        mapOf(
+            "owner" to route.owner.name,
+            "group" to route.group.name,
+            "method" to route.method,
+            "pathPattern" to route.pathPattern,
+            "description" to route.description,
+            "handlerKind" to route.handlerKind(),
+        )
+
+    private fun RegisteredRoute.handlerKind(): String =
+        when (httpRoute) {
+            null -> "metadata"
+            is ContractRoute -> "contract"
+            is RoutingHttpHandler -> "routing"
+            else -> httpRoute!!::class.simpleName ?: "unknown"
+        }
+
+    private fun extensionReadiness(extensionContribution: ExtensionContribution): List<Map<String, Any>> {
+        if (extensionContribution.readinessChecks.isEmpty()) return emptyList()
+        return listOf(
+            mapOf(
+                "extensionId" to (extensionContribution.manifest?.id ?: "platform"),
+                "checks" to
+                    extensionContribution.readinessChecks.map { check ->
+                        mapOf(
+                            "name" to check.name,
+                            "status" to check.status.name,
+                            "message" to check.message,
+                            "required" to check.required,
+                        )
+                    },
+            )
+        )
     }
 }
 

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/HealthCheckIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/HealthCheckIntegrationTest.kt
@@ -2,6 +2,8 @@ package io.github.rygel.outerstellar.platform.web
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.containsSubstring
+import io.github.rygel.outerstellar.platform.extension.ExtensionContributionContext
+import io.github.rygel.outerstellar.platform.extension.PlatformExtension
 import kotlin.test.Test
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
@@ -67,4 +69,38 @@ class HealthCheckIntegrationTest : WebTest() {
         assertThat(response, hasBody(!containsSubstring("users")))
         assertThat(response, hasBody(!containsSubstring("Exception")))
     }
+
+    @Test
+    fun `GET health exposes optional extension readiness without failing`() {
+        val response = buildApp(extension = readinessExtension(requiredDown = false))(Request(GET, "/health"))
+
+        assertThat(response, hasStatus(Status.OK))
+        assertThat(response, bodyContains("extensions"))
+        assertThat(response, bodyContains("preview-cache"))
+        assertThat(response, bodyContains("Preview cache is disabled"))
+    }
+
+    @Test
+    fun `GET health fails when required extension readiness is down`() {
+        val response = buildApp(extension = readinessExtension(requiredDown = true))(Request(GET, "/health"))
+
+        assertThat(response, hasStatus(Status.SERVICE_UNAVAILABLE))
+        assertThat(response, bodyContains("\"status\":\"DOWN\""))
+        assertThat(response, bodyContains("content-dir"))
+        assertThat(response, bodyContains("Set CONTENT_DIR to an existing directory"))
+    }
+
+    private fun readinessExtension(requiredDown: Boolean): PlatformExtension =
+        object : PlatformExtension {
+            override val id = "reports"
+            override val appLabel = "Reports"
+
+            override fun contribute(context: ExtensionContributionContext) {
+                if (requiredDown) {
+                    context.readiness.down("content-dir", "Set CONTENT_DIR to an existing directory")
+                } else {
+                    context.readiness.warn("preview-cache", "Preview cache is disabled")
+                }
+            }
+        }
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PlatformDiagnosticsIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PlatformDiagnosticsIntegrationTest.kt
@@ -1,0 +1,66 @@
+package io.github.rygel.outerstellar.platform.web
+
+import com.natpryce.hamkrest.assertion.assertThat
+import io.github.rygel.outerstellar.platform.extension.ExtensionContributionContext
+import io.github.rygel.outerstellar.platform.extension.PlatformExtension
+import kotlin.test.Test
+import org.http4k.contract.bindContract
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.hamkrest.hasStatus
+import org.http4k.routing.ResourceLoader
+
+class PlatformDiagnosticsIntegrationTest : WebTest() {
+    private val app by lazy { buildApp(extension = diagnosticsExtension()) }
+
+    @Test
+    fun `debug routes is localhost only`() {
+        val response = app(Request(GET, "/debug/routes").header("Host", "platform.example"))
+
+        assertThat(response, hasStatus(Status.FORBIDDEN))
+    }
+
+    @Test
+    fun `debug routes includes handler kind and wildcard route diagnostics`() {
+        val response = app(Request(GET, "/debug/routes").header("Host", "localhost:8080"))
+
+        assertThat(response, hasStatus(Status.OK))
+        assertThat(response, bodyContains("\"handlerKind\":\"contract\""))
+        assertThat(response, bodyContains("\"handlerKind\":\"routing\""))
+        assertThat(response, bodyContains("/extensions/reports/assets/*"))
+        assertThat(response, bodyContains("reports-cache"))
+    }
+
+    @Test
+    fun `platform shell component urls are registered in route diagnostics`() {
+        val body = app(Request(GET, "/debug/routes").header("Host", "localhost:8080")).bodyString()
+
+        listOf("/components/footer-status", "/components/notification-bell").forEach { componentPath ->
+            assert(body.contains(""""pathPattern":"$componentPath"""")) {
+                "Shell component route $componentPath was not registered in diagnostics: $body"
+            }
+        }
+    }
+
+    private fun diagnosticsExtension(): PlatformExtension =
+        object : PlatformExtension {
+            override val id = "reports"
+            override val appLabel = "Reports"
+
+            override fun contribute(context: ExtensionContributionContext) {
+                context.routes.publicUi(
+                    ("/reports/diagnostics" bindContract GET).to { _: Request -> Response(Status.OK) },
+                    "Reports diagnostics",
+                    "/reports/diagnostics",
+                )
+                context.routes.staticAssets(
+                    "/extensions/reports/assets",
+                    ResourceLoader.Classpath("assets"),
+                    "Reports assets",
+                )
+                context.readiness.up("reports-cache", "Reports cache is ready")
+            }
+        }
+}

--- a/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.forbidden page.approved
+++ b/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.forbidden page.approved
@@ -23,7 +23,6 @@
     
     
     <link rel="preload" href="/site.css?v=[CACHE-BUSTER]" as="style">
-    <link rel="preload" href="/vendor/remixicon/remixicon.woff2" as="font" type="font/woff2" crossorigin>
     <link href="/vendor/remixicon/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="/site.css?v=[CACHE-BUSTER]">
     
@@ -281,6 +280,5 @@
 <script nonce="[CSP-NONCE]" src="/platform.js?v=[CACHE-BUSTER]"></script>
 </body>
 </html>
-
 
 

--- a/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.not-found error page.approved
+++ b/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.not-found error page.approved
@@ -23,7 +23,6 @@
     
     
     <link rel="preload" href="/site.css?v=[CACHE-BUSTER]" as="style">
-    <link rel="preload" href="/vendor/remixicon/remixicon.woff2" as="font" type="font/woff2" crossorigin>
     <link href="/vendor/remixicon/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="/site.css?v=[CACHE-BUSTER]">
     
@@ -281,6 +280,5 @@
 <script nonce="[CSP-NONCE]" src="/platform.js?v=[CACHE-BUSTER]"></script>
 </body>
 </html>
-
 
 

--- a/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.server-error page.approved
+++ b/platform-web/src/test/resources/io/github/rygel/outerstellar/platform/web/approval/ErrorPagesApprovalTest.server-error page.approved
@@ -23,7 +23,6 @@
     
     
     <link rel="preload" href="/site.css?v=[CACHE-BUSTER]" as="style">
-    <link rel="preload" href="/vendor/remixicon/remixicon.woff2" as="font" type="font/woff2" crossorigin>
     <link href="/vendor/remixicon/remixicon.css" rel="stylesheet" />
     <link rel="stylesheet" href="/site.css?v=[CACHE-BUSTER]">
     
@@ -281,6 +280,5 @@
 <script nonce="[CSP-NONCE]" src="/platform.js?v=[CACHE-BUSTER]"></script>
 </body>
 </html>
-
 
 

--- a/scripts/run-dev.ps1
+++ b/scripts/run-dev.ps1
@@ -1,5 +1,10 @@
 $env:DEV_MODE = "true"
 $env:APP_PROFILE = "dev"
+$markerOwner = if ($env:AGENT_OWNER) { $env:AGENT_OWNER } else { "outerstellar-run-dev" }
+$markerTask = if ($env:AGENT_TASK) { $env:AGENT_TASK } else { "web-dev" }
+$env:AGENT_OWNER = $markerOwner
+$env:AGENT_TASK = $markerTask
+$env:MAVEN_OPTS = (($env:MAVEN_OPTS, "-Dagent.owner=$markerOwner -Dagent.task=$markerTask") | Where-Object { $_ }) -join " "
 
 Write-Host "Starting outerstellar-platform development mode..." -ForegroundColor Cyan
 

--- a/scripts/start-web.ps1
+++ b/scripts/start-web.ps1
@@ -31,6 +31,13 @@ Remove-Item $watcherLog, $watcherErrorLog, $appLog, $appErrorLog, $tailwindLog, 
 $env:DEV_MODE = "true"
 $port = if ($env:PORT) { [int]$env:PORT } else { 8080 }
 
+$markerOwner = if ($env:AGENT_OWNER) { $env:AGENT_OWNER } else { "outerstellar-start-web" }
+$markerTaskPrefix = if ($env:AGENT_TASK) { $env:AGENT_TASK } else { "web-dev" }
+$mavenMarkerOpts = "-Dagent.owner=$markerOwner -Dagent.task=$markerTaskPrefix"
+$env:MAVEN_OPTS = (($env:MAVEN_OPTS, $mavenMarkerOpts) | Where-Object { $_ }) -join " "
+$env:AGENT_OWNER = $markerOwner
+$env:AGENT_TASK = $markerTaskPrefix
+
 Write-Host "Ensuring Node dependencies..." -ForegroundColor Cyan
 & $npmCommand.Source run css:ensure
 if ($LASTEXITCODE -ne 0) {
@@ -38,6 +45,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Starting watcher..." -ForegroundColor Cyan
+$env:AGENT_TASK = "$markerTaskPrefix-maven-watch"
 $watcherProcess = Start-Process `
     -FilePath $mavenCommand.Source `
     -ArgumentList "-Pruntime-dev", "-pl", "platform-web", "fizzed-watcher:run" `
@@ -48,6 +56,7 @@ $watcherProcess = Start-Process `
     -PassThru
 
 Write-Host "Starting Tailwind watcher..." -ForegroundColor Cyan
+$env:AGENT_TASK = "$markerTaskPrefix-tailwind-watch"
 $tailwindProcess = Start-Process `
     -FilePath $npmCommand.Source `
     -ArgumentList "run", "watch:css" `
@@ -58,6 +67,7 @@ $tailwindProcess = Start-Process `
     -PassThru
 
 Write-Host "Starting web application..." -ForegroundColor Green
+$env:AGENT_TASK = "$markerTaskPrefix-web-app"
 $appProcess = Start-Process `
     -FilePath $mavenCommand.Source `
     -ArgumentList "-Pruntime-dev", "-pl", "platform-web", "compile", "exec:java" `
@@ -70,6 +80,7 @@ $appProcess = Start-Process `
 Set-Content -Path $watcherPidFile -Value $watcherProcess.Id
 Set-Content -Path $tailwindPidFile -Value $tailwindProcess.Id
 Set-Content -Path $appPidFile -Value $appProcess.Id
+$env:AGENT_TASK = $markerTaskPrefix
 
 $healthUrl = "http://localhost:$port/health"
 $started = $false

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -58,6 +58,11 @@ if ($ExtraArgs) {
 
 $timeoutMs = $TimeoutMinutes * 60 * 1000
 $startTime = Get-Date
+$markerOwner = if ($env:AGENT_OWNER) { $env:AGENT_OWNER } else { "outerstellar-test-script" }
+$markerTask = if ($env:AGENT_TASK) { $env:AGENT_TASK } else { "reactor-verify" }
+$env:AGENT_OWNER = $markerOwner
+$env:AGENT_TASK = $markerTask
+$env:MAVEN_OPTS = (($env:MAVEN_OPTS, "-Dagent.owner=$markerOwner -Dagent.task=$markerTask") | Where-Object { $_ }) -join " "
 
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host " Test Runner (timeout: ${TimeoutMinutes}min)" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary

- Adds extension readiness checks to the extension contribution API and exposes them in extension diagnostics.
- Adds local-only `/debug/routes` diagnostics with owner, group, method, path pattern, description, and handler kind.
- Moves `/components/footer-status` into platform component routes so shell component URLs are registered, removes the unused Remix icon font preload, and marks dev/test processes for shared-machine ownership.

Closes #476.

## Validation

- `mvn -pl platform-extension-api -am test "-Dtest=ExtensionContractTest" "-Dsurefire.failIfNoSpecifiedTests=false"`
- `mvn -pl platform-web -am test "-Dtest=HealthCheckIntegrationTest,PlatformDiagnosticsIntegrationTest" "-Dsurefire.failIfNoSpecifiedTests=false" "-Dexec.skip=true"`
- `mvn install -T 1C -DskipTests "-Djacoco.skip=true" "-Denforcer.skip=true"`
- `mvn --% clean verify -T4 -pl !platform-desktop,!platform-desktop-javafx`
