### PR TITLE
fix(security): mask secrets in AppConfig and nested config toString()

### DIFF
--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
@@ -23,14 +23,20 @@ private const val DEFAULT_CSP_POLICY =
 
 const val DEFAULT_PERMISSIONS_POLICY = "camera=(), microphone=(), geolocation=()"
 
-data class SegmentConfig(val writeKey: String = "", val enabled: Boolean = false)
+data class SegmentConfig(val writeKey: String = "", val enabled: Boolean = false) {
+    override fun toString(): String = "SegmentConfig(writeKey=${mask(writeKey)}, enabled=$enabled)"
+}
 
 data class JwtConfig(
     val enabled: Boolean = false,
     val secret: String = "",
     val issuer: String = "outerstellar",
     val expirySeconds: Long = DEFAULT_JWT_EXPIRY_SECONDS,
-)
+) {
+    // HMAC secret is a signing key — never expose it in logs, stack traces, or debug output.
+    override fun toString(): String =
+        "JwtConfig(enabled=$enabled, secret=${mask(secret)}, issuer=$issuer, expirySeconds=$expirySeconds)"
+}
 
 data class EmailConfig(
     val enabled: Boolean = false,
@@ -40,7 +46,10 @@ data class EmailConfig(
     val password: String = "",
     val from: String = "noreply@example.com",
     val startTls: Boolean = true,
-)
+) {
+    override fun toString(): String =
+        "EmailConfig(enabled=$enabled, host=$host, port=$port, username=$username, password=${mask(password)}, from=$from, startTls=$startTls)"
+}
 
 data class AppleOAuthConfig(
     val enabled: Boolean = false,
@@ -48,7 +57,10 @@ data class AppleOAuthConfig(
     val clientId: String = "",
     val keyId: String = "",
     val privateKeyPem: String = "",
-)
+) {
+    override fun toString(): String =
+        "AppleOAuthConfig(enabled=$enabled, teamId=$teamId, clientId=$clientId, keyId=$keyId, privateKeyPem=${mask(privateKeyPem)})"
+}
 
 data class PushNotificationConfig(
     val enabled: Boolean = false,
@@ -58,7 +70,11 @@ data class PushNotificationConfig(
     val apnsKeyId: String = "",
     val apnsPrivateKeyPem: String = "",
     val apnsBundleId: String = "",
-)
+) {
+    override fun toString(): String =
+        "PushNotificationConfig(enabled=$enabled, provider=$provider, fcmServiceAccountJson=${mask(fcmServiceAccountJson)}, " +
+            "apnsTeamId=$apnsTeamId, apnsKeyId=$apnsKeyId, apnsPrivateKeyPem=${mask(apnsPrivateKeyPem)}, apnsBundleId=$apnsBundleId)"
+}
 
 data class SecurityHeadersConfig(
     val permissionsPolicy: String = DEFAULT_PERMISSIONS_POLICY,
@@ -110,6 +126,19 @@ data class AppConfig(
     val runtime: RuntimeConfig = RuntimeConfig(),
     val platformMode: PlatformMode = PlatformMode.FullPlatform,
 ) {
+    // Override the data-class toString() so the DB password (and the secrets nested in jwt/email/appleOAuth/
+    // pushNotifications, whose own toString() implementations mask them) are never written to logs, stack
+    // traces, error messages, or observability output. See issue #524.
+    override fun toString(): String =
+        "AppConfig(version=$version, port=$port, jdbcUrl=$jdbcUrl, jdbcUser=$jdbcUser, jdbcPassword=${mask(jdbcPassword)}, " +
+            "profile=$profile, devDashboardEnabled=$devDashboardEnabled, devMode=$devMode, sessionCookieSecure=$sessionCookieSecure, " +
+            "sessionTimeoutMinutes=$sessionTimeoutMinutes, corsOrigins=$corsOrigins, csrfEnabled=$csrfEnabled, segment=$segment, " +
+            "email=$email, appBaseUrl=$appBaseUrl, maxFailedLoginAttempts=$maxFailedLoginAttempts, " +
+            "lockoutDurationSeconds=$lockoutDurationSeconds, registrationEnabled=$registrationEnabled, " +
+            "sessionAbsoluteTimeoutMinutes=$sessionAbsoluteTimeoutMinutes, jwt=$jwt, cspPolicy=$cspPolicy, staticDir=$staticDir, " +
+            "trustedProxies=$trustedProxies, appleOAuth=$appleOAuth, pushNotifications=$pushNotifications, " +
+            "securityHeaders=$securityHeaders, runtime=$runtime, platformMode=$platformMode)"
+
     companion object {
         const val DEFAULT_APP_BASE_URL = "http://localhost:8080"
         const val DEFAULT_JDBC_PASSWORD = "outerstellar"
@@ -406,3 +435,10 @@ private fun Map<String, Any>.bool(key: String, env: Map<String, String>, envKey:
 
 private fun Map<String, Any>.long(key: String, env: Map<String, String>, envKey: String, default: Long): Long =
     env[envKey]?.toLong() ?: (this[key] as? Long) ?: default
+
+/**
+ * Masks a secret value for safe inclusion in `toString()` output. Empty/blank values are reported as `""` (so it's
+ * clear the secret is genuinely unset); any non-blank value is reported as `***`. The actual secret material is never
+ * rendered, not even partially — leaking a suffix would still leak entropy.
+ */
+private fun mask(secret: String): String = if (secret.isBlank()) "\"\"" else "\"***\""

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/AppConfigTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/AppConfigTest.kt
@@ -131,4 +131,59 @@ class AppConfigTest {
         assert(config.securityHeaders.strictTransportSecurity == "max-age=31536000; includeSubDomains")
         assert(config.securityHeaders.perRouteOverrides.isEmpty())
     }
+
+    @Test
+    fun `AppConfig toString masks the JDBC password and nested secrets`() {
+        val config =
+            AppConfig(
+                jdbcPassword = "super-secret-db-password",
+                jwt = JwtConfig(enabled = true, secret = "jwt-hmac-signing-key"),
+                email = EmailConfig(enabled = true, password = "smtp-password"),
+                appleOAuth = AppleOAuthConfig(enabled = true, privateKeyPem = "-----BEGIN PRIVATE KEY-----"),
+                pushNotifications =
+                    PushNotificationConfig(
+                        enabled = true,
+                        fcmServiceAccountJson = """{"type":"service_account"}""",
+                        apnsPrivateKeyPem = "-----BEGIN APNS KEY-----",
+                    ),
+                segment = SegmentConfig(writeKey = "segment-write-key"),
+            )
+        val rendered = config.toString()
+
+        assert(!rendered.contains("super-secret-db-password")) { "JDBC password leaked in toString: $rendered" }
+        assert(!rendered.contains("jwt-hmac-signing-key")) { "JWT secret leaked in toString: $rendered" }
+        assert(!rendered.contains("smtp-password")) { "SMTP password leaked in toString: $rendered" }
+        assert(!rendered.contains("BEGIN PRIVATE KEY")) { "Apple OAuth private key leaked in toString: $rendered" }
+        assert(!rendered.contains("service_account")) { "FCM service account JSON leaked in toString: $rendered" }
+        assert(!rendered.contains("BEGIN APNS KEY")) { "APNS private key leaked in toString: $rendered" }
+        assert(!rendered.contains("segment-write-key")) { "Segment write key leaked in toString: $rendered" }
+    }
+
+    @Test
+    fun `AppConfig toString preserves non-secret fields for diagnostics`() {
+        // jdbcPassword="" (explicitly blank) exercises the empty-secret marker path; the data-class
+        // default is "outerstellar", which would be masked as "***" — so set it explicitly here.
+        val config = AppConfig(port = 9090, jdbcUser = "outerstellar", jdbcPassword = "", profile = "prod")
+        val rendered = config.toString()
+
+        // Non-secret values remain visible so toString() is still useful for diagnostics.
+        assert(rendered.contains("port=9090")) { "Expected port in toString: $rendered" }
+        assert(rendered.contains("jdbcUser=outerstellar")) { "Expected jdbcUser in toString: $rendered" }
+        assert(rendered.contains("profile=prod")) { "Expected profile in toString: $rendered" }
+        // A blank password renders as an explicit empty marker, not the literal secret.
+        assert(rendered.contains("jdbcPassword=\"\"")) { "Expected blank jdbcPassword marker: $rendered" }
+    }
+
+    @Test
+    fun `JwtConfig toString masks the HMAC secret`() {
+        val rendered = JwtConfig(secret = "do-not-leak-me").toString()
+        assert(!rendered.contains("do-not-leak-me")) { "JWT secret leaked: $rendered" }
+        assert(rendered.contains("***")) { "Expected mask marker: $rendered" }
+    }
+
+    @Test
+    fun `EmailConfig toString masks the SMTP password`() {
+        val rendered = EmailConfig(password = "do-not-leak-me").toString()
+        assert(!rendered.contains("do-not-leak-me")) { "SMTP password leaked: $rendered" }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #524 — `AppConfig` and its nested config data classes (`JwtConfig`, `EmailConfig`, `AppleOAuthConfig`, `PushNotificationConfig`, `SegmentConfig`) are Kotlin data classes whose auto-generated `toString()` interpolates every field verbatim. Any `toString()` of the config — via debug logging, an exception message, a stack trace, or observability tooling — wrote the **DB password, JWT HMAC secret, SMTP password, Apple OAuth private key, FCM service-account JSON, APNS private key, and Segment write key** to logs.

The leak is currently **latent** (no `logger.info("\$config")` exists in `Main`), but a data class that cannot be safely stringified is a standing footgun — once the JWT secret is logged, an attacker can forge admin bearer tokens.

## Change

Override `toString()` on each secret-bearing config data class via a private `mask()` helper:
- Non-blank secrets render as `"***"` (never partially — leaking a suffix would still leak entropy)
- Blank secrets render as `""` so it's obvious the value is genuinely unset
- Non-secret fields remain fully visible, so `toString()` stays useful for diagnostics

Masked fields: `AppConfig.jdbcPassword`, `JwtConfig.secret`, `EmailConfig.password`, `AppleOAuthConfig.privateKeyPem`, `PushNotificationConfig.fcmServiceAccountJson`, `PushNotificationConfig.apnsPrivateKeyPem`, `SegmentConfig.writeKey`.

No data class loses its generated `equals()`/`hashCode()`/`copy()` — only `toString()` is overridden.

## Tests
4 new `AppConfigTest` cases assert no secret material appears in `toString()` (JDBC password, JWT secret, SMTP password, Apple OAuth key, FCM JSON, APNS key, Segment write key), and that non-secret fields (port, jdbcUser, profile) remain visible for diagnostics.

## Verification
Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS** (SpotBugs, detekt, checkstyle, PMD, Spotless)
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**, **1279 tests, 0 failures, 0 errors, 0 skipped**

Desktop modules excluded per AGENTS.md (require Podman containers).

Closes #524.