### PR TITLE
fix(security): use a single generic audit detail for all auth failures

### DIFF
--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AuthService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AuthService.kt
@@ -37,24 +37,20 @@ class AuthService(
                     logger.warn("Authentication failed: User ${sanitize(username)} not found")
                     auditRepository?.logAction(
                         "AUTHENTICATION_FAILED",
-                        detail = "User not found",
+                        detail = "Invalid credentials",
                         targetUsername = sanitize(username),
                     )
                     return null
                 }
         if (!user.enabled) {
             logger.warn("Authentication failed: User ${sanitize(username)} is disabled")
-            auditRepository?.logAction("AUTHENTICATION_FAILED", actor = user, detail = "Account disabled")
+            auditRepository?.logAction("AUTHENTICATION_FAILED", actor = user, detail = "Invalid credentials")
             return null
         }
         val lockedUntil = user.lockedUntil
         if (lockedUntil != null && lockedUntil.isAfter(Instant.now())) {
             logger.warn("Authentication failed: User ${sanitize(username)} is locked until $lockedUntil")
-            auditRepository?.logAction(
-                "AUTHENTICATION_FAILED",
-                actor = user,
-                detail = "Account locked until $lockedUntil",
-            )
+            auditRepository?.logAction("AUTHENTICATION_FAILED", actor = user, detail = "Invalid credentials")
             return null
         }
         if (passwordEncoder.matches(password, user.passwordHash)) {
@@ -69,7 +65,7 @@ class AuthService(
         }
         val attempts = userRepository.incrementFailedLoginAttempts(user.id)
         logger.warn("Authentication failed: Invalid password for user ${sanitize(username)} (attempt $attempts)")
-        auditRepository?.logAction("AUTHENTICATION_FAILED", actor = user, detail = "Invalid password")
+        auditRepository?.logAction("AUTHENTICATION_FAILED", actor = user, detail = "Invalid credentials")
         if (attempts >= config.maxFailedLoginAttempts) {
             val until = Instant.now().plusSeconds(config.lockoutDurationSeconds)
             userRepository.updateLockedUntil(user.id, until)

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthServiceTest.kt
@@ -159,7 +159,7 @@ class AuthServiceTest {
             auditRepository.log(
                 match {
                     it.action == "AUTHENTICATION_FAILED" &&
-                        it.detail == "User not found" &&
+                        it.detail == "Invalid credentials" &&
                         it.targetUsername == "unknown"
                 }
             )
@@ -174,7 +174,7 @@ class AuthServiceTest {
         service.authenticate("testuser", "anypass")
 
         verify {
-            auditRepository.log(match { it.action == "AUTHENTICATION_FAILED" && it.detail == "Account disabled" })
+            auditRepository.log(match { it.action == "AUTHENTICATION_FAILED" && it.detail == "Invalid credentials" })
         }
     }
 
@@ -186,9 +186,7 @@ class AuthServiceTest {
         service.authenticate("testuser", "correctpass")
 
         verify {
-            auditRepository.log(
-                match { it.action == "AUTHENTICATION_FAILED" && it.detail?.startsWith("Account locked until") == true }
-            )
+            auditRepository.log(match { it.action == "AUTHENTICATION_FAILED" && it.detail == "Invalid credentials" })
         }
     }
 
@@ -201,7 +199,7 @@ class AuthServiceTest {
         service.authenticate("testuser", "wrongpass")
 
         verify {
-            auditRepository.log(match { it.action == "AUTHENTICATION_FAILED" && it.detail == "Invalid password" })
+            auditRepository.log(match { it.action == "AUTHENTICATION_FAILED" && it.detail == "Invalid credentials" })
         }
     }
 


### PR DESCRIPTION
Closes #509. All four `AUTHENTICATION_FAILED` audit-log details (User not found / Account disabled / Account locked / Invalid password) collapsed to a single generic `"Invalid credentials"` so audit-log consumers can't enumerate valid accounts. Detailed discriminator stays in server `logger.warn` (ops-only), not the audited DB row. 4 AuthServiceTest cases updated. Gate green (§425).