### PR TITLE
fix: close HikariDataSource (DB pool) on graceful shutdown

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/Main.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/Main.kt
@@ -1,7 +1,6 @@
 package io.github.rygel.outerstellar.platform
 
 import io.github.rygel.outerstellar.platform.infra.NativeStartupCheck
-import io.github.rygel.outerstellar.platform.security.AsyncActivityUpdater
 import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -71,11 +70,11 @@ fun main() {
     outboxScheduler.schedule(outboxTask, 0, TimeUnit.MILLISECONDS)
     logger.info(elapsed(t0, "Background jobs started"))
 
-    registerShutdownHook(components.security.asyncActivityUpdater, outboxScheduler, server)
+    registerShutdownHook(components, outboxScheduler, server)
 }
 
 private fun registerShutdownHook(
-    activityUpdater: AsyncActivityUpdater,
+    components: ServerComponents,
     outboxScheduler: ScheduledExecutorService,
     server: Http4kServer,
 ) {
@@ -84,20 +83,28 @@ private fun registerShutdownHook(
             Thread(
                 {
                     logger.info("Graceful shutdown initiated")
-                    logger.info("Flushing pending activity updates...")
-                    activityUpdater.flush()
-                    logger.info("Stopping outbox scheduler...")
-                    outboxScheduler.shutdown()
                     try {
-                        if (!outboxScheduler.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                        logger.info("Flushing pending activity updates...")
+                        components.security.asyncActivityUpdater.flush()
+                        logger.info("Stopping outbox scheduler...")
+                        outboxScheduler.shutdown()
+                        try {
+                            if (!outboxScheduler.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                                outboxScheduler.shutdownNow()
+                            }
+                        } catch (e: InterruptedException) {
                             outboxScheduler.shutdownNow()
                         }
-                    } catch (e: InterruptedException) {
-                        outboxScheduler.shutdownNow()
+                        logger.info("Stopping HTTP server...")
+                        server.stop()
+                    } finally {
+                        // Always close the persistence layer (HikariDataSource) last so DB connections
+                        // are released to the pool and Postgres even if an earlier shutdown step throws.
+                        logger.info("Closing persistence (DB pool)...")
+                        runCatching { components.persistence.close() }
+                            .onFailure { logger.warn("Failed to close persistence cleanly", it) }
+                        logger.info("Shutdown complete")
                     }
-                    logger.info("Stopping HTTP server...")
-                    server.stop()
-                    logger.info("Shutdown complete")
                 },
                 "graceful-shutdown",
             )


### PR DESCRIPTION
## Summary

Fixes #525 — on every JVM shutdown (SIGTERM, container stop, redeploy) both Hikari connection pools were abandoned without `close()`, leaking Postgres connections until the server-side idle reaper reaped them and exhausting `max_connections` on frequent deploys.

### Root cause
`MainKt.registerShutdownHook` flushed the activity updater, stopped the outbox scheduler, and stopped the HTTP server — but never closed `ServerComponents.persistence`. The pool was created and used for the JVM's lifetime but never released.

### Why the fix is one line of logic
`PersistenceComponents.close()` **already closes the DataSource correctly**:
```kotlin
override fun close() {
    (dataSource as? AutoCloseable)?.close()  // HikariDataSource is AutoCloseable
}
```
The mechanism worked — it was simply never invoked from the production `Main`. The **extension archetype and starter host `Main.kt` already do this** (`components.persistence.close()`); only `platform-web/Main.kt` was missing it. This PR aligns production with that established pattern.

### Change
`registerShutdownHook` now takes `ServerComponents` and calls `components.persistence.close()` inside a `finally`, so the pool is released even if an earlier shutdown step (`server.stop()`, outbox drain) throws. The existing flush → outbox-shutdown → server-stop ordering is preserved. Unused `AsyncActivityUpdater` import removed.

## Verification
Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS** (SpotBugs, detekt, checkstyle, PMD, Spotless)
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**, **1275 tests, 0 failures, 0 errors, 0 skipped**

Desktop modules excluded per AGENTS.md (require Podman containers).

Closes #525.