### PR TITLE
refactor: non-nullable service deps + HikariCP bump + PCF PR gate

### DIFF
--- a/.github/workflows/pcf-pr-gate.yml
+++ b/.github/workflows/pcf-pr-gate.yml
@@ -1,0 +1,28 @@
+name: PCF PR Gate
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  readiness:
+    name: Contribution Readiness
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: PCF readiness check
+        uses: VrtxOmega/premature-contribution-firewall@ee022516a5aaf134b9633322537300bb8483713c # v0.1.3
+        with:
+          mode: pr-gate
+          fail-on: never

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/ApiKeyService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/ApiKeyService.kt
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory
 
 class ApiKeyService(
     private val userRepository: UserRepository,
-    private val apiKeyRepository: ApiKeyRepository? = null,
+    private val apiKeyRepository: ApiKeyRepository,
     private val auditRepository: AuditRepository? = null,
 ) {
     private val logger = LoggerFactory.getLogger(ApiKeyService::class.java)
@@ -25,7 +25,7 @@ class ApiKeyService(
         val keyHash = TokenHashing.hash(rawKey)
 
         val apiKey = ApiKey(userId = userId, keyHash = keyHash, keyPrefix = keyPrefix, name = name)
-        apiKeyRepository?.save(apiKey)
+        apiKeyRepository.save(apiKey)
         logger.info("API key created for user {}", userId)
         val user = userRepository.findById(userId)
         auditRepository?.logAction("API_KEY_CREATED", actor = user, detail = "name=$name")
@@ -34,7 +34,7 @@ class ApiKeyService(
 
     fun authenticateApiKey(rawKey: String): User? {
         val keyHash = TokenHashing.hash(rawKey)
-        val apiKey = apiKeyRepository?.findByKeyHash(keyHash) ?: return null
+        val apiKey = apiKeyRepository.findByKeyHash(keyHash) ?: return null
         if (!apiKey.enabled) return null
 
         val user = userRepository.findById(apiKey.userId)
@@ -46,7 +46,7 @@ class ApiKeyService(
     }
 
     fun listApiKeys(userId: UUID): List<ApiKeySummary> {
-        return apiKeyRepository?.findByUserId(userId)?.map { key ->
+        return apiKeyRepository.findByUserId(userId).map { key ->
             ApiKeySummary(
                 id = key.id,
                 keyPrefix = key.keyPrefix,
@@ -55,11 +55,11 @@ class ApiKeyService(
                 createdAt = key.createdAt.toString(),
                 lastUsedAt = key.lastUsedAt?.toString(),
             )
-        } ?: emptyList()
+        }
     }
 
     fun deleteApiKey(userId: UUID, keyId: Long) {
-        apiKeyRepository?.delete(keyId, userId)
+        apiKeyRepository.delete(keyId, userId)
         logger.info("API key {} deleted for user {}", keyId, userId)
         val user = userRepository.findById(userId)
         auditRepository?.logAction("API_KEY_DELETED", actor = user, detail = "keyId=$keyId")

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
@@ -80,7 +80,7 @@ fun createSecurityComponents(
             config = securityConfig,
             activityUpdater = asyncActivityUpdater,
         )
-    val userAdminService = UserAdminService(userRepository = userRepository, auditRepository = auditRepository)
+    val userAdminService = UserAdminService(userRepository, auditRepository ?: error("AuditRepository required"))
     val authService =
         AuthService(
             userRepository = userRepository,
@@ -101,7 +101,7 @@ fun createSecurityComponents(
     val apiKeyService =
         ApiKeyService(
             userRepository = userRepository,
-            apiKeyRepository = apiKeyRepository,
+            apiKeyRepository = apiKeyRepository ?: error("ApiKeyRepository required for ApiKeyService"),
             auditRepository = auditRepository,
         )
     val passwordResetService =

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/UserAdminService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/UserAdminService.kt
@@ -11,10 +11,7 @@ import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import java.util.UUID
 import org.slf4j.LoggerFactory
 
-class UserAdminService(
-    private val userRepository: UserRepository,
-    private val auditRepository: AuditRepository? = null,
-) {
+class UserAdminService(private val userRepository: UserRepository, private val auditRepository: AuditRepository) {
     private val logger = LoggerFactory.getLogger(UserAdminService::class.java)
 
     fun listUsers(): List<UserSummary> = userRepository.findAll().map { it.toSummary() }
@@ -38,7 +35,7 @@ class UserAdminService(
         userRepository.updateEnabled(targetId, enabled)
         logger.info("User {} enabled set to {} by admin {}", sanitize(target.username), enabled, adminId)
         val action = if (enabled) "USER_ENABLED" else "USER_DISABLED"
-        auditRepository?.logAction(action, actor = admin, target = target)
+        auditRepository.logAction(action, actor = admin, target = target)
     }
 
     fun unlockAccount(adminId: UUID, targetId: UUID) {
@@ -49,7 +46,7 @@ class UserAdminService(
         val target = userRepository.findById(targetId) ?: throw UserNotFoundException(targetId.toString())
         userRepository.resetFailedLoginAttempts(targetId)
         logger.info("User {} unlocked by admin {}", sanitize(target.username), sanitize(admin.username))
-        auditRepository?.logAction("USER_UNLOCKED", actor = admin, target = target)
+        auditRepository.logAction("USER_UNLOCKED", actor = admin, target = target)
     }
 
     fun setUserRole(adminId: UUID, targetId: UUID, role: UserRole) {
@@ -63,7 +60,7 @@ class UserAdminService(
         val target = userRepository.findById(targetId) ?: throw UserNotFoundException(targetId.toString())
         userRepository.updateRole(targetId, role)
         logger.info("User {} role set to {} by admin {}", sanitize(target.username), role, adminId)
-        auditRepository?.logAction(
+        auditRepository.logAction(
             "USER_ROLE_CHANGED",
             actor = admin,
             target = target,
@@ -71,11 +68,11 @@ class UserAdminService(
         )
     }
 
-    fun countAuditEntries(): Long = auditRepository?.countAll() ?: 0L
+    fun countAuditEntries(): Long = auditRepository.countAll()
 
-    fun getAuditLog(limit: Int = 50): List<AuditEntry> = auditRepository?.findRecent(limit) ?: emptyList()
+    fun getAuditLog(limit: Int = 50): List<AuditEntry> = auditRepository.findRecent(limit)
 
-    fun getAuditLog(limit: Int, offset: Int): List<AuditEntry> = auditRepository?.findPage(limit, offset) ?: emptyList()
+    fun getAuditLog(limit: Int, offset: Int): List<AuditEntry> = auditRepository.findPage(limit, offset)
 
     private fun User.toSummary() =
         UserSummary(

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/WebFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/di/WebFactory.kt
@@ -75,7 +75,7 @@ fun createWebComponents(
     userRepository: UserRepository,
     messageRepository: MessageRepository,
     messageService: MessageService? = null,
-    contactService: ContactService? = null,
+    contactService: ContactService,
     voteRepository: VoteRepository,
     pollRepository: PollRepository,
     notificationRepository: NotificationRepository,

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AdminPageFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AdminPageFactory.kt
@@ -8,9 +8,9 @@ private const val ADMIN_SECONDS_PER_HOUR = 3600
 private const val ADMIN_SECONDS_PER_DAY = 86400
 
 class AdminPageFactory(
-    private val apiKeyService: io.github.rygel.outerstellar.platform.security.ApiKeyService? = null,
-    private val notificationService: io.github.rygel.outerstellar.platform.service.NotificationService? = null,
-    private val userAdminService: UserAdminService? = null,
+    private val apiKeyService: io.github.rygel.outerstellar.platform.security.ApiKeyService,
+    private val notificationService: io.github.rygel.outerstellar.platform.service.NotificationService,
+    private val userAdminService: UserAdminService,
 ) {
 
     fun buildUserAdminPage(
@@ -21,9 +21,9 @@ class AdminPageFactory(
     ): Page<UserAdminPage> {
         val i18n = shellRenderer.i18n
         val shell = shellRenderer.shell(i18n.translate("web.admin.users.title"), "/admin/users")
-        val totalCount = userAdminService?.countUsers() ?: 0L
+        val totalCount = userAdminService.countUsers()
         val safeOffset = offset.coerceIn(0, maxOf(0, totalCount.toInt() - 1))
-        val pageUsers = userAdminService?.listUsers(limit, safeOffset) ?: emptyList()
+        val pageUsers = userAdminService.listUsers(limit, safeOffset)
         val currentUserId = ctx.user?.id?.toString()
         val currentPage = (safeOffset / limit) + 1
         val hasPrevious = safeOffset > 0
@@ -80,9 +80,9 @@ class AdminPageFactory(
     fun buildAuditLogPage(shellRenderer: ShellRenderer, limit: Int = 20, offset: Int = 0): Page<AuditLogPage> {
         val i18n = shellRenderer.i18n
         val shell = shellRenderer.shell(i18n.translate("web.admin.audit.title"), "/admin/audit")
-        val totalCount = userAdminService?.countAuditEntries() ?: 0L
+        val totalCount = userAdminService.countAuditEntries()
         val safeOffset = offset.coerceIn(0, maxOf(0, totalCount.toInt() - 1))
-        val pageEntries = userAdminService?.getAuditLog(limit, safeOffset) ?: emptyList()
+        val pageEntries = userAdminService.getAuditLog(limit, safeOffset)
         val currentPage = (safeOffset / limit) + 1
         val hasPrevious = safeOffset > 0
         val hasNext = safeOffset + limit < totalCount
@@ -129,7 +129,7 @@ class AdminPageFactory(
         val i18n = shellRenderer.i18n
         val shell = shellRenderer.shell(i18n.translate("web.apikeys.title"), "/auth/api-keys")
         val userId = checkNotNull(ctx.user?.id) { "User not logged in" }
-        val keys = apiKeyService?.listApiKeys(userId) ?: emptyList()
+        val keys = apiKeyService.listApiKeys(userId)
 
         return Page(
             shell = shell,
@@ -205,12 +205,12 @@ class AdminPageFactory(
     fun buildNotificationsPage(ctx: RequestContext, shellRenderer: ShellRenderer): Page<NotificationsPage> {
         val i18n = shellRenderer.i18n
         val user = ctx.user ?: throw InsufficientPermissionException("Authentication required")
-        val unreadCount = notificationService?.countUnread(user.id) ?: 0
+        val unreadCount = notificationService.countUnread(user.id)
         val shell =
             shellRenderer
                 .shell(i18n.translate("web.notifications.title"), "/notifications")
                 .copy(notificationsUrl = shellRenderer.url("/notifications"), unreadNotificationCount = unreadCount)
-        val notifications = notificationService?.listForUser(user.id) ?: emptyList()
+        val notifications = notificationService.listForUser(user.id)
         return Page(
             shell = shell,
             data =
@@ -241,7 +241,7 @@ class AdminPageFactory(
     }
 
     fun buildNotificationBell(ctx: RequestContext, shellRenderer: ShellRenderer): NotificationBellFragment {
-        val unreadCount = ctx.user?.id?.let { notificationService?.countUnread(it) } ?: 0
+        val unreadCount = ctx.user?.id?.let { notificationService.countUnread(it) } ?: 0
         return NotificationBellFragment(
             unreadCount = unreadCount,
             notificationsUrl = shellRenderer.url("/notifications"),

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ContactTrashListFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ContactTrashListFactory.kt
@@ -1,11 +1,11 @@
 package io.github.rygel.outerstellar.platform.web
 
 class ContactTrashListFactory(
-    private val contactService: io.github.rygel.outerstellar.platform.service.ContactService?
+    private val contactService: io.github.rygel.outerstellar.platform.service.ContactService
 ) {
     fun build(shellRenderer: ShellRenderer): ContactTrashListViewModel {
         val i18n = shellRenderer.i18n
-        val dbContacts = contactService?.listContacts(limit = 100, offset = 0, includeDeleted = true) ?: emptyList()
+        val dbContacts = contactService.listContacts(limit = 100, offset = 0, includeDeleted = true)
         return ContactTrashListViewModel(
             contacts =
                 dbContacts.map {

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ContactsPageFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ContactsPageFactory.kt
@@ -1,7 +1,7 @@
 package io.github.rygel.outerstellar.platform.web
 
 class ContactsPageFactory(
-    private val contactService: io.github.rygel.outerstellar.platform.service.ContactService?,
+    private val contactService: io.github.rygel.outerstellar.platform.service.ContactService,
     private val contactTrashListFactory: ContactTrashListFactory,
 ) {
 
@@ -17,8 +17,8 @@ class ContactsPageFactory(
         val i18n = shellRenderer.i18n
         val shell = shellRenderer.shell(i18n.translate("web.nav.contacts"), "/contacts")
 
-        val dbContacts = contactService?.listContacts(query, limit, offset) ?: emptyList()
-        val totalCount = contactService?.countContacts(query) ?: 0L
+        val dbContacts = contactService.listContacts(query, limit, offset)
+        val totalCount = contactService.countContacts(query)
         val currentPage = (offset / limit) + 1
         val hasPrevious = offset > 0
         val hasNext = offset + limit < totalCount
@@ -65,7 +65,7 @@ class ContactsPageFactory(
 
     fun buildContactForm(shellRenderer: ShellRenderer, syncId: String? = null): ContactFormFragment {
         val i18n = shellRenderer.i18n
-        val existing = syncId?.let { contactService?.getContactBySyncId(it) }
+        val existing = syncId?.let { contactService.getContactBySyncId(it) }
         return ContactFormFragment(
             syncId = existing?.syncId ?: "",
             name = existing?.name ?: "",

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/PlatformAppTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/PlatformAppTest.kt
@@ -14,6 +14,7 @@ import io.github.rygel.outerstellar.platform.security.OAuthService
 import io.github.rygel.outerstellar.platform.security.SecurityComponents
 import io.github.rygel.outerstellar.platform.security.SessionService
 import io.github.rygel.outerstellar.platform.security.TOTPService
+import io.github.rygel.outerstellar.platform.security.UserAdminService
 import io.github.rygel.outerstellar.platform.web.ExtensionHostContextFactory
 import io.github.rygel.outerstellar.platform.web.StubMessageCache
 import io.github.rygel.outerstellar.platform.web.bodyContains
@@ -44,6 +45,7 @@ class PlatformAppTest {
                 security.apiKeyService,
                 security.oauthService,
                 security.sessionService,
+                security.userAdminService,
             )
 
         val handler = app(config = config, persistence = persistence, security = security, core = core, web = web).http
@@ -121,6 +123,7 @@ class PlatformAppTest {
         apiKeyService: ApiKeyService,
         oauthService: OAuthService,
         sessionService: SessionService,
+        userAdminService: UserAdminService,
     ): WebComponents {
         val messageService = mockk<io.github.rygel.outerstellar.platform.service.MessageService>(relaxed = true)
         val notificationService =
@@ -128,7 +131,11 @@ class PlatformAppTest {
         val voteRepo = mockk<io.github.rygel.outerstellar.platform.persistence.VoteRepository>(relaxed = true)
         val pollRepo = mockk<io.github.rygel.outerstellar.platform.persistence.PollRepository>(relaxed = true)
         val adminPageFactory =
-            io.github.rygel.outerstellar.platform.web.AdminPageFactory(null, notificationService, null)
+            io.github.rygel.outerstellar.platform.web.AdminPageFactory(
+                apiKeyService,
+                notificationService,
+                userAdminService,
+            )
         val authPageFactory = io.github.rygel.outerstellar.platform.web.AuthPageFactory()
         val errorPageFactory = io.github.rygel.outerstellar.platform.web.ErrorPageFactory()
         val sidebarFactory = io.github.rygel.outerstellar.platform.web.SidebarFactory()
@@ -140,9 +147,10 @@ class PlatformAppTest {
             )
         val searchPageFactory = io.github.rygel.outerstellar.platform.web.SearchPageFactory()
         val devDashboardPageFactory = io.github.rygel.outerstellar.platform.web.DevDashboardPageFactory()
-        val contactTrashListFactory = io.github.rygel.outerstellar.platform.web.ContactTrashListFactory(null)
+        val contactService = mockk<io.github.rygel.outerstellar.platform.service.ContactService>(relaxed = true)
+        val contactTrashListFactory = io.github.rygel.outerstellar.platform.web.ContactTrashListFactory(contactService)
         val contactsPageFactory =
-            io.github.rygel.outerstellar.platform.web.ContactsPageFactory(null, contactTrashListFactory)
+            io.github.rygel.outerstellar.platform.web.ContactsPageFactory(contactService, contactTrashListFactory)
         val homePageFactory =
             io.github.rygel.outerstellar.platform.web.HomePageFactory(messageService, contactTrashListFactory)
         val infraPageFactory = io.github.rygel.outerstellar.platform.web.InfraPageFactory(repository)

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/PlaywrightE2ETest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/PlaywrightE2ETest.kt
@@ -86,19 +86,6 @@ class PlaywrightE2ETest {
                 sessionRepository = persistence.sessionRepository,
             )
         val syncWebSocket = SyncWebSocket(security.sessionService)
-        val web =
-            createWebComponents(
-                config = testConfig,
-                apiKeyService = security.apiKeyService,
-                oauthService = security.oauthService,
-                syncWebSocket = syncWebSocket,
-                userAdminService = security.userAdminService,
-                userRepository = persistence.userRepository,
-                messageRepository = persistence.messageRepository,
-                voteRepository = persistence.voteRepository,
-                pollRepository = persistence.pollRepository,
-                notificationRepository = persistence.notificationRepository,
-            )
         val core =
             createCoreComponents(
                 config = testConfig,
@@ -109,6 +96,20 @@ class PlaywrightE2ETest {
                 auditRepository = persistence.auditRepository,
                 eventPublisher = syncWebSocket,
                 emailService = emailService,
+            )
+        val web =
+            createWebComponents(
+                config = testConfig,
+                apiKeyService = security.apiKeyService,
+                oauthService = security.oauthService,
+                syncWebSocket = syncWebSocket,
+                userAdminService = security.userAdminService,
+                userRepository = persistence.userRepository,
+                messageRepository = persistence.messageRepository,
+                contactService = core.contactService,
+                voteRepository = persistence.voteRepository,
+                pollRepository = persistence.pollRepository,
+                notificationRepository = persistence.notificationRepository,
             )
 
         messageRepo = persistence.messageRepository

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/ResponsiveLayoutE2ETest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/e2e/ResponsiveLayoutE2ETest.kt
@@ -93,19 +93,6 @@ class ResponsiveLayoutE2ETest {
                 sessionRepository = persistence.sessionRepository,
             )
         val syncWebSocket = SyncWebSocket(security.sessionService)
-        val web =
-            createWebComponents(
-                config = testConfig,
-                apiKeyService = security.apiKeyService,
-                oauthService = security.oauthService,
-                syncWebSocket = syncWebSocket,
-                userAdminService = security.userAdminService,
-                userRepository = persistence.userRepository,
-                messageRepository = persistence.messageRepository,
-                voteRepository = persistence.voteRepository,
-                pollRepository = persistence.pollRepository,
-                notificationRepository = persistence.notificationRepository,
-            )
         val core =
             createCoreComponents(
                 config = testConfig,
@@ -116,6 +103,20 @@ class ResponsiveLayoutE2ETest {
                 auditRepository = persistence.auditRepository,
                 eventPublisher = syncWebSocket,
                 emailService = emailService,
+            )
+        val web =
+            createWebComponents(
+                config = testConfig,
+                apiKeyService = security.apiKeyService,
+                oauthService = security.oauthService,
+                syncWebSocket = syncWebSocket,
+                userAdminService = security.userAdminService,
+                userRepository = persistence.userRepository,
+                messageRepository = persistence.messageRepository,
+                contactService = core.contactService,
+                voteRepository = persistence.voteRepository,
+                pollRepository = persistence.pollRepository,
+                notificationRepository = persistence.notificationRepository,
             )
 
         persistence.messageRepository.seedMessages()

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <logback.version>1.5.34</logback.version>
         <jbcrypt.version>0.4</jbcrypt.version>
         <java-jwt.version>4.5.2</java-jwt.version>
-        <hikaricp.version>7.0.2</hikaricp.version>
+        <hikaricp.version>7.1.0</hikaricp.version>
         <angus.mail.version>2.0.5</angus.mail.version>
         <jakarta.mail.api.version>2.1.5</jakarta.mail.api.version>
         <jakarta.activation.api.version>2.1.4</jakarta.activation.api.version>

--- a/starter-extension-app/pom.xml
+++ b/starter-extension-app/pom.xml
@@ -28,7 +28,7 @@
         <java.version>21</java.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <kotlin.version>2.3.10</kotlin.version>
-        <outerstellar-platform.version>3.6.7</outerstellar-platform.version>
+        <outerstellar-platform.version>3.6.16</outerstellar-platform.version>
         <jte.version>3.2.4</jte.version>
         <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
         <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>


### PR DESCRIPTION
## Summary

Three logically separate changes, kept in distinct commits for reviewability.

### 1. Non-nullable service dependencies (`refactor`)
Removes nullable (defaulting to `null`) constructors and the resulting `?.` / `?: emptyList()` safe-call noise from:
- `ApiKeyService`, `UserAdminService` (`platform-security`)
- `AdminPageFactory`, `ContactsPageFactory`, `ContactTrashListFactory`, `WebFactory` (`platform-web`)

These dependencies are mandatory for correct operation. Making them required moves the null-check to a single wiring point (`SecurityComponents` / `WebFactory`) and lets the compiler enforce it. Tests are updated to pass real (mocked) instances, and init ordering is fixed so `core` (provides `contactService`) is built before `web` consumes it.

### 2. Dependency bumps (`chore(deps)`)
- `hikaricp.version` 7.0.2 → 7.1.0
- `starter-extension-app`: `outerstellar-platform.version` 3.6.7 → 3.6.16 (starter was tracking a stale release)

### 3. CI workflow (`ci`)
Adds `.github/workflows/pcf-pr-gate.yml` — an advisory contribution-readiness gate (premature-contribution-firewall) on PRs to `main`/`develop`, pinned SHAs, read-only perms, never-fail mode.

## Verification

Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS** (SpotBugs, detekt, checkstyle, PMD, Spotless all pass)
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**, **1275 tests, 0 failures, 0 errors, 0 skipped**

Desktop modules excluded per AGENTS.md (require Podman containers).