### PR TITLE
fix(security): neutralise dangerous URL schemes in search result hrefs

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/SearchPageFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/SearchPageFactory.kt
@@ -29,6 +29,28 @@ class SearchPageFactory {
             val providerLimit = ceil(safeLimit.toDouble() / filtered.size).toInt()
             return filtered.flatMap { it.search(query, providerLimit) }.sortedByDescending { it.score }.take(safeLimit)
         }
+
+        /**
+         * Neutralises dangerous URL schemes for use in an `href` context. jte's `${...}` HTML-escapes, so attribute
+         * breakout via `"` is impossible, but it does NOT neutralise executable schemes — `javascript:`, `data:`,
+         * `vbscript:` survive unchanged and execute on click. This allow-lists only http(s), protocol-relative
+         * (`//host`), root-relative (`/path`), and fragment (`#`) URLs; anything else (including all executable
+         * schemes, with or without surrounding whitespace/case tricks) is collapsed to `#` so the link still renders
+         * but is inert. Defence-in-depth: SearchProvider is an extension SPI, so a careless/malicious third-party
+         * provider can't inject script via result URLs.
+         */
+        fun safeHref(url: String): String {
+            val trimmed = url.trim()
+            if (trimmed.isEmpty()) return "#"
+            // Root-relative and fragment links are always safe.
+            if (trimmed.startsWith("/") && !trimmed.startsWith("//")) return trimmed
+            val schemeEnd = trimmed.indexOf(':')
+            // No scheme (no colon before any '/', '?', '#') → relative/same-origin, safe.
+            val firstSlash = trimmed.indexOfAny(charArrayOf('/', '?', '#'))
+            if (schemeEnd == -1 || (firstSlash != -1 && schemeEnd > firstSlash)) return trimmed
+            val scheme = trimmed.substring(0, schemeEnd).lowercase()
+            return if (scheme == "http" || scheme == "https") trimmed else "#"
+        }
     }
 
     fun buildSearchPage(
@@ -42,7 +64,13 @@ class SearchPageFactory {
         val shell = shellRenderer.shell(i18n.translate("web.search.title"), "/search")
         val results =
             aggregateResults(providers, query, limit, typeFilter).map { r ->
-                SearchResultViewModel(id = r.id, title = r.title, subtitle = r.subtitle, url = r.url, type = r.type)
+                SearchResultViewModel(
+                    id = r.id,
+                    title = r.title,
+                    subtitle = r.subtitle,
+                    url = safeHref(r.url),
+                    type = r.type,
+                )
             }
         val typeFilters = buildTypeFilters(providers, query, typeFilter, i18n)
         return Page(

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SearchPageFactoryTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/SearchPageFactoryTest.kt
@@ -1,0 +1,102 @@
+package io.github.rygel.outerstellar.platform.web
+
+import io.github.rygel.outerstellar.platform.search.SearchProvider
+import io.github.rygel.outerstellar.platform.search.SearchResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+
+class SearchPageFactoryTest {
+    @Test
+    fun `safeHref preserves http and https URLs`() {
+        assertEquals("http://example.com/a", SearchPageFactory.safeHref("http://example.com/a"))
+        assertEquals("HTTPS://Example.com/a", SearchPageFactory.safeHref("HTTPS://Example.com/a"))
+    }
+
+    @Test
+    fun `safeHref preserves root-relative and fragment URLs`() {
+        assertEquals("/contacts?q=x", SearchPageFactory.safeHref("/contacts?q=x"))
+        assertEquals("#section", SearchPageFactory.safeHref("#section"))
+    }
+
+    @Test
+    fun `safeHref neutralises executable schemes`() {
+        assertEquals("#", SearchPageFactory.safeHref("javascript:alert(document.cookie)"))
+        assertEquals("#", SearchPageFactory.safeHref("JaVaScRiPt:alert(1)"))
+        assertEquals("#", SearchPageFactory.safeHref("data:text/html,<script>alert(1)</script>"))
+        assertEquals("#", SearchPageFactory.safeHref("vbscript:msgbox(1)"))
+    }
+
+    @Test
+    fun `safeHref neutralises executable schemes with surrounding whitespace`() {
+        // Browsers strip leading/control whitespace before resolving a scheme.
+        assertEquals("#", SearchPageFactory.safeHref("  javascript:alert(1)"))
+        assertEquals("#", SearchPageFactory.safeHref("\tjavascript:alert(1)"))
+    }
+
+    @Test
+    fun `safeHref returns placeholder for empty url`() {
+        assertEquals("#", SearchPageFactory.safeHref(""))
+        assertEquals("#", SearchPageFactory.safeHref("   "))
+    }
+
+    @Test
+    fun `safeHref does not mistake a colon in the path for a scheme`() {
+        assertEquals("/path/with:colon", SearchPageFactory.safeHref("/path/with:colon"))
+        assertEquals("relative/path:colon", SearchPageFactory.safeHref("relative/path:colon"))
+    }
+
+    @Test
+    fun `buildSearchPage neutralises a malicious provider's javascript url`() {
+        // Regression guard for issue #517: a SearchProvider returning a javascript: URL must not reach the
+        // rendered href unneutralised, even though the built-in providers currently emit only safe paths.
+        val maliciousProvider =
+            object : SearchProvider {
+                override val type = "evil"
+
+                override fun search(query: String, limit: Int): List<SearchResult> =
+                    listOf(
+                        SearchResult(
+                            id = "1",
+                            title = "click me",
+                            subtitle = "",
+                            url = "javascript:fetch('/api/v1/session')",
+                            type = "evil",
+                        )
+                    )
+            }
+        val factory = SearchPageFactory()
+        val page =
+            factory.buildSearchPage(
+                shellRenderer = shellRenderer(),
+                query = "click",
+                providers = listOf(maliciousProvider),
+            )
+
+        assertEquals(1, page.data.results.size)
+        val renderedUrl = page.data.results.single().url
+        assertEquals("#", renderedUrl, "javascript: URL must be neutralised before reaching the view model")
+        assertFalse(renderedUrl.contains("javascript"), "Rendered URL must not contain 'javascript': $renderedUrl")
+    }
+
+    @Test
+    fun `buildSearchPage preserves a safe https url from a provider`() {
+        val provider =
+            object : SearchProvider {
+                override val type = "links"
+
+                override fun search(query: String, limit: Int): List<SearchResult> =
+                    listOf(SearchResult("1", "doc", "", "https://docs.example.com/guide", "links"))
+            }
+        val factory = SearchPageFactory()
+        val page = factory.buildSearchPage(shellRenderer(), "doc", listOf(provider))
+
+        assertEquals("https://docs.example.com/guide", page.data.results.single().url)
+    }
+
+    private fun shellRenderer(): ShellRenderer =
+        // Minimal anonymous context: search rendering only needs i18n + the shell title/path, not a session.
+        ShellRenderer(RequestContext(Request(GET, "/search")))
+}


### PR DESCRIPTION
## Summary

Fixes #517 — `SearchPage.kte` renders result links as `<a href="${result.url}">`. jte's `${...}` HTML-escapes, so attribute breakout via `"` is blocked, but it does **not** neutralise executable URL schemes — `href` is a URL-context attribute, so `javascript:`, `data:`, and `vbscript:` values survive unchanged and execute on click (session hijack / account takeover).

The repro from the issue (`javascript:fetch('/api/v1/...')`) reaches the rendered `href` unneutralised.

## Current exposure
The built-in providers (`ContactSearchProvider`, `MessageSearchProvider`) currently emit only hardcoded safe relative URLs (`/contacts`, `/`), so this is **latent** today. But `SearchProvider` is an **extension SPI** — any third-party provider indexing attacker-influenced content (profile links, catalog/discord links) without scheme validation would create a live XSS. The template provided no defence-in-depth.

## Change
`SearchPageFactory.safeHref()` — an allow-list applied at the single chokepoint where every provider's `SearchResult` flows into the `SearchResultViewModel`:
- **Preserves**: `http(s)`, protocol-relative (`//host`), root-relative (`/path`), fragment (`#`), and schemeless-relative URLs
- **Collapses to `#`**: everything else — `javascript:`, `data:`, `vbscript:`, unknown schemes, case tricks (`JaVaScRiPt:`), and leading-whitespace tricks (browsers strip control whitespace before resolving a scheme)

A malicious/careless provider cannot inject script via the href; the link still renders but is inert.

## Tests
New `SearchPageFactoryTest` (8 cases): `safeHref` exhaustively (scheme variants, whitespace/case bypass attempts, path-colon false positives, empty), plus end-to-end through `buildSearchPage` with a malicious provider returning `javascript:fetch('/api/v1/session')` — asserting it's neutralised to `#` in the rendered view model.

## Verification
Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS** (SpotBugs, detekt, checkstyle, PMD, Spotless)
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**, **1292 tests, 0 failures, 0 errors, 0 skipped**

Desktop modules excluded per AGENTS.md (require Podman containers).

Closes #517.