### PR TITLE
feat: add /health/live and /health/ready endpoints for orchestrator probes

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/HttpHandlerFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/HttpHandlerFactory.kt
@@ -50,9 +50,24 @@ internal class HttpHandlerFactory(
         val unfiltered =
             mutableListOf(
                 static(staticResourceLoader()),
+                "/health/live" bind
+                    GET to
+                    {
+                        // Liveness: process up, no dependency probes (avoids restart loops on transient blips).
+                        StaticRoutes.localhostOnly.then { StaticRoutes.buildLivenessResponse() }(it)
+                    },
+                "/health/ready" bind
+                    GET to
+                    {
+                        // Readiness: probes DB + extension readiness — traffic should be withheld if DOWN.
+                        StaticRoutes.localhostOnly.then {
+                            StaticRoutes.buildHealthResponse(userRepository, extensionContribution)
+                        }(it)
+                    },
                 "/health" bind
                     GET to
                     {
+                        // Backward-compatible alias for /health/ready (the pre-existing behaviour).
                         StaticRoutes.localhostOnly.then {
                             StaticRoutes.buildHealthResponse(userRepository, extensionContribution)
                         }(it)

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/StaticRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/StaticRoutes.kt
@@ -81,6 +81,18 @@ internal object StaticRoutes {
             )
     }
 
+    /**
+     * Liveness probe: the process is up and the JVM is serving. Always 200 — if this fails, the orchestrator should
+     * restart the container. Does NOT probe dependencies (DB, extensions) so a transient dependency blip doesn't cause
+     * a restart loop. Kubernetes `/health/live` convention.
+     */
+    fun buildLivenessResponse(): Response {
+        val body = mapOf("status" to "UP", "timestamp" to Instant.now().toString())
+        return Response(Status.OK)
+            .header("content-type", "application/json; charset=utf-8")
+            .body(KotlinxSerialization.asJsonObject(body).toString())
+    }
+
     @Suppress("TooGenericExceptionCaught", "SwallowedException")
     fun buildHealthResponse(userRepository: UserRepository, extensionContribution: ExtensionContribution): Response {
         val checks = mutableMapOf<String, Any>("status" to "UP")

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/HealthEndpointTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/HealthEndpointTest.kt
@@ -1,0 +1,49 @@
+package io.github.rygel.outerstellar.platform.web
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.containsSubstring
+import kotlin.test.Test
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Status
+import org.http4k.hamkrest.hasStatus
+
+class HealthEndpointTest : WebTest() {
+    // Health endpoints are localhost-only; tests run on loopback so they pass the filter.
+
+    @Test
+    fun `health live returns 200 with status UP`() {
+        val app = buildApp()
+        val response = app(Request(GET, "/health/live"))
+        assertThat(response, hasStatus(Status.OK))
+        assertThat(response.bodyString(), containsSubstring("\"status\":\"UP\""))
+    }
+
+    @Test
+    fun `health live does not probe the database`() {
+        // Liveness must not depend on the DB (a transient DB blip must not cause a restart loop).
+        val app = buildApp()
+        val response = app(Request(GET, "/health/live"))
+        assertThat(response, hasStatus(Status.OK))
+        assert(!response.bodyString().contains("database")) { "Liveness must not probe DB: ${response.body}" }
+    }
+
+    @Test
+    fun `health ready returns 200 and reports database status when DB is up`() {
+        val app = buildApp()
+        val response = app(Request(GET, "/health/ready"))
+        assertThat(response, hasStatus(Status.OK))
+        val body = response.bodyString()
+        assertThat(body, containsSubstring("database"))
+        assertThat(body, containsSubstring("\"status\":\"UP\""))
+    }
+
+    @Test
+    fun `legacy health endpoint still works as readiness alias`() {
+        val app = buildApp()
+        val response = app(Request(GET, "/health"))
+        // Backward compat: /health behaves as readiness (probes DB).
+        assertThat(response, hasStatus(Status.OK))
+        assertThat(response.bodyString(), containsSubstring("database"))
+    }
+}


### PR DESCRIPTION
Closes #528. Adds the Kubernetes liveness/readiness split: `/health/live` (always 200, no DB probe — avoids restart loops on transient blips), `/health/ready` (existing DB+extension probe, 503 when DOWN), and `/health` kept as backward-compat alias. All localhost-only. 4 new `HealthEndpointTest` cases. Gate green (§425): **1316 tests, 0 failures**.