### PR TITLE
fix: make graceful shutdown robust to per-step exceptions

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/Main.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/Main.kt
@@ -83,10 +83,12 @@ private fun registerShutdownHook(
             Thread(
                 {
                     logger.info("Graceful shutdown initiated")
-                    try {
-                        logger.info("Flushing pending activity updates...")
-                        components.security.asyncActivityUpdater.flush()
-                        logger.info("Stopping outbox scheduler...")
+                    // Each independent cleanup step is guarded individually: a failure in one
+                    // (e.g. DB error during flush, port still bound during server.stop) must not
+                    // skip the others. Shutdown is the wrong place to propagate — catch Throwable
+                    // and log, so the JVM always reaches a fully-stopped state.
+                    runStep("flush activity updates") { components.security.asyncActivityUpdater.flush() }
+                    runStep("stop outbox scheduler") {
                         outboxScheduler.shutdown()
                         try {
                             if (!outboxScheduler.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
@@ -95,18 +97,25 @@ private fun registerShutdownHook(
                         } catch (e: InterruptedException) {
                             outboxScheduler.shutdownNow()
                         }
-                        logger.info("Stopping HTTP server...")
-                        server.stop()
-                    } finally {
-                        // Always close the persistence layer (HikariDataSource) last so DB connections
-                        // are released to the pool and Postgres even if an earlier shutdown step throws.
-                        logger.info("Closing persistence (DB pool)...")
-                        runCatching { components.persistence.close() }
-                            .onFailure { logger.warn("Failed to close persistence cleanly", it) }
-                        logger.info("Shutdown complete")
                     }
+                    runStep("stop HTTP server") { server.stop() }
+                    // Close the DB pool last so connections are released even if an earlier step threw.
+                    runStep("close persistence (DB pool)") { components.persistence.close() }
+                    logger.info("Shutdown complete")
                 },
                 "graceful-shutdown",
             )
         )
+}
+
+/** Runs a shutdown step, logging its start and swallowing any Throwable so subsequent steps still run. */
+private fun runStep(name: String, step: () -> Unit) {
+    logger.info("$name...")
+    try {
+        step()
+    } catch (t: Throwable) {
+        // Shutdown-hook exceptions are swallowed by the JVM and abort the remaining cleanup,
+        // leaving the process half-dead. Catch everything and log so every step gets a chance.
+        logger.warn("Failed to $name", t)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #526 — the shutdown hook guarded only the outbox `awaitTermination` window (against `InterruptedException`); every other step ran unguarded. A single thrown exception anywhere in shutdown (e.g. a DB error during `flush()`, port still bound during `server.stop()`) aborted all subsequent cleanup, leaving the JVM **half-dead**: outbox thread still running, HTTP socket still bound, DB pool leaked. Since shutdown-hook exceptions are swallowed by the JVM, the failure was silent and hard to diagnose.

## Change

Wrap each independent cleanup step in its own `try/catch(Throwable)` via a small `runStep()` helper that logs the step name, runs it, and swallows + logs any failure so the remaining steps still execute. `Throwable` (not `Exception`) is deliberate — shutdown is the wrong place to propagate; the goal is to reach a fully-stopped state regardless of which step misbehaves.

Steps, in order, each independently guarded: flush activity updates → stop outbox scheduler → stop HTTP server → close persistence (DB pool, last).

## ⚠️ Overlaps with #534 (and fixes #525)

This PR also adds `components.persistence.close()` as the final guarded step — the exact fix from **#534** (which itself fixes **#525**). If this PR merges, **#534 becomes redundant** and should be closed unmerged (it's fully subsumed here, plus the robustness fix). I built this independently off `develop` per AGENTS.md §483 (one branch per PR); whichever merges first, the other rebases or closes.

## One self-caught issue during the gate

SpotBugs flagged `UPM_UNCALLED_PRIVATE_METHOD` on the initial `inline fun runStep` — Kotlin inlined the call sites away, so the JVM bytecode had no `runStep` invocation, making it look dead. Removed `inline` (the function runs once at shutdown; inlining bought nothing). Gate now passes.

## Verification
Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS** (SpotBugs, detekt, checkstyle, PMD, Spotless)
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**, **1275 tests, 0 failures, 0 errors, 0 skipped**

Desktop modules excluded per AGENTS.md (require Podman containers).

Closes #526. Supersedes #534 (also fixes #525).