### PR TITLE
fix(security): run a dummy BCrypt verify on the not-found login path

### DIFF
--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AuthService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AuthService.kt
@@ -30,10 +30,24 @@ class AuthService(
     private val partialAuthStore: Cache<String, PartialAuth> =
         Caffeine.newBuilder().expireAfterWrite(5, TimeUnit.MINUTES).maximumSize(10_000).build()
 
+    /**
+     * A dummy password hash used to keep the not-found login path's timing equal to the bad-password path (issue #505).
+     * Computed once via the injected encoder so its cost factor matches the deployment's real password hashes; the
+     * value is constant but never used to authenticate anyone.
+     */
+    private val dummyPasswordHash: String by lazy { passwordEncoder.encode("timing-mitigation-dummy") }
+
     fun authenticate(username: String, password: String): AuthResult? {
         val user =
             userRepository.findByUsername(username)
                 ?: run {
+                    // Timing-oracle mitigation (issue #505): a non-existent account returns immediately
+                    // and never invokes the (deliberately slow) BCrypt check, so it responds far faster
+                    // than an existing account with a wrong password — a reliable enumeration signal.
+                    // Run a dummy BCrypt verify against a precomputed hash so the not-found path takes
+                    // the same ~50-150ms as the bad-password path. The result is discarded. Standard
+                    // mitigation (Spring Security, Django, etc.).
+                    passwordEncoder.matches(password, dummyPasswordHash)
                     logger.warn("Authentication failed: User ${sanitize(username)} not found")
                     auditRepository?.logAction(
                         "AUTHENTICATION_FAILED",

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthServiceTest.kt
@@ -92,6 +92,17 @@ class AuthServiceTest {
     }
 
     @Test
+    fun `authenticate runs a dummy password verify on the not-found path to mask the timing oracle`() {
+        // Regression guard for issue #505: the not-found path must invoke passwordEncoder.matches so its
+        // latency matches the bad-password path (otherwise timing reveals which usernames exist).
+        every { userRepository.findByUsername("unknown") } returns null
+
+        service.authenticate("unknown", "anypass")
+
+        verify { passwordEncoder.matches(any(), any()) }
+    }
+
+    @Test
     fun `authenticate returns null for locked account`() {
         val lockedUser = testUser.copy(lockedUntil = Instant.now().plusSeconds(300))
         every { userRepository.findByUsername("testuser") } returns lockedUser


### PR DESCRIPTION
Closes #505. The not-found login path now runs a dummy `passwordEncoder.matches(...)` against a lazily-computed dummy hash so its latency matches the bad-password path — closing the timing-oracle account-enumeration vector. Dummy hash uses the injected encoder (matches deployment cost factor); result discarded. Standard mitigation (Spring Security, Django). New `AuthServiceTest` case asserts `matches` is invoked on the not-found path. Gate green (§425).