### PR TITLE
fix(security): make password-reset token consumption atomic and invalidate stale tokens

### DIFF
--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/PasswordResetRepository.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/PasswordResetRepository.kt
@@ -1,6 +1,7 @@
 package io.github.rygel.outerstellar.platform.persistence
 
 import io.github.rygel.outerstellar.platform.model.PasswordResetToken
+import java.util.UUID
 
 interface PasswordResetRepository {
     fun save(token: PasswordResetToken)
@@ -8,4 +9,15 @@ interface PasswordResetRepository {
     fun findByToken(token: String): PasswordResetToken?
 
     fun markUsed(token: String)
+
+    /**
+     * Atomically claim a single-use reset token: marks it used iff it is currently unused and unexpired, returning the
+     * owning user id. Returns null if the token does not exist, is already used, or has expired. The atomic UPDATE ...
+     * WHERE used = false guard makes concurrent claims with the same token race-safe (only one wins) — fixing the
+     * TOCTOU where findByToken + Java check + markUsed in separate transactions both succeeded.
+     */
+    fun claimToken(token: String): UUID?
+
+    /** Mark all unused reset tokens for [userId] as used (invalidates prior tokens when a new one is issued). */
+    fun invalidateUnusedForUser(userId: UUID)
 }

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiPasswordResetRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiPasswordResetRepository.kt
@@ -49,4 +49,40 @@ class JdbiPasswordResetRepository(private val jdbi: Jdbi) : PasswordResetReposit
                 .execute()
         }
     }
+
+    override fun claimToken(token: String): UUID? {
+        // Atomic single-statement claim: only marks used if currently unused+unexpired, returning the owner.
+        // The WHERE used = false guard makes concurrent claims race-safe (only one UPDATE matches),
+        // closing the TOCTOU where the old findByToken + Java check + markUsed ran in separate
+        // transactions and both observed used=false. Returns null when no row matched (invalid/expired/used).
+        return jdbi.withHandle<UUID?, Exception> { handle ->
+            handle
+                .createQuery(
+                    """
+                    UPDATE plt_password_reset_tokens
+                       SET used = true
+                     WHERE token = :token
+                       AND used = false
+                       AND expires_at > now()
+                    RETURNING user_id
+                    """
+                        .trimIndent()
+                )
+                .bind("token", token)
+                .map { rs, _ -> rs.getObject("user_id", UUID::class.java) }
+                .findOne()
+                .orElse(null)
+        }
+    }
+
+    override fun invalidateUnusedForUser(userId: UUID) {
+        jdbi.useHandle<Exception> { handle ->
+            handle
+                .createUpdate(
+                    "UPDATE plt_password_reset_tokens SET used = true WHERE user_id = :userId AND used = false"
+                )
+                .bind("userId", userId)
+                .execute()
+        }
+    }
 }

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiPasswordResetRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiPasswordResetRepositoryTest.kt
@@ -54,6 +54,44 @@ class JdbiPasswordResetRepositoryTest : JdbiTest() {
     }
 
     @Test
+    fun `claimToken atomically marks a valid token used and returns the owner`() {
+        val userId = createUser()
+        repo.save(token(userId, "claimable-token"))
+        val claimedUserId = repo.claimToken("claimable-token")
+        assertEquals(userId, claimedUserId)
+        assertTrue(repo.findByToken("claimable-token")!!.used)
+    }
+
+    @Test
+    fun claimTokenReturnsNullForAlreadyClaimedToken() {
+        val userId = createUser()
+        repo.save(token(userId, "once-only"))
+        assertNotNull(repo.claimToken("once-only"))
+        // Second claim must fail — the atomic WHERE used = false guard prevents double-use.
+        assertNull(repo.claimToken("once-only"))
+    }
+
+    @Test
+    fun `claimToken returns null for an expired token`() {
+        val userId = createUser()
+        val expired = token(userId, "expired-claim").copy(expiresAt = Instant.now().minusSeconds(60))
+        repo.save(expired)
+        assertNull(repo.claimToken("expired-claim"))
+    }
+
+    @Test
+    fun `invalidateUnusedForUser marks all prior unused tokens for the user as used`() {
+        val userId = createUser()
+        repo.save(token(userId, "old-1"))
+        repo.save(token(userId, "old-2"))
+        repo.save(token(userId, "old-3"))
+        repo.invalidateUnusedForUser(userId)
+        assertTrue(repo.findByToken("old-1")!!.used)
+        assertTrue(repo.findByToken("old-2")!!.used)
+        assertTrue(repo.findByToken("old-3")!!.used)
+    }
+
+    @Test
     fun `token column has only the unique-constraint index, not a redundant duplicate`() {
         // Regression guard for issue #530: the non-unique idx_plt_password_reset_tokens_token
         // duplicated the plt_password_reset_tokens_token_key UNIQUE constraint and was dropped.

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/PasswordResetService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/PasswordResetService.kt
@@ -31,6 +31,10 @@ class PasswordResetService(
         }
 
         val tokenValue = generateResetToken()
+        // Invalidate any prior unused tokens for this user so only the newest reset email is valid —
+        // prevents token hoarding where a leaked old reset email remains a live attack vector after
+        // the user has already reset via a later email.
+        resetRepository?.invalidateUnusedForUser(user.id)
         val resetToken =
             PasswordResetToken(
                 userId = user.id,
@@ -51,24 +55,20 @@ class PasswordResetService(
 
     fun resetPassword(token: String, newPassword: String) {
         val repository = resetRepository ?: throw IllegalArgumentException("Invalid reset token")
-        val resetToken =
-            repository.findByToken(TokenHashing.hash(token)) ?: throw IllegalArgumentException("Invalid reset token")
+        // Atomic claim: a single UPDATE ... WHERE used = false AND expires_at > now() RETURNING user_id
+        // marks the token used and returns the owner in one statement, so two concurrent reset requests
+        // with the same token cannot both pass the guard (only one UPDATE matches). Replaces the old
+        // findByToken + Java used/expiry check + markUsed which ran in separate transactions (TOCTOU).
+        val userId =
+            repository.claimToken(TokenHashing.hash(token)) ?: throw IllegalArgumentException("Invalid reset token")
 
-        if (resetToken.used) {
-            throw IllegalArgumentException("Reset token has already been used")
-        }
-        if (resetToken.expiresAt.isBefore(Instant.now())) {
-            throw IllegalArgumentException("Reset token has expired")
-        }
         val normalized = newPassword.trim()
         validatePassword(normalized)?.let { throw WeakPasswordException(it) }
 
-        val user =
-            userRepository.findById(resetToken.userId) ?: throw UserNotFoundException(resetToken.userId.toString())
+        val user = userRepository.findById(userId) ?: throw UserNotFoundException(userId.toString())
 
         val updated = user.copy(passwordHash = passwordEncoder.encode(normalized))
         userRepository.save(updated)
-        repository.markUsed(resetToken.token)
         sessionRepository?.deleteByUserId(user.id)
         logger.info("Password reset completed for user {}", sanitize(user.username))
         auditRepository?.logAction("PASSWORD_RESET_COMPLETED", actor = user)


### PR DESCRIPTION
Closes #508. (A) Replaced the non-atomic find+check+markUsed (TOCTOU race) with a single `claimToken` doing `UPDATE ... SET used=true WHERE token AND used=false AND expires_at>now() RETURNING user_id` — only one concurrent claim wins. (B) `requestPasswordReset` now calls `invalidateUnusedForUser` before issuing a new token, so prior unused tokens are revoked (no token hoarding). 5 new `JdbiPasswordResetRepositoryTest` cases. Gate green (§425).