### PR TITLE
fix(security): remove JWT claims cache so revocation takes effect immediately

### DIFF
--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/JwtService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/JwtService.kt
@@ -3,14 +3,12 @@ package io.github.rygel.outerstellar.platform.security
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.exceptions.JWTVerificationException
-import com.github.benmanes.caffeine.cache.Caffeine
 import io.github.rygel.outerstellar.platform.JwtConfig
 import io.github.rygel.outerstellar.platform.model.User
 import io.github.rygel.outerstellar.platform.model.UserRole
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger("outerstellar.JwtService")
@@ -29,13 +27,6 @@ class JwtService(private val config: JwtConfig) {
 
     private val algorithm by lazy { Algorithm.HMAC256(config.secret) }
 
-    /** Verified claims cached for 60 s to avoid re-parsing identical tokens on rapid requests. */
-    private val claimsCache =
-        Caffeine.newBuilder()
-            .maximumSize(2_000)
-            .expireAfterWrite(60, TimeUnit.SECONDS)
-            .build<String, Pair<UUID, Boolean>>()
-
     /** Issue a signed JWT for [user]. Returns null if JWT is not enabled. */
     fun generateToken(user: User): String? {
         if (!isEnabled) return null
@@ -52,26 +43,28 @@ class JwtService(private val config: JwtConfig) {
 
     /**
      * Verify [token] and return (userId, isAdmin). Returns null if JWT is not enabled, the token is invalid, or it has
-     * expired.
+     * expired. The token is re-verified on every call — HMAC-SHA256 verification is sub-millisecond, so a claims cache
+     * is not a meaningful optimisation, and caching raw bearer tokens as keys kept them valid for up to 60s after a
+     * credential-revoking event (logout, password change, role change, account disable) and exposed up to 2000 raw
+     * tokens in a heap dump. See issue #507.
      */
     fun extractClaims(token: String): Pair<UUID, Boolean>? {
         if (!isEnabled) return null
-        claimsCache.getIfPresent(token)?.let {
-            return it
-        }
         return try {
             val jwt = JWT.require(algorithm).withIssuer(config.issuer).build().verify(token)
             val userId = UUID.fromString(jwt.subject)
             val isAdmin = jwt.getClaim("admin")?.asBoolean() ?: false
-            (userId to isAdmin).also { claimsCache.put(token, it) }
+            userId to isAdmin
         } catch (e: JWTVerificationException) {
             logger.warn("JWT verification failed: {}", e.message)
             null
         }
     }
 
-    /** Evict a token from the claims cache (e.g. on logout). */
+    /** No-op retained for API compatibility. Caching was removed (issue #507); tokens always re-verify. */
+    @Suppress("UnusedParameter")
     fun invalidate(token: String) {
-        claimsCache.invalidate(token)
+        // Intentionally empty: there is no longer a claims cache to invalidate. Retained so callers
+        // (logout, password reset, role change) compile without modification.
     }
 }


### PR DESCRIPTION
Closes #507. Removed the Caffeine claims cache (keyed on raw bearer tokens) from `JwtService.extractClaims` — it kept tokens valid for up to 60s after logout/password-change/role-change/disable and exposed up to 2000 raw tokens in a heap dump. HMAC-SHA256 verify is sub-ms, so re-verifying on every call closes all three impact vectors with no meaningful perf cost. `invalidate()` retained as a no-op for API compatibility. Gate green (§425).