### PR TITLE
fix: five sync-engine defects (dirty flag, pull loop, conflict, 401, schema version)

### DIFF
--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/SyncModels.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/SyncModels.kt
@@ -39,15 +39,37 @@ data class SyncPushRequest(val messages: List<SyncMessage> = emptyList()) {
     }
 }
 
-@Serializable data class SyncConflict(val syncId: String, val reason: String, val serverMessage: SyncMessage? = null)
+/**
+ * Wire-format schema version for the sync protocol. Bumped on any breaking change to a sync DTO's field set or
+ * semantics. Clients and servers that disagree on [SCHEMA_VERSION] reject the exchange rather than silently
+ * dropping/misinterpreting fields. See issue #523.
+ */
+const val SYNC_SCHEMA_VERSION: Int = 1
 
-@Serializable data class SyncPushResponse(val appliedCount: Int = 0, val conflicts: List<SyncConflict> = emptyList())
+@Serializable
+data class SyncConflict(
+    val syncId: String,
+    val reason: String,
+    val serverMessage: SyncMessage? = null,
+    // The client's version of the conflicting message, so the UI can show "yours vs theirs" and so the
+    // MINE conflict strategy can recover the local content after sync. Previously absent (issue #521),
+    // leaving resolveConflict(MINE) unable to restore the displaced local edit.
+    val clientMessage: SyncMessage? = null,
+)
+
+@Serializable
+data class SyncPushResponse(
+    val appliedCount: Int = 0,
+    val conflicts: List<SyncConflict> = emptyList(),
+    val schemaVersion: Int = SYNC_SCHEMA_VERSION,
+)
 
 @Serializable
 data class SyncPullResponse(
     val messages: List<SyncMessage> = emptyList(),
     val serverTimestamp: Long = 0,
     val hasMore: Boolean = false,
+    val schemaVersion: Int = SYNC_SCHEMA_VERSION,
 )
 
 data class SyncStats(val pushedCount: Int = 0, val pulledCount: Int = 0, val conflictCount: Int = 0)

--- a/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/client/HttpSyncClient.kt
+++ b/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/client/HttpSyncClient.kt
@@ -1,5 +1,6 @@
 package io.github.rygel.outerstellar.platform.sync.client
 
+import io.github.rygel.outerstellar.platform.model.SessionExpiredException
 import io.github.rygel.outerstellar.platform.model.SyncException
 import io.github.rygel.outerstellar.platform.sync.SyncPullResponse
 import io.github.rygel.outerstellar.platform.sync.SyncPushRequest
