### PR TITLE
fix(security): fail-loud config parsing and reject insecure defaults at startup

### DIFF
--- a/.github/workflows/ci-docker-e2e.yml
+++ b/.github/workflows/ci-docker-e2e.yml
@@ -45,7 +45,7 @@ jobs:
         env:
           POSTGRES_DB: outerstellar
           POSTGRES_USER: outerstellar
-          POSTGRES_PASSWORD: outerstellar
+          POSTGRES_PASSWORD: e2e-test-password
         ports:
           - 5432:5432
         options: >-
@@ -101,7 +101,7 @@ jobs:
             -e SESSIONCOOKIESECURE=false \
             -e "JDBC_URL=jdbc:postgresql://host.docker.internal:5432/outerstellar" \
             -e JDBC_USER=outerstellar \
-            -e JDBC_PASSWORD=outerstellar \
+            -e JDBC_PASSWORD=e2e-test-password \
             outerstellar-platform:e2e
 
       - name: Wait for application to be ready

--- a/.github/workflows/ci-native-image.yml
+++ b/.github/workflows/ci-native-image.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           POSTGRES_DB: outerstellar
           POSTGRES_USER: outerstellar
-          POSTGRES_PASSWORD: outerstellar
+          POSTGRES_PASSWORD: e2e-test-password
         ports:
           - 5432:5432
         options: >-
@@ -89,7 +89,7 @@ jobs:
             -p 8080:8080 \
             -e "JDBC_URL=jdbc:postgresql://host.docker.internal:5432/outerstellar" \
             -e JDBC_USER=outerstellar \
