### PR TITLE
fix: drop Secure flag from _csrf cookie so double-submit works over HTTP

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -430,6 +430,7 @@ object Filters {
         }
     }
 
+    @Suppress("UnusedParameter")
     fun csrfProtection(sessionCookieSecure: Boolean, enabled: Boolean = true): Filter = Filter { next ->
         { request ->
             if (!enabled) return@Filter next(request)
@@ -474,7 +475,16 @@ object Filters {
                             RequestContext.CSRF_COOKIE,
                             newToken,
                             path = "/",
-                            secure = sessionCookieSecure,
+                            // The _csrf cookie backs a double-submit token: the browser must read it
+                            // client-side and submit the value back in the X-CSRF-Token header / _csrf
+                            // form field. That requires the cookie to be *stored* over HTTP too (localhost
+                            // dev, TLS-terminating reverse proxies). A Secure flag would make the browser
+                            // refuse to store it over http:// per RFC 6265bis, silently breaking every
+                            // state-changing request. CSRF protection comes from token-matching, not from
+                            // transport — so the cookie must NOT be Secure. (The session cookie, which is
+                            // auto-sent and transport-only, correctly keeps Secure.) httpOnly stays false
+                            // so JS can read the token; SameSite=Strict provides the cross-site defence.
+                            secure = false,
                             httpOnly = false,
                             sameSite = SameSite.Strict,
                         )

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/CsrfProtectionIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/CsrfProtectionIntegrationTest.kt
@@ -124,4 +124,21 @@ class CsrfProtectionIntegrationTest : WebTest() {
         val csrfCookieInResponse = response.cookies().find { it.name == RequestContext.CSRF_COOKIE }
         assert(csrfCookieInResponse != null) { "Expected _csrf cookie to be set on first GET" }
     }
+
+    @Test
+    fun `CSRF cookie is emitted without Secure so double-submit works over HTTP and TLS-terminating proxies`() {
+        // Regression guard for issue #515: the _csrf cookie backs a double-submit token, so the browser
+        // must STORE it over http:// (localhost dev, reverse-proxy → plain HTTP to app). A Secure flag
+        // makes the browser refuse to store it over HTTP per RFC 6265bis, silently breaking every POST.
+        // The test config defaults sessionCookieSecure=true (the production default); the CSRF cookie must
+        // still be non-Secure regardless, since CSRF protection comes from token-matching not transport.
+        val response = app(Request(GET, "/"))
+        val setCookieHeader = response.header("Set-Cookie") ?: ""
+        assert(setCookieHeader.contains("_csrf", ignoreCase = true)) {
+            "Expected _csrf Set-Cookie, got: $setCookieHeader"
+        }
+        assert(!setCookieHeader.contains("secure", ignoreCase = true)) {
+            "_csrf cookie must NOT carry Secure (breaks double-submit over HTTP): $setCookieHeader"
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #515 — the `_csrf` cookie backs a **double-submit** CSRF token: the browser must read it client-side and submit the value back in the `X-CSRF-Token` header / `_csrf` form field. The cookie was emitted with `Secure=sessionCookieSecure` (which **defaults to `true`**), so a browser receiving it over `http://` refused to store it per RFC 6265bis. With no `_csrf` cookie stored, **every state-changing POST/PUT/DELETE/PATCH failed the double-submit check and returned 403** — silently breaking localhost dev (`appBaseUrl=http://localhost:8080`) and any deploy where TLS is terminated upstream (reverse proxy → plain HTTP to app).

## Why dropping Secure is correct (not a weakening)
The double-submit pattern fundamentally requires the cookie to be **stored and read regardless of transport scheme** — that's why `httpOnly` is already `false`. CSRF protection comes from **token-matching** (the cookie value must equal the submitted header/form value), **not from transport security**. The `Secure` flag was actively breaking the mechanism it was meant to protect. The session cookie (`app_session`), which is auto-sent and transport-only, **correctly keeps its `Secure` flag** — only the `_csrf` cookie changes. `SameSite=Strict` provides the cross-site defence.

## Change
Set `secure = false` unconditionally on the `_csrf` cookie in `csrfProtection()`. The `sessionCookieSecure` param is retained for API stability (extensions may call `Filters.csrfProtection`) but no longer affects the cookie; suppressed `UnusedParameter` with a comment.

## Test
New `CsrfProtectionIntegrationTest` case asserts the `_csrf` cookie is emitted **without `Secure`** even when the test config defaults `sessionCookieSecure=true` (the production default) — pinning the fix against regression.

## Verification
Commit gate (AGENTS.md §425) satisfied locally on Java 21 (Temurin 21.0.9):
- `mvn install -T 1C -DskipTests -Djacoco.skip=true -Denforcer.skip=true` — **BUILD SUCCESS** (SpotBugs, detekt, checkstyle, PMD, Spotless)
- `mvn clean verify -T4 -pl '!platform-desktop,!platform-desktop-javafx'` — **BUILD SUCCESS**, **1312 tests, 0 failures, 0 errors, 0 skipped**

Desktop modules excluded per AGENTS.md (require Podman containers).

Closes #515.