### PR TITLE
release: update v3.6.15 with bulk route registration (#488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [3.6.15] – 2026-06-10
 
+### Added
+
+- **Bulk route registration** — `ExtensionRouteContributionRegistry` now supports `publicUiAll`, `protectedUiAll`, `apiAll`, `adminAll`, `registerAll`, and `pages` methods for registering multiple routes in a single call, reducing extension `contribute()` boilerplate (#488).
+
 ### Changed
 
 - **JTE template registry validation** — startup now warns when no `PrecompiledJteTemplateRegistry` implementations are discovered via ServiceLoader; template-not-found errors log registered class count and sample class names for faster diagnosis (#484).

--- a/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContributionContext.kt
+++ b/platform-extension-api/src/main/kotlin/io/github/rygel/outerstellar/platform/extension/ExtensionContributionContext.kt
@@ -80,6 +80,26 @@ class ExtensionRouteContributionRegistry internal constructor(private val host: 
         register(route, RouteGroup.Admin, description, pathPattern)
     }
 
+    fun publicUiAll(routes: List<ContractRoute>, basePath: String) {
+        routes.forEach { publicUi(it, basePath) }
+    }
+
+    fun protectedUiAll(routes: List<ContractRoute>, basePath: String) {
+        routes.forEach { protectedUi(it, basePath) }
+    }
+
+    fun apiAll(routes: List<ContractRoute>, basePath: String) {
+        routes.forEach { api(it, basePath) }
+    }
+
+    fun adminAll(routes: List<ContractRoute>, basePath: String) {
+        routes.forEach { admin(it, basePath) }
+    }
+
+    fun registerAll(registrations: List<ExtensionRouteRegistration>) {
+        this.registrations += registrations
+    }
+
     fun staticAssets(pathPrefix: String, loader: ResourceLoader, description: String = "Extension static assets") {
         registrations +=
             ExtensionRouteRegistration.staticAssets(
@@ -113,6 +133,10 @@ class ExtensionRouteContributionRegistry internal constructor(private val host: 
 
     fun publicPage(path: String, model: (Request) -> ViewModel, description: String = path) =
         page(path, model, description, RouteGroup.PublicUi)
+
+    fun pages(routes: List<ContractRoute>, group: RouteGroup = RouteGroup.ProtectedUi, basePath: String) {
+        routes.forEach { register(it, group, basePath, basePath) }
+    }
 
     internal fun snapshot(): List<ExtensionRouteRegistration> = registrations.toList()
 }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ExtensionContributionTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ExtensionContributionTest.kt
@@ -355,6 +355,56 @@ class ExtensionContributionTest {
         assertEquals(listOf("/assets/reports/reports.css"), contribution.options.assets.stylesheets)
     }
 
+    @Test
+    fun `bulk route registration methods register all routes`() {
+        val route1 = ("/extension/reports/page1" bindContract GET).to { _ -> Response(Status.OK) }
+        val route2 = ("/extension/reports/page2" bindContract GET).to { _ -> Response(Status.OK) }
+        val adminRoute = ("/admin/reports/settings" bindContract GET).to { _ -> Response(Status.OK) }
+        val extension =
+            object : PlatformExtension {
+                override val id = "reports"
+                override val mode = PlatformMode.ExtensionHost
+
+                override fun contribute(context: ExtensionContributionContext) {
+                    context.routes.publicUiAll(listOf(route1, route2), "/extension/reports")
+                    context.routes.adminAll(listOf(adminRoute), "/admin/reports")
+                }
+            }
+
+        val contribution = ExtensionContribution.from(extension, PlatformMode.FullPlatform, extensionContext())
+
+        assertEquals(3, contribution.routeRegistrations.size)
+        assertEquals(RouteGroup.PublicUi, contribution.routeRegistrations[0].group)
+        assertEquals(RouteGroup.PublicUi, contribution.routeRegistrations[1].group)
+        assertEquals(RouteGroup.Admin, contribution.routeRegistrations[2].group)
+    }
+
+    @Test
+    fun `registerAll accepts pre-built registration list`() {
+        val route = ("/extension/reports/page" bindContract GET).to { _ -> Response(Status.OK) }
+        val registration =
+            ExtensionRouteRegistration(
+                route = route,
+                group = RouteGroup.ProtectedUi,
+                description = "Reports page",
+                pathPattern = "/extension/reports/page",
+            )
+        val extension =
+            object : PlatformExtension {
+                override val id = "reports"
+                override val mode = PlatformMode.ExtensionHost
+
+                override fun contribute(context: ExtensionContributionContext) {
+                    context.routes.registerAll(listOf(registration))
+                }
+            }
+
+        val contribution = ExtensionContribution.from(extension, PlatformMode.FullPlatform, extensionContext())
+
+        assertEquals(1, contribution.routeRegistrations.size)
+        assertEquals("Reports page", contribution.routeRegistrations[0].description)
+    }
+
     private fun extensionContext(): ExtensionHostContext {
         val context =
             ExtensionHostContext.forTesting(


### PR DESCRIPTION
## Summary

Updates the v3.6.15 release to include #488 (bulk route registration API) which was merged into develop after the original release PR #486 was created.

### Changes since PR #486
- ExtensionRouteContributionRegistry bulk methods: publicUiAll, protectedUiAll, piAll, dminAll, egisterAll, pages (#488)
- Updated CHANGELOG entry for v3.6.15

The version remains 3.6.15 — no version bump needed since the previous release hasn't been published to Maven Central yet.