### PR TITLE
fix: set Max-Age on app_session cookie so browser lifetime matches server policy

### DIFF
--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AuthRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AuthRoutes.kt
@@ -92,7 +92,14 @@ class AuthRoutes(
                             val sessionToken = sessionService.createSession(user.id)
                             Response(Status.FOUND)
                                 .header("location", shellRenderer.url(returnTo))
-                                .header("Set-Cookie", SessionCookie.create(sessionToken, appConfig.sessionCookieSecure))
+                                .header(
+                                    "Set-Cookie",
+                                    SessionCookie.create(
+                                        sessionToken,
+                                        appConfig.sessionCookieSecure,
+                                        appConfig.sessionTimeoutMinutes * 60L,
+                                    ),
+                                )
                         } else {
                             renderer.render(
                                 AuthResultFragment(

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -310,6 +310,7 @@ object Filters {
         userRepository: UserRepository,
         sessionService: SessionService,
         sessionCookieSecure: Boolean,
+        sessionTimeoutMinutes: Int = 30,
     ): Filter = Filter { next ->
         { request ->
             val host = request.header("Host")
@@ -322,7 +323,10 @@ object Filters {
                     val token = sessionService.createSession(admin.id)
                     val response = next(request.cookie(Cookie(RequestContext.SESSION_COOKIE, token)))
                     if (response.cookies().none { it.name == RequestContext.SESSION_COOKIE }) {
-                        response.header("Set-Cookie", SessionCookie.create(token, sessionCookieSecure))
+                        response.header(
+                            "Set-Cookie",
+                            SessionCookie.create(token, sessionCookieSecure, sessionTimeoutMinutes * 60L),
+                        )
                     } else {
                         response
                     }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/OAuthRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/OAuthRoutes.kt
@@ -31,6 +31,7 @@ class OAuthRoutes(
     private val sessionService: SessionService,
     private val sessionCookieSecure: Boolean = false,
     private val appBaseUrl: String = "http://localhost:8080",
+    private val sessionTimeoutMinutes: Int = 30,
 ) : ServerRoutes {
 
     private val logger = LoggerFactory.getLogger(OAuthRoutes::class.java)
@@ -141,7 +142,10 @@ class OAuthRoutes(
             logger.info("OAuth sign-in successful: user={} provider={}", user.username, providerName)
             Response(Status.FOUND)
                 .header("location", "/")
-                .header("Set-Cookie", SessionCookie.create(sessionToken, sessionCookieSecure))
+                .header(
+                    "Set-Cookie",
+                    SessionCookie.create(sessionToken, sessionCookieSecure, sessionTimeoutMinutes * 60L),
+                )
                 .cookie(Cookie("oauth_state", "", maxAge = 0L, path = "/"))
         } catch (e: OAuthException) {
             logger.warn("OAuth callback error for provider={}: {}", providerName, e.message)

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/TOTPRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/TOTPRoutes.kt
@@ -19,6 +19,7 @@ class TOTPRoutes(
     private val sessionCookieSecure: Boolean,
     private val totpService: TOTPService,
     private val sessionService: SessionService,
+    private val sessionTimeoutMinutes: Int = 30,
 ) {
     val routes =
         routes(
@@ -35,7 +36,10 @@ class TOTPRoutes(
                         "success" -> {
                             val sessionToken = result.token ?: return@to Response(OK).body("Missing session token")
                             Response(OK)
-                                .header("Set-Cookie", SessionCookie.create(sessionToken, sessionCookieSecure))
+                                .header(
+                                    "Set-Cookie",
+                                    SessionCookie.create(sessionToken, sessionCookieSecure, sessionTimeoutMinutes * 60L),
+                                )
                                 .header("HX-Redirect", "/")
                         }
                         "invalid_code" ->

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/FilterChainFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/FilterChainFactory.kt
@@ -46,6 +46,7 @@ internal class FilterChainFactory(
                         userRepository,
                         security.sessionService,
                         config.sessionCookieSecure,
+                        config.sessionTimeoutMinutes,
                     )
                 )
                 .then(

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/HttpHandlerFactory.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/HttpHandlerFactory.kt
@@ -80,6 +80,7 @@ internal class HttpHandlerFactory(
                     config.sessionCookieSecure,
                     sec.totpService,
                     sec.sessionService,
+                    config.sessionTimeoutMinutes,
                 )
                 .routes
         appRoutes += TOTPApiRoutes(sec.authService, sec.totpService, sec.sessionService).routes

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/UiRouteRegistrar.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/assembly/UiRouteRegistrar.kt
@@ -194,6 +194,7 @@ internal class UiRouteRegistrar(
                 sessionService = security.sessionService,
                 sessionCookieSecure = config.sessionCookieSecure,
                 appBaseUrl = config.appBaseUrl,
+                sessionTimeoutMinutes = config.sessionTimeoutMinutes,
             )
         oauthRoutes.routes.forEach { route ->
             registry.register(


### PR DESCRIPTION
Closes #518. All four session-establishing routes (login, OAuth, TOTP, dev-auto-login) now pass `sessionTimeoutMinutes * 60L` to `SessionCookie.create`, so the browser persists the cookie to match server policy (previously emitted with no Max-Age → cleared on browser close). Not a security change (server-side expiry still bounds lifetime). Gate green (§425): install + full verify, 0 failures.