### PR TITLE
fix(security): harden TOTP backup codes — BCrypt hashing + constant-time comparison

### DIFF
--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
@@ -72,7 +72,7 @@ fun createSecurityComponents(
             sessionAbsoluteTimeoutSeconds = config.sessionAbsoluteTimeoutMinutes.toLong() * 60,
             registrationEnabled = config.registrationEnabled,
         )
-    val totpService = TOTPService()
+    val totpService = TOTPService(passwordEncoder)
     val sessionService =
         SessionService(
             sessionRepository = sessionRepository ?: error("SessionRepository required"),

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/TOTPService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/TOTPService.kt
@@ -8,9 +8,14 @@ import dev.samstevens.totp.recovery.RecoveryCodeGenerator
 import dev.samstevens.totp.secret.DefaultSecretGenerator
 import dev.samstevens.totp.time.SystemTimeProvider
 import dev.samstevens.totp.util.Utils
-import java.security.MessageDigest
 
-class TOTPService {
+/**
+ * Hashes and verifies TOTP backup codes. Backup codes are an equally critical credential as the main password (a single
+ * code bypasses TOTP entirely), so they are stored with the same slow, salted KDF used for passwords rather than a fast
+ * unsalted digest. Verification goes through [PasswordEncoder.matches], whose underlying
+ * [org.mindrot.jbcrypt.BCrypt.checkpw] is constant-time.
+ */
+class TOTPService(private val backupCodeEncoder: PasswordEncoder) {
 
     private val secretGenerator = DefaultSecretGenerator(32)
     private val codeVerifier =
@@ -45,21 +50,17 @@ class TOTPService {
 
     fun generateBackupCodes(): Pair<List<String>, String> {
         val codes = recoveryCodeGenerator.generateCodes(16).toList()
-        val hashed = codes.map { sha256(it) }
+        val hashed = codes.map { backupCodeEncoder.encode(it) }
         return codes to serializeJson(hashed)
     }
 
     fun verifyBackupCode(code: String, hashedCodesJson: String): String? {
         val hashedCodes = parseJsonList(hashedCodesJson).toMutableList()
-        val hashed = sha256(code)
-        val idx = hashedCodes.indexOfFirst { it == hashed }
+        val idx = hashedCodes.indexOfFirst { backupCodeEncoder.matches(code, it) }
         if (idx == -1) return null
         hashedCodes.removeAt(idx)
         return if (hashedCodes.isEmpty()) "" else serializeJson(hashedCodes)
     }
-
-    private fun sha256(value: String): String =
-        MessageDigest.getInstance("SHA-256").digest(value.toByteArray()).joinToString("") { "%02x".format(it) }
 
     private fun serializeJson(list: List<String>): String = list.joinToString(",", "[", "]") { "\"$it\"" }
 

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthServiceTest.kt
@@ -46,7 +46,7 @@ class AuthServiceTest {
                 userRepository = userRepository,
                 passwordEncoder = passwordEncoder,
                 auditRepository = auditRepository,
-                totpService = TOTPService(),
+                totpService = TOTPService(BCryptPasswordEncoder(logRounds = 4)),
             )
     }
 
@@ -213,7 +213,7 @@ class AuthServiceTest {
                 passwordEncoder = passwordEncoder,
                 auditRepository = auditRepository,
                 config = SecurityConfig(registrationEnabled = false),
-                totpService = TOTPService(),
+                totpService = TOTPService(BCryptPasswordEncoder(logRounds = 4)),
             )
 
         assertThrows<RegistrationDisabledException> { disabledService.register("new@test.com", "ValidP@ss1") }

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthServiceTotpTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthServiceTotpTest.kt
@@ -29,7 +29,7 @@ class AuthServiceTotpTest {
         userRepository = mockk(relaxed = true)
         sessionRepository = mockk(relaxed = true)
         passwordEncoder = mockk(relaxed = true)
-        totpService = TOTPService()
+        totpService = TOTPService(BCryptPasswordEncoder(logRounds = 4))
         authService =
             AuthService(
                 userRepository = userRepository,

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/TOTPServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/TOTPServiceTest.kt
@@ -14,7 +14,8 @@ class TOTPServiceTest {
 
     @BeforeEach
     fun setUp() {
-        totpService = TOTPService()
+        // logRounds = 4 keeps the suite fast (repo convention) — production uses the default 12.
+        totpService = TOTPService(BCryptPasswordEncoder(logRounds = 4))
     }
 
     @Test
@@ -57,6 +58,28 @@ class TOTPServiceTest {
         assertNotNull(result, "Valid code should return updated JSON")
         val result2 = totpService.verifyBackupCode(rawCodes[0], result!!)
         assertNull(result2, "Consumed code should not verify again")
+    }
+
+    @Test
+    fun `generateBackupCodes stores BCrypt hashes`() {
+        val (_, hashed) = totpService.generateBackupCodes()
+        val stored = hashed.removeSurrounding("[", "]").split(",").map { it.trim().removeSurrounding("\"") }
+        stored.forEach { hash ->
+            assertTrue(
+                hash.startsWith("\$2a$") || hash.startsWith("\$2b$"),
+                "Backup code must be a BCrypt hash, was: $hash",
+            )
+        }
+    }
+
+    @Test
+    fun `verifyBackupCode rejects legacy unsalted SHA-256 hashes`() {
+        // Pre-fix backup codes were stored as 64-char hex SHA-256 digests. After the BCrypt migration
+        // these must no longer verify (they cannot be re-hashed without the plaintext, so they are
+        // invalidated by design). Simulate a stored legacy hash for a known code.
+        val legacySha256 = "a".repeat(64)
+        val stored = """["$legacySha256"]"""
+        assertNull(totpService.verifyBackupCode("anything", stored), "Legacy SHA-256 hash must not verify")
     }
 
     @Test

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/PlatformAppTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/PlatformAppTest.kt
@@ -10,6 +10,7 @@ import io.github.rygel.outerstellar.platform.infra.createRenderer
 import io.github.rygel.outerstellar.platform.persistence.MessageRepository
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import io.github.rygel.outerstellar.platform.security.ApiKeyService
+import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.OAuthService
 import io.github.rygel.outerstellar.platform.security.SecurityComponents
 import io.github.rygel.outerstellar.platform.security.SessionService
@@ -98,7 +99,7 @@ class PlatformAppTest {
             passwordResetService = mockk(relaxed = true),
             oauthService = mockk(relaxed = true),
             authRealms = emptyList(),
-            totpService = TOTPService(),
+            totpService = TOTPService(BCryptPasswordEncoder(logRounds = 4)),
             sessionService = mockk(relaxed = true),
             userAdminService = mockk(relaxed = true),
         )

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityIntegrationTest.kt
@@ -27,7 +27,7 @@ class SecurityIntegrationTest : WebTest() {
                 userRepository = localUserRepository,
                 passwordEncoder = passwordEncoder,
                 config = SecurityConfig(),
-                totpService = TOTPService(),
+                totpService = TOTPService(BCryptPasswordEncoder(logRounds = 4)),
             )
     }
 

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ChangePasswordWebIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ChangePasswordWebIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.natpryce.hamkrest.assertion.assertThat
 import io.github.rygel.outerstellar.platform.model.User
 import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.AuthService
+import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.TOTPService
 import java.util.UUID
 import kotlin.test.Test
@@ -51,7 +52,13 @@ class ChangePasswordWebIntegrationTest : WebTest() {
             )
         userRepository.save(testUser)
 
-        authService = AuthService(userRepository, encoder, auditRepository, totpService = TOTPService())
+        authService =
+            AuthService(
+                userRepository,
+                encoder,
+                auditRepository,
+                totpService = TOTPService(BCryptPasswordEncoder(logRounds = 4)),
+            )
 
         testToken = sessionSvc.createSession(testUser.id)
 

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
@@ -56,7 +56,13 @@ class OAuthIntegrationTest : WebTest() {
                 oauthRepository = localOAuthRepository,
                 auditRepository = auditRepository,
             )
-        localAuthService = AuthService(userRepository, encoder, auditRepository, totpService = TOTPService())
+        localAuthService =
+            AuthService(
+                userRepository,
+                encoder,
+                auditRepository,
+                totpService = TOTPService(BCryptPasswordEncoder(logRounds = 4)),
+            )
 
         app = buildApp()
     }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/WebTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/WebTest.kt
@@ -171,7 +171,7 @@ abstract class WebTest {
         val contactsPageFactory = ContactsPageFactory(resolvedContactService, contactTrashListFactory)
         val homePageFactory = HomePageFactory(messageService, contactTrashListFactory)
         val infraPageFactory = InfraPageFactory(messageRepository)
-        val authService = AuthService(userRepository, encoder, auditRepository, totpService = TOTPService())
+        val authService = AuthService(userRepository, encoder, auditRepository, totpService = TOTPService(encoder))
         val accountService = AccountService(userRepository, encoder, sessionRepository, auditRepository)
 
         val persistence = buildPersistence(resolvedUserRepo, outbox, txManager, overrides)
@@ -271,7 +271,7 @@ abstract class WebTest {
                 ),
             oauthService = oauthService,
             authRealms = emptyList(),
-            totpService = TOTPService(),
+            totpService = TOTPService(encoder),
             sessionService = sessionSvc,
             userAdminService = userAdminService,
         )


### PR DESCRIPTION
## Summary

Fixes two related TOTP backup-code security weaknesses as one coherent crypto-hardening change.

### #506 — backup codes stored as unsalted SHA-256
Backup codes were hashed with single-pass `SHA-256(code)` and stored as 64-char hex — far weaker than the main passwords, which use BCrypt (logRounds=12). Yet a backup code is an equally critical credential: **a single code bypasses TOTP entirely**.

**Fix:** hash backup codes with the same `BCryptPasswordEncoder` already used for passwords (logRounds=12 in production). Reuses the existing `org.mindrot.jbcrypt` dependency — no new dependency.

### #511 — non-constant-time comparison
`verifyBackupCode()` compared candidate vs. stored hash with `String.equals` (via `Intrinsics.areEqual`), a short-circuiting per-byte comparison — a textbook timing side-channel on a secret.

**Fix:** verification now goes through `PasswordEncoder.matches()`, whose underlying `BCrypt.checkpw` is constant-time.

## Migration strategy (no SQL migration)
Existing stored SHA-256 hashes **cannot** be re-hashed to BCrypt (only the digest is stored, not the plaintext). So legacy codes are **invalidated by design**: `BCryptPasswordEncoder.matches()` returns `false` for non-`$2a$` input, so old codes simply stop verifying. Affected users regenerate by disabling/re-enabling TOTP. This is the intended security outcome — the old unsalted-SHA256 codes were untrustworthy.

No DB schema change; no Flyway migration.

## Scope
- `TOTPService` — new required `backupCodeEncoder: PasswordEncoder` constructor param; `generateBackupCodes`/`verifyBackupCode` rewritten; `sha256()` removed.
- `SecurityComponents` — `TOTPService` now wired with the existing `BCryptPasswordEncoder` instance (same one used for passwords).
- Tests — `TOTPServiceTest` gains 2 regression cases (generates BCrypt hashes; rejects legacy SHA-256 format). 9 test wiring sites pass `BCryptPasswordEncoder(logRounds=4)` (repo fast-test convention).
- No consumer change needed — `AuthService`, `JdbiUserRepository`, web routes all treat the stored value as an opaque JSON string, so the `$2a$...` format is transparent.

## Verification
Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS** (SpotBugs, detekt, checkstyle, PMD, Spotless)
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**, **1277 tests, 0 failures, 0 errors, 0 skipped**

Desktop modules excluded per AGENTS.md (require Podman containers).

Closes #506, #511.