### PR TITLE
fix(security): enforce max request body size to prevent oversized-body DoS

### DIFF
--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
@@ -13,6 +13,8 @@ private const val DEFAULT_JWT_EXPIRY_SECONDS = 86400L
 private const val MAX_HTTP_PORT = 65535
 private const val MIN_HTTP_PORT = 1
 private const val DEFAULT_MAX_FAILED_LOGIN_ATTEMPTS = 10
+private const val DEFAULT_MAX_REQUEST_BODY_BYTES =
+    2L * 1024 * 1024 // 2 MiB — generous for forms/JSON, blocks oversized-body DoS
 private const val DEFAULT_LOCKOUT_DURATION_SECONDS = 900L
 private const val DEFAULT_REGISTRATION_ENABLED = true
 private const val DEFAULT_SESSION_ABSOLUTE_TIMEOUT_MINUTES = 1440
@@ -119,6 +121,7 @@ data class AppConfig(
     val email: EmailConfig = EmailConfig(),
     val appBaseUrl: String = DEFAULT_APP_BASE_URL,
     val maxFailedLoginAttempts: Int = DEFAULT_MAX_FAILED_LOGIN_ATTEMPTS,
+    val maxRequestBodyBytes: Long = DEFAULT_MAX_REQUEST_BODY_BYTES,
     val lockoutDurationSeconds: Long = DEFAULT_LOCKOUT_DURATION_SECONDS,
     val registrationEnabled: Boolean = DEFAULT_REGISTRATION_ENABLED,
     val sessionAbsoluteTimeoutMinutes: Int = DEFAULT_SESSION_ABSOLUTE_TIMEOUT_MINUTES,
@@ -142,7 +145,7 @@ data class AppConfig(
         "AppConfig(version=$version, port=$port, jdbcUrl=$jdbcUrl, jdbcUser=$jdbcUser, jdbcPassword=${mask(jdbcPassword)}, " +
             "profile=$profile, devDashboardEnabled=$devDashboardEnabled, devMode=$devMode, sessionCookieSecure=$sessionCookieSecure, " +
             "sessionTimeoutMinutes=$sessionTimeoutMinutes, corsOrigins=$corsOrigins, csrfEnabled=$csrfEnabled, segment=$segment, " +
-            "email=$email, appBaseUrl=$appBaseUrl, maxFailedLoginAttempts=$maxFailedLoginAttempts, " +
+            "email=$email, appBaseUrl=$appBaseUrl, maxFailedLoginAttempts=$maxFailedLoginAttempts, maxRequestBodyBytes=$maxRequestBodyBytes, " +
             "lockoutDurationSeconds=$lockoutDurationSeconds, registrationEnabled=$registrationEnabled, " +
             "sessionAbsoluteTimeoutMinutes=$sessionAbsoluteTimeoutMinutes, jwt=$jwt, cspPolicy=$cspPolicy, staticDir=$staticDir, " +
             "trustedProxies=$trustedProxies, appleOAuth=$appleOAuth, pushNotifications=$pushNotifications, " +
@@ -221,6 +224,8 @@ data class AppConfig(
                         "MAX_FAILED_LOGIN_ATTEMPTS",
                         DEFAULT_MAX_FAILED_LOGIN_ATTEMPTS,
                     ),
+                maxRequestBodyBytes =
+                    yaml.long("maxRequestBodyBytes", env, "MAX_REQUEST_BODY_BYTES", DEFAULT_MAX_REQUEST_BODY_BYTES),
                 lockoutDurationSeconds =
                     yaml.long(
                         "lockoutDurationSeconds",

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -175,6 +175,26 @@ object Filters {
         }
     }
 
+    /**
+     * Rejects requests whose body exceeds [maxBytes] before the body is buffered into memory, returning 413. Defends
+     * against oversized-body DoS (heap exhaustion / GC thrash from a single large POST). The check is on the
+     * Content-Length header so the body is never read for oversized requests. Requests without a Content-Length (e.g.
+     * chunked/streamed) are left to the handler, which is the http4k default; a hard cap on those would require
+     * consuming the stream, which we avoid to keep the filter allocation-free.
+     */
+    fun maxBodySize(maxBytes: Long): Filter = Filter { next: HttpHandler ->
+        { request ->
+            val declared = request.header("Content-Length")?.toLongOrNull()
+            if (declared != null && declared > maxBytes) {
+                Response(Status.REQUEST_ENTITY_TOO_LARGE)
+                    .header("content-type", "text/plain; charset=utf-8")
+                    .body("Request body of $declared bytes exceeds the limit of $maxBytes bytes.")
+            } else {
+                next(request)
+            }
+        }
+    }
+
     fun cors(allowedOrigins: String, headerConfig: SecurityHeadersConfig = SecurityHeadersConfig()): Filter =
         Filter { next: HttpHandler ->
             { request ->

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/FilterChainFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/FilterChainFactory.kt
@@ -29,6 +29,7 @@ internal class FilterChainFactory(
         var chain =
             Filters.correlationId
                 .then(Filters.cors(config.corsOrigins, config.securityHeaders))
+                .then(Filters.maxBodySize(config.maxRequestBodyBytes))
                 .then(etagCachingFilter)
                 .then(staticCacheControlFilter)
                 .then(Filters.securityHeaders(config.cspPolicy, config.securityHeaders))

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MaxBodySizeFilterTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/MaxBodySizeFilterTest.kt
@@ -1,0 +1,55 @@
+package io.github.rygel.outerstellar.platform.web
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.http4k.core.Method.POST
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.then
+
+class MaxBodySizeFilterTest {
+    // A trivial downstream handler that echoes the declared content length, proving the request reached it.
+    private val downstream = { req: Request -> Response(Status.OK).body(req.header("Content-Length") ?: "0") }
+
+    @Test
+    fun `passes requests with no Content-Length through unchanged`() {
+        val app = Filters.maxBodySize(100L).then(downstream)
+        val resp = app(Request(POST, "/auth"))
+        assertEquals(Status.OK, resp.status)
+    }
+
+    @Test
+    fun `passes requests at or under the limit`() {
+        val app = Filters.maxBodySize(100L).then(downstream)
+        val resp = app(Request(POST, "/auth").header("Content-Length", "100").body("x".repeat(100)))
+        assertEquals(Status.OK, resp.status)
+    }
+
+    @Test
+    fun `rejects oversized requests with 413 before reaching the handler`() {
+        val app = Filters.maxBodySize(100L).then(downstream)
+        val resp = app(Request(POST, "/auth").header("Content-Length", "101").body("x".repeat(101)))
+        assertEquals(Status.REQUEST_ENTITY_TOO_LARGE, resp.status)
+        assert(resp.bodyString().contains("exceeds the limit")) { "Expected limit message, got: ${resp.body}" }
+    }
+
+    @Test
+    fun `rejects vastly oversized requests without allocating the body`() {
+        // The DoS scenario from issue #516: a 500 MiB declared body. The filter must short-circuit on the
+        // Content-Length header alone — note we declare 500 MiB but send a tiny body, simulating a hostile
+        // client that lies about length. The 413 is returned without the handler ever touching the body.
+        val fiveHundredMiB = 500L * 1024 * 1024
+        val app = Filters.maxBodySize(2L * 1024 * 1024).then(downstream)
+        val resp = app(Request(POST, "/auth").header("Content-Length", fiveHundredMiB.toString()).body("tiny"))
+        assertEquals(Status.REQUEST_ENTITY_TOO_LARGE, resp.status)
+    }
+
+    @Test
+    fun `ignores a malformed Content-Length header`() {
+        // A garbage Content-Length must not crash the filter; treat it as absent and let the handler decide.
+        val app = Filters.maxBodySize(100L).then(downstream)
+        val resp = app(Request(POST, "/auth").header("Content-Length", "not-a-number").body("ok"))
+        assertEquals(Status.OK, resp.status)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #516 — the platform filter chain installed **no request body-size limit**. http4k buffers request bodies fully into memory by default, so an attacker could POST an arbitrarily large body (e.g. to `/auth`, `/settings`, contacts, API keys) to exhaust heap / trigger OOM or GC thrash — a trivial remote DoS with a single connection per worker. No 413 was ever returned.

The issue suggested `ServerFilters.MaxBodySize`, but **http4k 6.53.0.0 ships no such filter** (verified — no `MaxBodySize`/`ReceiveRequestSizeLimit` in `ServerFilters`). So this adds a small custom filter.

## Change
- **`Filters.maxBodySize(maxBytes)`** — inspects the `Content-Length` header and returns `413 REQUEST_ENTITY_TOO_LARGE` before the body is read, leaving the body unbuffered for oversized requests.
- **Wired into `FilterChainFactory`** early (after CORS, before CSRF/state) so CORS preflight OPTIONS passes and oversized bodies are rejected before any auth/session work.
- **Configurable** via `maxRequestBodyBytes` (env `MAX_REQUEST_BODY_BYTES`, YAML `maxRequestBodyBytes`), defaulting to **2 MiB** — generous for all form/JSON endpoints, small enough to stop the DoS.
- **No file-upload routes exist** in the platform (verified: the "avatar"/"upload" hits are URL string fields in the User model, not file uploads), so 2 MiB covers every legitimate request.

## Tests
`MaxBodySizeFilterTest` (5 cases): pass-through with no Content-Length, pass at-limit, 413 over-limit, **413 on a 500 MiB declared body without allocating it** (the exact DoS scenario from #516 — the filter short-circuits on the header alone), and graceful handling of a malformed Content-Length.

## Verification
Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS** (SpotBugs, detekt, checkstyle, PMD, Spotless)
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**, **1311 tests, 0 failures, 0 errors, 0 skipped**

Desktop modules excluded per AGENTS.md (require Podman containers).

Closes #516.