@@ -24,6 +25,14 @@ class HttpSyncClient(private val baseUrl: String, private val session: ApiSessio
     override fun pull(since: Long): SyncPullResponse {
         val request = Request(GET, "$baseUrl/api/v1/sync?since=$since")
         val response = authenticated(request)
+        if (response.status == Status.UNAUTHORIZED || response.status == Status.FORBIDDEN) {
+            // A 401/403 means the bearer token is expired/revoked. Throw SessionExpiredException specifically
+            // (not the generic SyncException) so SyncDataModuleImpl.sync()'s SessionExpiredException arm
+            // catches it, clears state, and fires onSessionExpired — otherwise auto-sync loops forever on
+            // the dead token. The two exceptions are siblings (both extend OuterstellarException), so the
+            // generic Exception arm does NOT catch 401 as session-expiry. See issue #522.
+            throw SessionExpiredException("Pull rejected: ${response.status}")
+        }
         if (response.status != Status.OK) {
             throw SyncException("Pull failed: ${response.status}")
         }
@@ -33,6 +42,9 @@ class HttpSyncClient(private val baseUrl: String, private val session: ApiSessio
     override fun push(request: SyncPushRequest): SyncPushResponse {
         val httpRequest = Request(POST, "$baseUrl/api/v1/sync").with(pushRequestLens of request)
         val response = authenticated(httpRequest)
+        if (response.status == Status.UNAUTHORIZED || response.status == Status.FORBIDDEN) {
+            throw SessionExpiredException("Push rejected: ${response.status}")
+        }
         if (response.status != Status.OK) {
             throw SyncException("Push failed: ${response.status}")
         }

--- a/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/engine/module/SyncDataModuleImpl.kt
+++ b/platform-sync-client/src/main/kotlin/io/github/rygel/outerstellar/platform/sync/engine/module/SyncDataModuleImpl.kt
@@ -5,10 +5,12 @@ package io.github.rygel.outerstellar.platform.sync.engine.module
 import io.github.rygel.outerstellar.platform.analytics.AnalyticsService
 import io.github.rygel.outerstellar.platform.model.ConflictStrategy
 import io.github.rygel.outerstellar.platform.model.SessionExpiredException
+import io.github.rygel.outerstellar.platform.model.SyncException
 import io.github.rygel.outerstellar.platform.persistence.MessageRepository
 import io.github.rygel.outerstellar.platform.persistence.TransactionManager
 import io.github.rygel.outerstellar.platform.service.ContactService
 import io.github.rygel.outerstellar.platform.service.MessageService
+import io.github.rygel.outerstellar.platform.sync.SYNC_SCHEMA_VERSION
 import io.github.rygel.outerstellar.platform.sync.SyncPullResponse
 import io.github.rygel.outerstellar.platform.sync.SyncPushRequest
 import io.github.rygel.outerstellar.platform.sync.SyncStats
@@ -22,6 +24,11 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import org.slf4j.LoggerFactory
+
+// Pull-loop safety bounds (issue #520): cap rounds and total items to prevent infinite loops / OOM
+// when the server signals hasMore=true with empty batches or unbounded non-empty batches.
+private const val MAX_PULL_ROUNDS = 100
+private const val MAX_PULL_ITEMS = 50_000
 
 class SyncDataModuleImpl(
     private val syncClient: SyncClient,
@@ -120,9 +127,29 @@ class SyncDataModuleImpl(
         var pullHasMore = true
         var pullSince = lastSync
         var latestTimestamp = 0L
+        var pullRounds = 0
 
         while (pullHasMore) {
+            // Guards against infinite loops and unbounded memory (issue #520): cap the number of pull
+            // rounds and the total items, and treat hasMore=true with an empty batch as a protocol error
+            // (the cursor wouldn't advance, so the loop would spin on the same response forever).
+            if (++pullRounds > MAX_PULL_ROUNDS) {
+                throw SyncException("Pull exceeded $MAX_PULL_ROUNDS rounds; aborting to avoid runaway sync")
+            }
+            if (allPulled.size > MAX_PULL_ITEMS) {
+                throw SyncException("Pull exceeded $MAX_PULL_ITEMS items; aborting to avoid runaway sync")
+            }
             val pullBody: SyncPullResponse = syncClient.pull(pullSince)
+            // Reject a server speaking an incompatible wire-format schema rather than silently dropping
+            // or misinterpreting fields (issue #523).
+            if (pullBody.schemaVersion != SYNC_SCHEMA_VERSION) {
+                throw SyncException(
+                    "Server sync schema version ${pullBody.schemaVersion} is incompatible with client version $SYNC_SCHEMA_VERSION"
+                )
+            }
+            if (pullBody.hasMore && pullBody.messages.isEmpty()) {
+                throw SyncException("Server signalled hasMore=true with an empty batch; cursor would not advance")
+            }
             allPulled.addAll(pullBody.messages)
             pullHasMore = pullBody.hasMore
             latestTimestamp = pullBody.serverTimestamp
@@ -139,7 +166,16 @@ class SyncDataModuleImpl(
         transactionManager.inTransaction {
             allPulled.forEach { repository.upsertSyncedMessage(it, false) }
             pushBody.conflicts.forEach { conflict ->
-                conflict.serverMessage?.let { repository.upsertSyncedMessage(it, false) }
+                // Do NOT auto-overwrite the local row with the server message (issue #521): that destroyed
+                // the local edit and made resolveConflict(MINE) unable to recover it. Instead mark the
+                // conflict, preserving both versions so the UI can surface it and resolveConflict can act.
+                conflict.serverMessage?.let { repository.markConflict(conflict.syncId, it) }
+            }
+            // Clear the dirty flag on the locally-originated messages that were just pushed (issue #519).
+            // Without this, listDirtyMessages returns the same set on the next sync and re-pushes them
+            // every cycle. markClean takes the sync IDs of the pushed messages.
+            if (dirtyMessages.isNotEmpty()) {
+                repository.markClean(dirtyMessages.map { it.syncId })
             }
             repository.setLastSyncEpochMs(latestTimestamp)
         }


### PR DESCRIPTION
Closes #519, #520, #521, #522, #523. See commit message for per-issue detail. Gate green (§425): install + full verify, **1311 tests, 0 failures**.