### PR TITLE
feat: JTE registry validation and process hygiene

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfra.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/infra/JteInfra.kt
@@ -32,6 +32,13 @@ fun createRenderer(runtime: RuntimeConfig = RuntimeConfig()): TemplateRenderer {
     val precompiledRegistries by lazy { discoverPrecompiledTemplateRegistries() }
 
     if (doPreload) {
+        if (precompiledRegistries.isEmpty()) {
+            logger.warn(
+                "No PrecompiledJteTemplateRegistry implementations found via ServiceLoader. " +
+                    "Ensure the JTE Maven plugin includes JteClassRegistryExtension and the " +
+                    "META-INF/services file is generated. Templates will not resolve in production mode."
+            )
+        }
         logger.info(
             "Production mode: discovered {} JTE registries with {} template classes",
             precompiledRegistries.size,
@@ -146,10 +153,14 @@ private fun renderUsingPrecompiledRegistry(registries: List<PrecompiledJteTempla
         val templateClass = findPrecompiledTemplateClass(viewModel.template(), registries)
 
         if (templateClass == null) {
+            val availableTemplates = registries.flatMap { it.allClasses }.map { it.name }.sorted()
             logger.error(
-                "Template {} not found in {} generated class registries",
+                "Template {} not found in {} generated class registries ({} classes registered). " +
+                    "Ensure the JTE Maven plugin includes JteClassRegistryExtension. Registered: {}",
                 viewModel.template(),
                 registries.size,
+                availableTemplates.size,
+                availableTemplates.takeLast(10),
             )
             throw ViewNotFound(viewModel)
         }

--- a/scripts/start-web.ps1
+++ b/scripts/start-web.ps1
@@ -70,7 +70,7 @@ Write-Host "Starting web application..." -ForegroundColor Green
 $env:AGENT_TASK = "$markerTaskPrefix-web-app"
 $appProcess = Start-Process `
     -FilePath $mavenCommand.Source `
-    -ArgumentList "-Pruntime-dev", "-pl", "platform-web", "compile", "exec:java" `
+    -ArgumentList "-Pruntime-dev", "-pl", "platform-web", "compile", "exec:java", "-Dprocess.label=outerstellar-web-dev" `
     -WorkingDirectory $projectRoot `
     -RedirectStandardOutput $appLog `
     -RedirectStandardError $appErrorLog `


### PR DESCRIPTION
## Summary

- **#484**: Add startup warning when no PrecompiledJteTemplateRegistry implementations are found via ServiceLoader. Improve template-not-found error message to log registered class count and last 10 class names for easier debugging.
- **#476.5**: Add -Dprocess.label=outerstellar-web-dev to start-web.ps1 for process identification.

Note: Most of the original scope (#476 diagnostics, #479 static assets, #476.1 footer-status route, #476.4 preload fix) was already merged to develop in prior PRs. This PR closes the remaining gaps.

Closes #484
Refs #476

## Test plan
- [x] Full reactor build passes (mvn clean verify -T4)
- [x] Existing JteInfraTest passes (9 tests)
- [x] Existing PlatformDiagnosticsIntegrationTest passes (7 tests)