### PR TITLE
fix: replace hand-rolled JSON for TOTP backup codes with kotlinx.serialization

### DIFF
--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/TOTPService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/TOTPService.kt
@@ -8,6 +8,9 @@ import dev.samstevens.totp.recovery.RecoveryCodeGenerator
 import dev.samstevens.totp.secret.DefaultSecretGenerator
 import dev.samstevens.totp.time.SystemTimeProvider
 import dev.samstevens.totp.util.Utils
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
 
 /**
  * Hashes and verifies TOTP backup codes. Backup codes are an equally critical credential as the main password (a single
@@ -16,6 +19,14 @@ import dev.samstevens.totp.util.Utils
  * [org.mindrot.jbcrypt.BCrypt.checkpw] is constant-time.
  */
 class TOTPService(private val backupCodeEncoder: PasswordEncoder) {
+
+    // Reused JSON codec for the backup-code hash list. Stored format is a JSON array of strings (the BCrypt
+    // hashes), so ListSerializer(String.serializer()) handles all escaping of ",", "\"", "\" correctly —
+    // replacing the previous hand-rolled concat/split that silently corrupted on special characters (#512).
+    private val backupCodeJson = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
 
     private val secretGenerator = DefaultSecretGenerator(32)
     private val codeVerifier =
@@ -62,8 +73,14 @@ class TOTPService(private val backupCodeEncoder: PasswordEncoder) {
         return if (hashedCodes.isEmpty()) "" else serializeJson(hashedCodes)
     }
 
-    private fun serializeJson(list: List<String>): String = list.joinToString(",", "[", "]") { "\"$it\"" }
+    private fun serializeJson(list: List<String>): String =
+        backupCodeJson.encodeToString(ListSerializer(String.serializer()), list)
 
-    private fun parseJsonList(json: String): List<String> =
-        json.removeSurrounding("[", "]").split(",").map { it.trim().removeSurrounding("\"") }.filter { it.isNotEmpty() }
+    private fun parseJsonList(json: String): List<String> {
+        // verifyBackupCode returns "" to signal an exhausted code set; that "" is stored as the column value
+        // and later passed back here. Treat blank input as an empty list rather than attempting to decode it
+        // as JSON (which would throw).
+        if (json.isBlank()) return emptyList()
+        return backupCodeJson.decodeFromString(ListSerializer(String.serializer()), json)
+    }
 }

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/TOTPServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/TOTPServiceTest.kt
@@ -1,5 +1,8 @@
 package io.github.rygel.outerstellar.platform.security
 
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -89,5 +92,50 @@ class TOTPServiceTest {
         val uri1 = totpService.generateQrDataUri(secret1, "a@b.com")
         val uri2 = totpService.generateQrDataUri(secret2, "a@b.com")
         assertFalse(uri1 == uri2, "Different secrets should produce different QR URIs")
+    }
+
+    @Test
+    fun `verifyBackupCode parses a stored hash containing commas and quotes without corruption`() {
+        // Regression guard for issue #512: the old hand-rolled parser split on "," and stripped
+        // surrounding quotes, so a hash containing those characters was silently corrupted. A
+        // properly-escaped JSON array (as kotlinx.serialization now produces) must round-trip intact.
+        // Build the stored JSON via the same codec so it's guaranteed valid despite the special chars.
+        val trickyHash = """hash,with"quote\backslash"""
+        val other = "plain"
+        val stored = Json.encodeToString(ListSerializer(String.serializer()), listOf(trickyHash, other))
+        val stubMatchingEncoder =
+            object : PasswordEncoder {
+                override fun encode(raw: String): String = ""
+
+                override fun matches(raw: String, hashed: String): Boolean = hashed == trickyHash
+            }
+        val service = TOTPService(stubMatchingEncoder)
+        val remaining = service.verifyBackupCode("anything", stored)
+        assertNotNull(remaining, "A matching hash with special characters must parse and verify")
+        // The matched hash should be consumed, leaving only "plain".
+        assertEquals("""["plain"]""", remaining!!.replace(" ", ""))
+    }
+
+    @Test
+    fun `verifyBackupCode treats the blank exhausted sentinel as an empty code set`() {
+        // verifyBackupCode returns "" when the last code is consumed; that "" is stored and later re-parsed.
+        // The parser must yield an empty list (not throw) for blank input — the old code relied on this too.
+        assertNull(totpService.verifyBackupCode("anything", ""), "Blank sentinel must yield no match")
+    }
+
+    @Test
+    fun `verifyBackupCode round-trips a full generate-then-consume cycle without data loss`() {
+        // End-to-end: generate 16, consume all 16 in sequence; the final consume must return "" (exhausted),
+        // and re-verifying any code against the exhausted sentinel must return null. Confirms the JSON
+        // round-trip survives a realistic full-consumption sequence.
+        val (rawCodes, hashed) = totpService.generateBackupCodes()
+        var current = hashed
+        for (code in rawCodes) {
+            val updated = totpService.verifyBackupCode(code, current)
+            assertNotNull(updated, "Each code must verify in sequence")
+            current = updated!!
+        }
+        assertEquals("", current, "After consuming all codes the sentinel must be the empty string")
+        assertNull(totpService.verifyBackupCode(rawCodes[0], current), "Exhausted set must yield no match")
     }
 }


### PR DESCRIPTION
## Summary

Fixes #512 — `serializeJson`/`parseJsonList` in `TOTPService` built/parsed the backup-code hash list by hand: concat each entry in quotes joined by commas, parsed by `removeSurrounding("[]")` → `split(",")` → `removeSurrounding('"')`. **No escaping of `,`, `"`, or `\`** — so a hash (or a DBA edit, or a future code-generator change) containing those characters was silently corrupted into a wrong/empty code set, locking the user out of TOTP recovery.

The default `RecoveryCodeGenerator` and the BCrypt hashes (from #533) happen to contain none of those characters, so **today the round-trip works** — but the code was a classic hand-rolled-JSON footgun (the issue's repro is bytecode reasoning, confirmed by reading the code).

## Change
Replace both functions with `kotlinx.serialization`'s `ListSerializer(String.serializer())` — the project already bundles this (it serialises the sync DTOs and the `TotpModels`). Handles all escaping correctly. **Stored format is unchanged** (JSON array of strings), so existing data round-trips identically — no migration. `parseJsonList` treats the blank exhausted-sentinel (the `""` that `verifyBackupCode` returns/stores when the last code is consumed) as an empty list rather than attempting to decode it as JSON.

## Tests
3 new `TOTPServiceTest` cases:
- A stored hash containing `,` `"` and `\` parses and verifies without corruption (built via the same codec so the input is valid JSON)
- The blank exhausted sentinel yields no match instead of throwing
- A full generate-then-consume-all-16 cycle round-trips to the exhausted sentinel

## Verification
Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS** (SpotBugs, detekt, checkstyle, PMD, Spotless)
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**, **1309 tests, 0 failures, 0 errors, 0 skipped**

Desktop modules excluded per AGENTS.md (require Podman containers).

Closes #512.