-            -e JDBC_PASSWORD=outerstellar \
+            -e JDBC_PASSWORD=e2e-test-password \
             -e JTE_PRODUCTION=true \
             -e SESSIONCOOKIESECURE=false \
             -e DEVMODE=true \

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
@@ -33,6 +33,12 @@ data class JwtConfig(
     val issuer: String = "outerstellar",
     val expirySeconds: Long = DEFAULT_JWT_EXPIRY_SECONDS,
 ) {
+    init {
+        require(!enabled || secret.isNotBlank()) {
+            "JWT is enabled but the HMAC secret is blank. Set JWT_SECRET to a strong value (>= 32 chars) before enabling JWT."
+        }
+    }
+
     // HMAC secret is a signing key — never expose it in logs, stack traces, or debug output.
     override fun toString(): String =
         "JwtConfig(enabled=$enabled, secret=${mask(secret)}, issuer=$issuer, expirySeconds=$expirySeconds)"
@@ -126,6 +132,9 @@ data class AppConfig(
     val runtime: RuntimeConfig = RuntimeConfig(),
     val platformMode: PlatformMode = PlatformMode.FullPlatform,
 ) {
+    /** True when the JDBC password was not overridden from the shipped dev default. */
+    fun usesDefaultJdbcPassword(): Boolean = jdbcPassword == DEFAULT_JDBC_PASSWORD
+
     // Override the data-class toString() so the DB password (and the secrets nested in jwt/email/appleOAuth/
     // pushNotifications, whose own toString() implementations mask them) are never written to logs, stack
     // traces, error messages, or observability output. See issue #524.
@@ -141,7 +150,13 @@ data class AppConfig(
 
     companion object {
         const val DEFAULT_APP_BASE_URL = "http://localhost:8080"
-        const val DEFAULT_JDBC_PASSWORD = "outerstellar"
+
+        /**
+         * Shipped default JDBC password used only for local/dev convenience. Internal to avoid leaking the known-value
+         * credential through the public API; [AppConfig.usesDefaultJdbcPassword] is the supported way to detect that
+         * the operator did not override it.
+         */
+        internal const val DEFAULT_JDBC_PASSWORD = "outerstellar"
         private val logger = LoggerFactory.getLogger(AppConfig::class.java)
 
         fun fromEnvironment(environment: Map<String, String> = System.getenv()): AppConfig {
@@ -430,8 +445,20 @@ private fun Map<String, Any>.staticDir(env: Map<String, String>): String =
 private fun Map<String, Any>.int(key: String, env: Map<String, String>, envKey: String, default: Int): Int =
     env[envKey]?.toInt() ?: (this[key] as? Int) ?: default
 
-private fun Map<String, Any>.bool(key: String, env: Map<String, String>, envKey: String, default: Boolean): Boolean =
-    env[envKey]?.toBoolean() ?: (this[key] as? Boolean) ?: default
+private fun Map<String, Any>.bool(key: String, env: Map<String, String>, envKey: String, default: Boolean): Boolean {
+    // Fail loud on a malformed boolean value rather than silently disabling security-sensitive flags.
+    // Kotlin's String.toBoolean() returns false for any non-"true" string, so SESSION_COOKIE_SECURE=yes
+    // would silently disable the Secure flag; require an explicit true/false (case-insensitive) instead.
+    val raw = env[envKey] ?: return (this[key] as? Boolean) ?: default
+    return when (raw.lowercase()) {
+        "true" -> true
+        "false" -> false
+        else ->
+            throw IllegalArgumentException(
+                "Environment variable $envKey='$raw' is not a valid boolean (expected 'true' or 'false')."
+            )
+    }
+}
 
 private fun Map<String, Any>.long(key: String, env: Map<String, String>, envKey: String, default: Long): Long =
     env[envKey]?.toLong() ?: (this[key] as? Long) ?: default

--- a/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/AppConfigTest.kt
+++ b/platform-core/src/test/kotlin/io/github/rygel/outerstellar/platform/AppConfigTest.kt
@@ -2,6 +2,7 @@ package io.github.rygel.outerstellar.platform
 
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 
 class AppConfigTest {
 
@@ -186,5 +187,33 @@ class AppConfigTest {
     fun `EmailConfig toString masks the SMTP password`() {
         val rendered = EmailConfig(password = "do-not-leak-me").toString()
         assert(!rendered.contains("do-not-leak-me")) { "SMTP password leaked: $rendered" }
+    }
+
+    @Test
+    fun `usesDefaultJdbcPassword detects the shipped default`() {
+        assert(AppConfig().usesDefaultJdbcPassword()) { "Default config should use the shipped JDBC password" }
+        assert(AppConfig(jdbcPassword = "overridden").usesDefaultJdbcPassword().not()) {
+            "An overridden password should not be flagged as default"
+        }
+    }
+
+    @Test
+    fun `bool env var rejects non-boolean values instead of silently defaulting to false`() {
+        // Fail-loud parsing (issue #527): a typo like SESSIONCOOKIESECURE=yes must crash-start rather
+        // than silently disable the Secure cookie flag.
+        assertThrows<IllegalArgumentException> { AppConfig.fromEnvironment(mapOf("SESSIONCOOKIESECURE" to "yes")) }
+    }
+
+    @Test
+    fun `bool env var accepts true and false case-insensitively`() {
+        assert(AppConfig.fromEnvironment(mapOf("SESSIONCOOKIESECURE" to "TRUE")).sessionCookieSecure)
+        assert(AppConfig.fromEnvironment(mapOf("SESSIONCOOKIESECURE" to "False")).sessionCookieSecure.not())
+    }
+
+    @Test
+    fun `JwtConfig rejects enabled with a blank secret at construction`() {
+        assertThrows<IllegalArgumentException> { JwtConfig(enabled = true, secret = "") }
+        // Disabled with blank secret is still allowed (JWT simply won't be used).
+        JwtConfig(enabled = false, secret = "")
     }
 }

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/JwtServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/JwtServiceTest.kt
@@ -99,9 +99,13 @@ class JwtServiceTest {
     }
 
     @Test
-    fun `isEnabled is false when secret is blank`() {
-        val noSecret = JwtService(JwtConfig(enabled = true, secret = "", issuer = "test"))
-        assertTrue(!noSecret.isEnabled)
+    fun `constructing an enabled JwtConfig with a blank secret fails fast`() {
+        // Fail-fast contract (issue #527): an enabled JWT with no secret is rejected at construction,
+        // rather than silently running with an empty HMAC key. Previously JwtService would warn and
+        // treat itself as disabled; that runtime guard is now a startup-time precondition.
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            JwtConfig(enabled = true, secret = "", issuer = "test")
+        }
     }
 
     @Test

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/Main.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/Main.kt
@@ -26,16 +26,16 @@ fun main() {
     logger.info(elapsed(t0, "Components created"))
 
     if (
-        components.config.jdbcPassword == AppConfig.DEFAULT_JDBC_PASSWORD &&
+        components.config.usesDefaultJdbcPassword() &&
             components.config.profile != "default" &&
             components.config.profile != "test"
     ) {
         logger.error(
-            "FATAL: JDBC_PASSWORD is still the default '{}' with profile '{}'. " +
+            "FATAL: JDBC_PASSWORD is still the shipped default in profile '{}'. " +
                 "Set JDBC_PASSWORD to a secure value before deploying.",
-            AppConfig.DEFAULT_JDBC_PASSWORD,
             components.config.profile,
         )
+        System.exit(1)
     }
 
     val server = components.app.asServer(Netty(components.config.port)).start()


### PR DESCRIPTION
## Summary

Fixes #527 — insecure config defaults and fail-open env-var parsing that silently let the app boot in a compromised state.

### Note on the issue's JWT repro
The "server signs tokens with HMAC secret = empty string" failure described in #527's repro was **already mitigated** — `JwtService.isEnabled` (`= config.enabled && config.secret.isNotBlank()`) guards both `generateToken` and `extractClaims`, so no token is ever signed with `""`. This PR makes that misconfiguration **loud at startup** instead of a runtime warn-and-disable, but it was not an active forgeable-token bug.

## Changes (4 fail-open paths hardened)

1. **Default JDBC creds abort startup (non-dev profiles).** `Main.kt` already logged `FATAL` when `JDBC_PASSWORD` was still the shipped `"outerstellar"` default in a prod/staging profile — but it only *logged* and continued; the server booted anyway with known-value creds. Now `System.exit(1)`. The `default`/`test` profile exemption is preserved so local dev and the test suite are unaffected.

2. **`bool()` env parsing is fail-loud.** `String.toBoolean()` returns `false` for any non-`"true"` value, so a typo like `SESSIONCOOKIESECURE=yes` silently disabled the Secure cookie flag. Now only `true`/`false` (case-insensitive) are accepted; anything else throws `IllegalArgumentException` naming the offending env var. Matches the existing `int()`/`long()` semantics (which already throw on garbage).

3. **`JwtConfig` rejects `enabled`+blank-`secret` at construction** (`require{}`). The runtime guard in `JwtService` stays, but the misconfiguration is now a startup-time precondition error so it can't be missed in logs.

4. **`DEFAULT_JDBC_PASSWORD` is now `internal`** — the known-value credential no longer leaks through `AppConfig`'s public API. Detection uses the new `AppConfig.usesDefaultJdbcPassword()` helper.

## Tests
`AppConfigTest` gains 4 cases: `usesDefaultJdbcPassword` detection, fail-loud `bool` parsing, case-insensitive `bool` accept, and the `JwtConfig` precondition. `JwtServiceTest`'s "isEnabled false when secret blank" is updated to assert the new fail-fast construction contract. **1288 tests, 0 failures.**

## Verification
Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS** (SpotBugs, detekt, checkstyle, PMD, Spotless)
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**

⚠️ **Breaking for deployments:** any non-`default`/`test` profile that still relies on the shipped `outerstellar/outerstellar` JDBC credentials will now refuse to start. Set `JDBC_PASSWORD` explicitly.

Closes #527.