### PR TITLE
fix(security): track TOTP failures per-user and lock the account after N misses

### DIFF
--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/model/User.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/model/User.kt
@@ -11,6 +11,7 @@ data class User(
     val role: UserRole,
     val enabled: Boolean = true,
     val failedLoginAttempts: Int = 0,
+    val failedTotpAttempts: Int = 0,
     val lockedUntil: Instant? = null,
     val lastActivityAt: Instant? = null,
     val avatarUrl: String? = null,

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/UserRepository.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/UserRepository.kt
@@ -11,6 +11,10 @@ interface UserRepository {
 
     fun resetFailedLoginAttempts(userId: UUID)
 
+    fun incrementFailedTotpAttempts(userId: UUID): Int
+
+    fun resetFailedTotpAttempts(userId: UUID)
+
     fun updateLockedUntil(userId: UUID, lockedUntil: Instant?)
 
     fun findById(id: UUID): User?

--- a/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepository.kt
+++ b/platform-persistence-jdbi/src/main/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiUserRepository.kt
@@ -233,6 +233,40 @@ class JdbiUserRepository(private val jdbi: Jdbi) : UserRepository {
         }
     }
 
+    override fun incrementFailedTotpAttempts(userId: UUID): Int {
+        return jdbi.withHandle<Int, Exception> { handle ->
+            handle
+                .createQuery(
+                    """
+                    UPDATE plt_users
+                    SET failed_totp_attempts = failed_totp_attempts + 1
+                    WHERE id = :id
+                    RETURNING failed_totp_attempts
+                    """
+                        .trimIndent()
+                )
+                .bind("id", userId)
+                .mapTo(Int::class.java)
+                .one()
+        }
+    }
+
+    override fun resetFailedTotpAttempts(userId: UUID) {
+        jdbi.useHandle<Exception> { handle ->
+            handle
+                .createUpdate(
+                    """
+                    UPDATE plt_users
+                    SET failed_totp_attempts = 0
+                    WHERE id = :id
+                    """
+                        .trimIndent()
+                )
+                .bind("id", userId)
+                .execute()
+        }
+    }
+
     override fun updateLockedUntil(userId: UUID, lockedUntil: Instant?) {
         jdbi.useHandle<Exception> { handle ->
             handle
@@ -303,6 +337,7 @@ class JdbiUserRepository(private val jdbi: Jdbi) : UserRepository {
             role = UserRole.valueOf(rs.getString("role")),
             enabled = rs.getBoolean("enabled"),
             failedLoginAttempts = rs.getInt("failed_login_attempts"),
+            failedTotpAttempts = rs.getInt("failed_totp_attempts"),
             lockedUntil = rs.getNullableInstant("locked_until"),
             lastActivityAt = rs.getNullableInstant("last_activity_at"),
             avatarUrl = rs.getString("avatar_url"),
@@ -322,7 +357,7 @@ class JdbiUserRepository(private val jdbi: Jdbi) : UserRepository {
             """
             SELECT id, username, email, password_hash, role, enabled, last_activity_at, avatar_url,
                    email_notifications_enabled, push_notifications_enabled, language, theme, layout,
-                   failed_login_attempts, locked_until, totp_secret, totp_enabled, totp_backup_codes
+                   failed_login_attempts, failed_totp_attempts, locked_until, totp_secret, totp_enabled, totp_backup_codes
             FROM plt_users
             """
     }

--- a/platform-persistence-jdbi/src/main/resources/db/migration/V16__add_totp_attempt_counter.sql
+++ b/platform-persistence-jdbi/src/main/resources/db/migration/V16__add_totp_attempt_counter.sql
@@ -1,0 +1,6 @@
+-- Track failed TOTP attempts independently of failed password attempts. The previous TOTP rate-limit
+-- was per-partial-token (4 attempts) and resettable by re-authenticating with the correct password,
+-- which minted a fresh partial token with attemptCount=0 — so an attacker with the password could
+-- brute-force 6-digit TOTP codes indefinitely. This counter is per-user and drives account lockout
+-- after N failures, independent of the partial-token lifecycle (issue #510).
+ALTER TABLE plt_users ADD COLUMN IF NOT EXISTS failed_totp_attempts INT NOT NULL DEFAULT 0;

--- a/platform-persistence-jdbi/src/main/resources/db/migration/migrations.index
+++ b/platform-persistence-jdbi/src/main/resources/db/migration/migrations.index
@@ -5,6 +5,7 @@ V12__add_polls
 V13__utc_only_timestamptz
 V14__add_message_votes
 V15__drop_redundant_reset_token_index
+V16__add_totp_attempt_counter
 V2__user_profile_enhancements
 V3__sessions_table
 V4__user_preferences

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AuthService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AuthService.kt
@@ -101,6 +101,7 @@ class AuthService(
         return created
     }
 
+    @Suppress("ReturnCount")
     fun verifyTotp(partialToken: String, code: String, sessionService: SessionService): TotpVerifyResponse {
         val partial =
             partialAuthStore.asMap().compute(partialToken) { _, existing ->
@@ -113,6 +114,7 @@ class AuthService(
 
         if (totpService.verifyCode(secret, code)) {
             partialAuthStore.invalidate(partialToken)
+            userRepository.resetFailedTotpAttempts(user.id)
             val token = sessionService.createSession(user.id)
             return TotpVerifyResponse("success", token = token, username = user.username, role = user.role.name)
         }
@@ -123,11 +125,24 @@ class AuthService(
             if (updatedCodes != null) {
                 userRepository.updateTotpSecret(user.id, user.totpSecret, updatedCodes.ifEmpty { null })
                 partialAuthStore.invalidate(partialToken)
+                userRepository.resetFailedTotpAttempts(user.id)
                 val token = sessionService.createSession(user.id)
                 return TotpVerifyResponse("success", token = token, username = user.username, role = user.role.name)
             }
         }
 
+        // Per-user TOTP failure tracking (issue #510): the partial-token cap was resettable by
+        // re-authenticating, allowing indefinite TOTP brute-force. Increment a per-user counter
+        // independent of the partial-token lifecycle, and lock the account once it reaches the
+        // configured threshold (reusing the existing lockout infrastructure).
+        val attempts = userRepository.incrementFailedTotpAttempts(user.id)
+        if (attempts >= config.maxFailedLoginAttempts) {
+            val until = Instant.now().plusSeconds(config.lockoutDurationSeconds)
+            userRepository.updateLockedUntil(user.id, until)
+            partialAuthStore.invalidate(partialToken)
+            logger.warn("TOTP verification locked user ${sanitize(user.username)} after $attempts failed attempts")
+            return TotpVerifyResponse("locked")
+        }
         return TotpVerifyResponse("invalid_code")
     }
 

--- a/platform-web/src/main/resources/META-INF/native-image/io.github.rygel/outerstellar-platform-web/reachability-metadata.json
+++ b/platform-web/src/main/resources/META-INF/native-image/io.github.rygel/outerstellar-platform-web/reachability-metadata.json
@@ -768,6 +768,8 @@
   }, {
     "glob" : "db/migration/V15__drop_redundant_reset_token_index.sql"
   }, {
+    "glob" : "db/migration/V16__add_totp_attempt_counter.sql"
+  }, {
     "glob" : "db/migration/V1__initial_schema.sql"
   }, {
     "glob" : "db/migration/V2__user_profile_enhancements.sql"


### PR DESCRIPTION
Closes #510. Adds a per-user `failed_totp_attempts` counter (V16 migration) incremented on every TOTP/backup-code failure; locks the account via the existing lockout infrastructure once the threshold is reached. The old per-partial-token cap was resettable by re-authenticating, allowing indefinite TOTP brute-force. Counter is independent of the partial-token lifecycle and reset on success. Gate green (§425): **1311 tests, 0 failures**.