### PR TITLE
chore: bump dependencies and harden CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,13 +52,19 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Populate dependency cache
-        run: mvn dependency:go-offline -q 2>/dev/null || true
+        run: mvn org.apache.maven.plugins:maven-dependency-plugin:3.8.1:go-offline -q 2>/dev/null || true
 
       - name: Compile, install, and run quality checks
-        run: >
-          mvn install -T 1C -DskipTests
-          -Djacoco.skip=true
-          -Denforcer.skip=true
+        run: |
+          for i in 1 2 3; do
+            mvn install -T 1C -DskipTests \
+              -Djacoco.skip=true \
+              -Denforcer.skip=true \
+              --fail-at-end && exit 0
+            echo "Maven build attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
+          exit 1
 
       - name: Run additional quality checks
         if: github.event_name == 'push'

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <java.version>21</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <kotlin.version>2.3.10</kotlin.version>
-        <http4k.version>6.52.0.0</http4k.version>
+        <http4k.version>6.53.0.0</http4k.version>
         <netty.version>4.2.15.Final</netty.version>
         <flyway.version>12.8.1</flyway.version>
         <postgresql.version>42.7.11</postgresql.version>
@@ -72,10 +72,10 @@
         <enforcer.version>3.6.3</enforcer.version>
         <checkstyle.version>3.6.0</checkstyle.version>
         <pmd.version>3.28.0</pmd.version>
-        <spotbugs.version>4.9.8.3</spotbugs.version>
+        <spotbugs.version>4.10.2.0</spotbugs.version>
         <spotless.version>3.6.0</spotless.version>
         <ktfmt.version>0.62</ktfmt.version>
-        <jacoco.version>0.8.14</jacoco.version>
+        <jacoco.version>0.8.15</jacoco.version>
         <extra-enforcer-rules.version>1.12.0</extra-enforcer-rules.version>
         <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
         <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
@@ -90,10 +90,10 @@
         <http4k-connect.version>6.1.0.0</http4k-connect.version>
         <mockk.version>1.14.11</mockk.version>
         <archunit.version>1.4.2</archunit.version>
-        <micrometer.version>1.16.5</micrometer.version>
+        <micrometer.version>1.17.0</micrometer.version>
         <resilience4j.version>2.4.0</resilience4j.version>
         <caffeine.version>3.2.4</caffeine.version>
-        <opentelemetry.version>1.62.0</opentelemetry.version>
+        <opentelemetry.version>1.63.0</opentelemetry.version>
         <totp.version>1.7.1</totp.version>
         <zxing.version>3.5.4</zxing.version>
 
@@ -118,7 +118,7 @@
         <maven.plugin.api.version>3.9.16</maven.plugin.api.version>
         <maven.plugin.annotations.version>3.15.2</maven.plugin.annotations.version>
         <maven.plugin.plugin.version>3.15.2</maven.plugin.plugin.version>
-        <native.maven.plugin.version>1.1.1</native.maven.plugin.version>
+        <native.maven.plugin.version>1.1.2</native.maven.plugin.version>
         <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
         <maven.shade.plugin.version>3.6.2</maven.shade.plugin.version>
         <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>


### PR DESCRIPTION
## Summary

- Bump 6 dependencies to latest stable versions (Kotlin, Jackson RC, and JavaFX EA excluded)
- Harden CI build against transient Maven Central 403 errors that caused PR #491 CI failure

### Dependency updates
| Dependency | Old | New |
|---|---|---|
| http4k | 6.52.0.0 | 6.53.0.0 |
| spotbugs | 4.9.8.3 | 4.10.2.0 |
| jacoco | 0.8.14 | 0.8.15 |
| micrometer | 1.16.5 | 1.17.0 |
| opentelemetry | 1.62.0 | 1.63.0 |
| native-maven-plugin | 1.1.1 | 1.1.2 |

### CI hardening
- Fix dependency:go-offline prefix resolution by using full plugin GAV
- Add 3-attempt retry loop for Maven Central transient failures (addresses PR #491 failure)

## Test plan
- [x] Full reactor mvn clean install -DskipTests passes locally
- [ ] CI passes on this PR