### PR TITLE
test: fix three dead @Test methods nested inside assertDoesNotThrow

### DIFF
--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/AppConfigTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/AppConfigTest.kt
@@ -71,23 +71,24 @@ class AppConfigTest {
             val config = AppConfig.fromEnvironment(env)
             assert(config.port == 9091)
             assert(config.sessionTimeoutMinutes == 60)
-            @Test
-            fun `profile defaults to default when APP_PROFILE not set`() {
-                val config = AppConfig.fromEnvironment(emptyMap())
-                assert(config.profile == "default") { "Expected 'default' but was ${config.profile}" }
-            }
-
-            @Test
-            fun `profile is set from APP_PROFILE env var`() {
-                val config = AppConfig.fromEnvironment(mapOf("APP_PROFILE" to "prod"))
-                assert(config.profile == "prod") { "Expected 'prod' but was ${config.profile}" }
-            }
-
-            @Test
-            fun `DEFAULT_JDBC_PASSWORD constant matches data class default`() {
-                assert(AppConfig.DEFAULT_JDBC_PASSWORD == AppConfig().jdbcPassword)
-            }
         }
+    }
+
+    @Test
+    fun `profile defaults to default when APP_PROFILE not set`() {
+        val config = AppConfig.fromEnvironment(emptyMap())
+        assert(config.profile == "default") { "Expected 'default' but was ${config.profile}" }
+    }
+
+    @Test
+    fun `profile is set from APP_PROFILE env var`() {
+        val config = AppConfig.fromEnvironment(mapOf("APP_PROFILE" to "prod"))
+        assert(config.profile == "prod") { "Expected 'prod' but was ${config.profile}" }
+    }
+
+    @Test
+    fun `DEFAULT_JDBC_PASSWORD constant matches data class default`() {
+        assert(AppConfig.DEFAULT_JDBC_PASSWORD == AppConfig().jdbcPassword)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes a pre-existing test-hygiene bug surfaced by the commit gate while working on #524.

Three `@Test` functions in `AppConfigTest` — `profile defaults to default when APP_PROFILE not set`, `profile is set from APP_PROFILE env var`, and `DEFAULT_JDBC_PASSWORD constant matches data class default` — were declared **inside the body** of `accepts valid config without warnings`'s `assertDoesNotThrow` block.

JUnit 5 compiles these as static private lambdas on the enclosing test method and refuses to execute them, emitting warnings on every test run:

```
@Test method '...$profile_defaults_to_default_when_APP_PROFILE_not_set()'
must not be static. It will not be executed.
@Test method '...' must not be private. It will not be executed.
```

So these assertions **never ran** — a silent gap in coverage for the `profile` env-var parsing and the `DEFAULT_JDBC_PASSWORD` invariant.

## Change
Hoist the three `@Test` functions to class top level so JUnit discovers and executes them. The port/timeout assertions that legitimately belong in `accepts valid config without warnings` stay inside `assertDoesNotThrow`. No production code changed.

## Verification
Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS**
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**, **1278 tests, 0 failures, 0 errors, 0 skipped** (up from 1275 — the 3 formerly-dead tests now run and pass)

The JUnit "must not be static/private" warnings are gone. Desktop modules excluded per AGENTS.md (require Podman containers).