### PR TITLE
feat: add bulk route registration to ExtensionRouteContributionRegistry (#488)

### DIFF
--- a/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContributionContext.kt
+++ b/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContributionContext.kt
@@ -80,6 +80,26 @@ class ExtensionRouteContributionRegistry internal constructor(private val host: 
         register(route, RouteGroup.Admin, description, pathPattern)
     }
 
+    fun publicUiAll(routes: List<ContractRoute>, basePath: String) {
+        routes.forEach { publicUi(it, basePath) }
+    }
+
+    fun protectedUiAll(routes: List<ContractRoute>, basePath: String) {
+        routes.forEach { protectedUi(it, basePath) }
+    }
+
+    fun apiAll(routes: List<ContractRoute>, basePath: String) {
+        routes.forEach { api(it, basePath) }
+    }
+
+    fun adminAll(routes: List<ContractRoute>, basePath: String) {
+        routes.forEach { admin(it, basePath) }
+    }
+
+    fun registerAll(registrations: List<ExtensionRouteRegistration>) {
+        this.registrations += registrations
+    }
+
     fun staticAssets(pathPrefix: String, loader: ResourceLoader, description: String = "Extension static assets") {
         registrations +=
             ExtensionRouteRegistration.staticAssets(
@@ -113,6 +133,10 @@ class ExtensionRouteContributionRegistry internal constructor(private val host: 
 
     fun publicPage(path: String, model: (Request) -> ViewModel, description: String = path) =
         page(path, model, description, RouteGroup.PublicUi)
+
+    fun pages(routes: List<ContractRoute>, group: RouteGroup = RouteGroup.ProtectedUi, basePath: String) {
+        routes.forEach { register(it, group, basePath, basePath) }
+    }
 
     internal fun snapshot(): List<ExtensionRouteRegistration> = registrations.toList()
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ExtensionContributionTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ExtensionContributionTest.kt
@@ -355,6 +355,56 @@ class ExtensionContributionTest {
         assertEquals(listOf("/assets/reports/reports.css"), contribution.options.assets.stylesheets)
     }
 
+    @Test
+    fun `bulk route registration methods register all routes`() {
+        val route1 = ("/extension/reports/page1" bindContract GET).to { _ -> Response(Status.OK) }
+        val route2 = ("/extension/reports/page2" bindContract GET).to { _ -> Response(Status.OK) }
+        val adminRoute = ("/admin/reports/settings" bindContract GET).to { _ -> Response(Status.OK) }
+        val extension =
+            object : PlatformExtension {
+                override val id = "reports"
+                override val mode = PlatformMode.ExtensionHost
+
+                override fun contribute(context: ExtensionContributionContext) {
+                    context.routes.publicUiAll(listOf(route1, route2), "/extension/reports")
+                    context.routes.adminAll(listOf(adminRoute), "/admin/reports")
+                }
+            }
+
+        val contribution = ExtensionContribution.from(extension, PlatformMode.FullPlatform, extensionContext())
+
+        assertEquals(3, contribution.routeRegistrations.size)
+        assertEquals(RouteGroup.PublicUi, contribution.routeRegistrations[0].group)
+        assertEquals(RouteGroup.PublicUi, contribution.routeRegistrations[1].group)
+        assertEquals(RouteGroup.Admin, contribution.routeRegistrations[2].group)
+    }
+
+    @Test
+    fun `registerAll accepts pre-built registration list`() {
+        val route = ("/extension/reports/page" bindContract GET).to { _ -> Response(Status.OK) }
+        val registration =
+            ExtensionRouteRegistration(
+                route = route,
+                group = RouteGroup.ProtectedUi,
+                description = "Reports page",
+                pathPattern = "/extension/reports/page",
+            )
+        val extension =
+            object : PlatformExtension {
+                override val id = "reports"
+                override val mode = PlatformMode.ExtensionHost
+
+                override fun contribute(context: ExtensionContributionContext) {
+                    context.routes.registerAll(listOf(registration))
+                }
+            }
+
+        val contribution = ExtensionContribution.from(extension, PlatformMode.FullPlatform, extensionContext())
+
+        assertEquals(1, contribution.routeRegistrations.size)
+        assertEquals("Reports page", contribution.routeRegistrations[0].description)
+    }
+
     private fun extensionContext(): ExtensionHostContext {
         val context =
             ExtensionHostContext.forTesting(


### PR DESCRIPTION
## Summary

Adds bulk route registration methods to ExtensionRouteContributionRegistry so extensions can register multiple routes in a single call instead of hundreds of individual calls.

### New methods

| Method | Purpose |
|--------|---------|
| publicUiAll(routes, basePath) | Register multiple public UI routes |
| protectedUiAll(routes, basePath) | Register multiple protected UI routes |
| piAll(routes, basePath) | Register multiple API routes |
| dminAll(routes, basePath) | Register multiple admin routes |
| egisterAll(registrations) | Accept pre-built ExtensionRouteRegistration list |
| pages(routes, group, basePath) | Register page routes with shared group |

### Motivation

website-outerstellar had a 730-line contribute() method due to no bulk API. These methods allow concise bulk registration while preserving the existing single-route methods for backward compatibility.

### Testing

- 2 new tests in ExtensionContributionTest covering bulk registration and egisterAll
- Full reactor build passes: all modules green (5m19s)

Closes #488