### PR TITLE
fix(security): prevent demoting or disabling the last enabled administrator

### DIFF
--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/UserAdminService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/UserAdminService.kt
@@ -32,6 +32,9 @@ class UserAdminService(private val userRepository: UserRepository, private val a
             throw InsufficientPermissionException("Only administrators can enable/disable accounts")
         }
         val target = userRepository.findById(targetId) ?: throw UserNotFoundException(targetId.toString())
+        if (!enabled && target.role == UserRole.ADMIN && wouldLeaveNoEnabledAdmin(targetId)) {
+            throw InsufficientPermissionException("Cannot disable the last enabled administrator")
+        }
         userRepository.updateEnabled(targetId, enabled)
         logger.info("User {} enabled set to {} by admin {}", sanitize(target.username), enabled, adminId)
         val action = if (enabled) "USER_ENABLED" else "USER_DISABLED"
@@ -58,6 +61,9 @@ class UserAdminService(private val userRepository: UserRepository, private val a
             throw InsufficientPermissionException("Only administrators can change user roles")
         }
         val target = userRepository.findById(targetId) ?: throw UserNotFoundException(targetId.toString())
+        if (target.role == UserRole.ADMIN && role != UserRole.ADMIN && wouldLeaveNoEnabledAdmin(targetId)) {
+            throw InsufficientPermissionException("Cannot demote the last enabled administrator")
+        }
         userRepository.updateRole(targetId, role)
         logger.info("User {} role set to {} by admin {}", sanitize(target.username), role, adminId)
         auditRepository.logAction(
@@ -73,6 +79,14 @@ class UserAdminService(private val userRepository: UserRepository, private val a
     fun getAuditLog(limit: Int = 50): List<AuditEntry> = auditRepository.findRecent(limit)
 
     fun getAuditLog(limit: Int, offset: Int): List<AuditEntry> = auditRepository.findPage(limit, offset)
+
+    /**
+     * True iff [targetId] is the only enabled ADMIN — i.e. demoting or disabling them would leave zero enabled
+     * administrators, locking everyone out of admin endpoints with no recovery short of DB intervention. Counts enabled
+     * admins excluding the target; <= 0 means the target is the last one.
+     */
+    private fun wouldLeaveNoEnabledAdmin(targetId: UUID): Boolean =
+        userRepository.findAll().count { it.role == UserRole.ADMIN && it.enabled && it.id != targetId } == 0
 
     private fun User.toSummary() =
         UserSummary(

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityServiceTest.kt
@@ -129,6 +129,38 @@ class SecurityServiceTest {
     }
 
     @Test
+    fun `setUserRole refuses to demote the last enabled admin`() {
+        // Regression guard for issue #513: demoting the only enabled admin would lock everyone out of
+        // admin endpoints with no recovery short of DB intervention. Actor is a disabled admin (role check
+        // passes on role, not enabled), target is the sole enabled admin.
+        val soleEnabledAdmin = adminUser.copy(id = UUID.randomUUID())
+        val actor = adminUser.copy(id = UUID.randomUUID(), enabled = false)
+        every { userRepository.findById(actor.id) } returns actor
+        every { userRepository.findById(soleEnabledAdmin.id) } returns soleEnabledAdmin
+        every { userRepository.findAll() } returns listOf(soleEnabledAdmin, actor, testUser)
+
+        assertThrows<InsufficientPermissionException> {
+            userAdminService.setUserRole(actor.id, soleEnabledAdmin.id, UserRole.USER)
+        }
+    }
+
+    @Test
+    fun `setUserEnabled refuses to disable the last enabled admin`() {
+        // Actor is a disabled admin (role check passes on role, not enabled), target is the sole enabled
+        // admin. Disabling the target would leave zero enabled admins. Actor != target so the self-check
+        // does not short-circuit; the last-admin guard must fire.
+        val soleEnabledAdmin = adminUser.copy(id = UUID.randomUUID())
+        val actor = adminUser.copy(id = UUID.randomUUID(), enabled = false)
+        every { userRepository.findById(actor.id) } returns actor
+        every { userRepository.findById(soleEnabledAdmin.id) } returns soleEnabledAdmin
+        every { userRepository.findAll() } returns listOf(soleEnabledAdmin, actor, testUser)
+
+        assertThrows<InsufficientPermissionException> {
+            userAdminService.setUserEnabled(actor.id, soleEnabledAdmin.id, false)
+        }
+    }
+
+    @Test
     fun `createApiKey returns key with osk prefix`() {
         val response = apiKeyService.createApiKey(testUser.id, "my-key")
 


### PR DESCRIPTION
Closes #513. `setUserRole` and `setUserEnabled` now refuse actions that would leave zero enabled administrators (unrecoverable lockout). New `wouldLeaveNoEnabledAdmin` guard counts enabled admins excluding the target. 2 new `SecurityServiceTest` cases. Gate green (§425).