### PR TITLE
fix(security): hash tokens with HMAC-SHA256 keyed by a deployment pepper

### DIFF
--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/AppConfig.kt
@@ -8,6 +8,7 @@ import org.snakeyaml.engine.v2.api.LoadSettings
 private const val DEFAULT_HTTP_PORT = 8080
 private const val DEFAULT_SMTP_PORT = 587
 private const val DEFAULT_SESSION_TIMEOUT_MINUTES = 30
+private const val DEFAULT_TOKEN_PEPPER = "outerstellar-dev-token-pepper"
 private const val MIN_SESSION_TIMEOUT_MINUTES = 1
 private const val DEFAULT_JWT_EXPIRY_SECONDS = 86400L
 private const val MAX_HTTP_PORT = 65535
@@ -115,6 +116,7 @@ data class AppConfig(
     val devMode: Boolean = false,
     val sessionCookieSecure: Boolean = true,
     val sessionTimeoutMinutes: Int = DEFAULT_SESSION_TIMEOUT_MINUTES,
+    val tokenPepper: String = DEFAULT_TOKEN_PEPPER,
     val corsOrigins: String = "",
     val csrfEnabled: Boolean = true,
     val segment: SegmentConfig = SegmentConfig(),
@@ -144,7 +146,7 @@ data class AppConfig(
     override fun toString(): String =
         "AppConfig(version=$version, port=$port, jdbcUrl=$jdbcUrl, jdbcUser=$jdbcUser, jdbcPassword=${mask(jdbcPassword)}, " +
             "profile=$profile, devDashboardEnabled=$devDashboardEnabled, devMode=$devMode, sessionCookieSecure=$sessionCookieSecure, " +
-            "sessionTimeoutMinutes=$sessionTimeoutMinutes, corsOrigins=$corsOrigins, csrfEnabled=$csrfEnabled, segment=$segment, " +
+            "sessionTimeoutMinutes=$sessionTimeoutMinutes, tokenPepper=${mask(tokenPepper)}, corsOrigins=$corsOrigins, csrfEnabled=$csrfEnabled, segment=$segment, " +
             "email=$email, appBaseUrl=$appBaseUrl, maxFailedLoginAttempts=$maxFailedLoginAttempts, maxRequestBodyBytes=$maxRequestBodyBytes, " +
             "lockoutDurationSeconds=$lockoutDurationSeconds, registrationEnabled=$registrationEnabled, " +
             "sessionAbsoluteTimeoutMinutes=$sessionAbsoluteTimeoutMinutes, jwt=$jwt, cspPolicy=$cspPolicy, staticDir=$staticDir, " +
@@ -212,6 +214,7 @@ data class AppConfig(
                 devMode = yaml.bool("devMode", env, "DEVMODE", false),
                 sessionCookieSecure = yaml.bool("sessionCookieSecure", env, "SESSIONCOOKIESECURE", true),
                 sessionTimeoutMinutes = timeout,
+                tokenPepper = yaml.str("tokenPepper", env, "TOKEN_PEPPER", DEFAULT_TOKEN_PEPPER),
                 corsOrigins = yaml.str("corsOrigins", env, "CORSORIGINS", ""),
                 csrfEnabled = yaml.bool("csrfEnabled", env, "CSRFENABLED", true),
                 segment = buildSegmentConfig(yaml["segment"] as? Map<String, Any>, env),

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/security/TokenHashing.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/security/TokenHashing.kt
@@ -1,10 +1,35 @@
 package io.github.rygel.outerstellar.platform.security
 
-import java.security.MessageDigest
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
-object TokenHashing {
+/**
+ * Hashes opaque high-entropy tokens (session tokens, API keys, password-reset tokens) for at-rest storage and indexed
+ * lookup using HMAC-SHA256 keyed by a deployment-specific [pepper].
+ *
+ * The pepper means a DB-read attacker cannot use the stored hashes directly (they'd also need the pepper, which lives
+ * in config/env, not the DB), and the signing key can be rotated by changing the pepper. HMAC is the correct
+ * construction for this — unlike the previous un-keyed SHA-256, the hash is not computable from the token alone.
+ *
+ * The hash is deterministic for a given pepper+token (so it remains a usable DB index), but not without the pepper.
+ * Tokens are high-entropy, so brute-force of the token from a known pepper+hash is infeasible.
+ *
+ * @param pepper a deployment-specific secret key. Must be non-blank in non-dev profiles; a fixed default is used only
+ *   so dev/test boots without configuration.
+ */
+class TokenHashing(pepper: String) {
+    private val key = SecretKeySpec(pepper.toByteArray(Charsets.UTF_8), "HmacSHA256")
+
     fun hash(token: String): String {
-        val digest = MessageDigest.getInstance("SHA-256")
-        return digest.digest(token.toByteArray()).joinToString("") { "%02x".format(it) }
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(key)
+        val raw = mac.doFinal(token.toByteArray(Charsets.UTF_8))
+        return Base64.getEncoder().encodeToString(raw)
+    }
+
+    companion object {
+        /** Default pepper used only when none is configured (dev/test). Never use in production. */
+        const val DEFAULT_PEPPER: String = "outerstellar-dev-token-pepper"
     }
 }

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiApiKeyRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiApiKeyRepositoryTest.kt
@@ -11,6 +11,8 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+private val tokenHashing = TokenHashing(TokenHashing.DEFAULT_PEPPER)
+
 class JdbiApiKeyRepositoryTest : JdbiTest() {
 
     private val repo by lazy { JdbiApiKeyRepository(jdbi) }
@@ -18,7 +20,7 @@ class JdbiApiKeyRepositoryTest : JdbiTest() {
     private fun apiKey(userId: UUID, name: String = "My Key") =
         ApiKey(
             userId = userId,
-            keyHash = TokenHashing.hash("raw-key-${UUID.randomUUID()}"),
+            keyHash = tokenHashing.hash("raw-key-${UUID.randomUUID()}"),
             keyPrefix = "sk_test",
             name = name,
             enabled = true,
@@ -29,7 +31,7 @@ class JdbiApiKeyRepositoryTest : JdbiTest() {
     fun `save and findByKeyHash round-trips`() {
         val userId = createUser()
         val rawKey = "raw-test-key"
-        val hash = TokenHashing.hash(rawKey)
+        val hash = tokenHashing.hash(rawKey)
         val key =
             ApiKey(
                 userId = userId,
@@ -108,11 +110,11 @@ class JdbiApiKeyRepositoryTest : JdbiTest() {
     }
 
     @Test
-    fun `TokenHashing produces consistent SHA-256 hex`() {
-        val hash1 = TokenHashing.hash("test-key")
-        val hash2 = TokenHashing.hash("test-key")
+    fun `TokenHashing produces consistent HMAC-SHA256`() {
+        val hash1 = tokenHashing.hash("test-key")
+        val hash2 = tokenHashing.hash("test-key")
         assertEquals(hash1, hash2)
-        assertEquals(64, hash1.length) // SHA-256 = 32 bytes = 64 hex chars
+        assertEquals(44, hash1.length) // HMAC-SHA256 = 32 bytes = 44 Base64 chars
         assertFalse(hash1.contains("test-key"))
     }
 }

--- a/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiSessionRepositoryTest.kt
+++ b/platform-persistence-jdbi/src/test/kotlin/io/github/rygel/outerstellar/platform/persistence/JdbiSessionRepositoryTest.kt
@@ -11,6 +11,8 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+private val tokenHashing = TokenHashing(TokenHashing.DEFAULT_PEPPER)
+
 class JdbiSessionRepositoryTest : JdbiTest() {
 
     private val repo by lazy { JdbiSessionRepository(jdbi) }
@@ -19,7 +21,7 @@ class JdbiSessionRepositoryTest : JdbiTest() {
     fun `save and findByTokenHash round-trips`() {
         val userId = createUser()
         val rawToken = "oss_test_token_${UUID.randomUUID()}"
-        val tokenHash = TokenHashing.hash(rawToken)
+        val tokenHash = tokenHashing.hash(rawToken)
         val session =
             Session(tokenHash = tokenHash, userId = userId, expiresAt = Instant.now().plus(30, ChronoUnit.MINUTES))
         repo.save(session)
@@ -37,7 +39,7 @@ class JdbiSessionRepositoryTest : JdbiTest() {
     @Test
     fun `findByTokenHash returns null for expired session`() {
         val userId = createUser()
-        val tokenHash = TokenHashing.hash("expired_token")
+        val tokenHash = tokenHashing.hash("expired_token")
         val session =
             Session(tokenHash = tokenHash, userId = userId, expiresAt = Instant.now().minus(1, ChronoUnit.HOURS))
         repo.save(session)
@@ -47,7 +49,7 @@ class JdbiSessionRepositoryTest : JdbiTest() {
     @Test
     fun `updateExpiresAt extends session`() {
         val userId = createUser()
-        val tokenHash = TokenHashing.hash("extend_token")
+        val tokenHash = tokenHashing.hash("extend_token")
         val session =
             Session(tokenHash = tokenHash, userId = userId, expiresAt = Instant.now().plus(5, ChronoUnit.MINUTES))
         repo.save(session)
@@ -62,7 +64,7 @@ class JdbiSessionRepositoryTest : JdbiTest() {
     @Test
     fun `deleteByTokenHash removes session`() {
         val userId = createUser()
-        val tokenHash = TokenHashing.hash("delete_token")
+        val tokenHash = tokenHashing.hash("delete_token")
         val session =
             Session(tokenHash = tokenHash, userId = userId, expiresAt = Instant.now().plus(30, ChronoUnit.MINUTES))
         repo.save(session)
@@ -73,8 +75,8 @@ class JdbiSessionRepositoryTest : JdbiTest() {
     @Test
     fun `deleteByUserId removes all sessions for user`() {
         val userId = createUser()
-        val hash1 = TokenHashing.hash("token1")
-        val hash2 = TokenHashing.hash("token2")
+        val hash1 = tokenHashing.hash("token1")
+        val hash2 = tokenHashing.hash("token2")
         repo.save(Session(tokenHash = hash1, userId = userId, expiresAt = Instant.now().plus(30, ChronoUnit.MINUTES)))
         repo.save(Session(tokenHash = hash2, userId = userId, expiresAt = Instant.now().plus(30, ChronoUnit.MINUTES)))
         repo.deleteByUserId(userId)
@@ -85,8 +87,8 @@ class JdbiSessionRepositoryTest : JdbiTest() {
     @Test
     fun `deleteExpired removes only expired sessions`() {
         val userId = createUser()
-        val expiredHash = TokenHashing.hash("expired")
-        val activeHash = TokenHashing.hash("active")
+        val expiredHash = tokenHashing.hash("expired")
+        val activeHash = tokenHashing.hash("active")
         repo.save(
             Session(tokenHash = expiredHash, userId = userId, expiresAt = Instant.now().minus(1, ChronoUnit.HOURS))
         )

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/ApiKeyService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/ApiKeyService.kt
@@ -14,6 +14,7 @@ class ApiKeyService(
     private val userRepository: UserRepository,
     private val apiKeyRepository: ApiKeyRepository,
     private val auditRepository: AuditRepository? = null,
+    private val tokenHashing: TokenHashing = TokenHashing(TokenHashing.DEFAULT_PEPPER),
 ) {
     private val logger = LoggerFactory.getLogger(ApiKeyService::class.java)
     private val secureRandom = java.security.SecureRandom()
@@ -22,7 +23,7 @@ class ApiKeyService(
         require(name.isNotBlank()) { "API key name is required" }
         val rawKey = "osk_" + generateRandomHex(API_KEY_HEX_LENGTH)
         val keyPrefix = rawKey.take(API_KEY_PREFIX_LENGTH)
-        val keyHash = TokenHashing.hash(rawKey)
+        val keyHash = tokenHashing.hash(rawKey)
 
         val apiKey = ApiKey(userId = userId, keyHash = keyHash, keyPrefix = keyPrefix, name = name)
         apiKeyRepository.save(apiKey)
@@ -33,7 +34,7 @@ class ApiKeyService(
     }
 
     fun authenticateApiKey(rawKey: String): User? {
-        val keyHash = TokenHashing.hash(rawKey)
+        val keyHash = tokenHashing.hash(rawKey)
         val apiKey = apiKeyRepository.findByKeyHash(keyHash) ?: return null
         if (!apiKey.enabled) return null
 

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/PasswordResetService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/PasswordResetService.kt
@@ -20,6 +20,7 @@ class PasswordResetService(
     private val sessionRepository: SessionRepository? = null,
     private val emailService: EmailService,
     private val appBaseUrl: String = io.github.rygel.outerstellar.platform.AppConfig.DEFAULT_APP_BASE_URL,
+    private val tokenHashing: TokenHashing = TokenHashing(TokenHashing.DEFAULT_PEPPER),
 ) {
     private val logger = LoggerFactory.getLogger(PasswordResetService::class.java)
 
@@ -38,7 +39,7 @@ class PasswordResetService(
         val resetToken =
             PasswordResetToken(
                 userId = user.id,
-                token = TokenHashing.hash(tokenValue),
+                token = tokenHashing.hash(tokenValue),
                 expiresAt = Instant.now().plusSeconds(RESET_TOKEN_TTL_SECONDS),
             )
         resetRepository?.save(resetToken)
@@ -60,7 +61,7 @@ class PasswordResetService(
         // with the same token cannot both pass the guard (only one UPDATE matches). Replaces the old
         // findByToken + Java used/expiry check + markUsed which ran in separate transactions (TOCTOU).
         val userId =
-            repository.claimToken(TokenHashing.hash(token)) ?: throw IllegalArgumentException("Invalid reset token")
+            repository.claimToken(tokenHashing.hash(token)) ?: throw IllegalArgumentException("Invalid reset token")
 
         val normalized = newPassword.trim()
         validatePassword(normalized)?.let { throw WeakPasswordException(it) }

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
@@ -50,6 +50,7 @@ fun createSecurityComponents(
         sessionRepository = sessionRepository,
     )
 
+@Suppress("LongMethod")
 fun createSecurityComponents(
     config: AppConfig,
     userRepository: UserRepository,
@@ -61,6 +62,7 @@ fun createSecurityComponents(
     sessionRepository: SessionRepository? = null,
 ): SecurityComponents {
     val passwordEncoder = BCryptPasswordEncoder()
+    val tokenHashing = TokenHashing(config.tokenPepper)
     val jwtService = JwtService(config.jwt)
     val asyncActivityUpdater = AsyncActivityUpdater(userRepository)
     val securityConfig =
@@ -79,6 +81,7 @@ fun createSecurityComponents(
             userRepository = userRepository,
             config = securityConfig,
             activityUpdater = asyncActivityUpdater,
+            tokenHashing = tokenHashing,
         )
     val userAdminService = UserAdminService(userRepository, auditRepository ?: error("AuditRepository required"))
     val authService =
@@ -103,6 +106,7 @@ fun createSecurityComponents(
             userRepository = userRepository,
             apiKeyRepository = apiKeyRepository ?: error("ApiKeyRepository required for ApiKeyService"),
             auditRepository = auditRepository,
+            tokenHashing = tokenHashing,
         )
     val passwordResetService =
         PasswordResetService(
@@ -113,6 +117,7 @@ fun createSecurityComponents(
             sessionRepository = sessionRepository,
             emailService = emailService,
             appBaseUrl = config.appBaseUrl,
+            tokenHashing = tokenHashing,
         )
     val oauthService =
         OAuthService(

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SessionService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SessionService.kt
@@ -14,13 +14,14 @@ class SessionService(
     private val userRepository: UserRepository,
     private val config: SecurityConfig,
     private val activityUpdater: AsyncActivityUpdater? = null,
+    private val tokenHashing: TokenHashing = TokenHashing(TokenHashing.DEFAULT_PEPPER),
 ) {
     private val logger = LoggerFactory.getLogger(SessionService::class.java)
     private val secureRandom = SecureRandom()
 
     fun createSession(userId: UUID): String {
         val rawToken = "oss_" + generateRandomHex(SESSION_TOKEN_HEX_LENGTH)
-        val tokenHash = TokenHashing.hash(rawToken)
+        val tokenHash = tokenHashing.hash(rawToken)
         val session =
             Session(
                 tokenHash = tokenHash,
@@ -33,7 +34,7 @@ class SessionService(
     }
 
     fun lookupSession(rawToken: String): SessionLookup {
-        val tokenHash = TokenHashing.hash(rawToken)
+        val tokenHash = tokenHashing.hash(rawToken)
         val activeSession = sessionRepository.findByTokenHash(tokenHash)
         if (activeSession != null) {
             val absoluteDeadline = activeSession.createdAt.plusSeconds(config.sessionAbsoluteTimeoutSeconds)
@@ -57,7 +58,7 @@ class SessionService(
     }
 
     fun deleteSession(rawToken: String) {
-        sessionRepository.deleteByTokenHash(TokenHashing.hash(rawToken))
+        sessionRepository.deleteByTokenHash(tokenHashing.hash(rawToken))
     }
 
     private fun generateRandomHex(length: Int): String {

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/SecurityServiceTest.kt
@@ -178,8 +178,7 @@ class SecurityServiceTest {
     @Test
     fun `authenticateApiKey returns user for valid key`() {
         val rawKey = "osk_abcdef1234567890abcdef1234567890"
-        val digest = java.security.MessageDigest.getInstance("SHA-256")
-        val expectedHash = digest.digest(rawKey.toByteArray()).joinToString("") { "%02x".format(it) }
+        val expectedHash = TokenHashing(TokenHashing.DEFAULT_PEPPER).hash(rawKey)
 
         val apiKey =
             ApiKey(id = 1L, userId = testUser.id, keyHash = expectedHash, keyPrefix = "osk_abcd", name = "test-key")
@@ -197,8 +196,7 @@ class SecurityServiceTest {
     @Test
     fun `authenticateApiKey returns null for disabled key`() {
         val rawKey = "osk_abcdef1234567890abcdef1234567890"
-        val digest = java.security.MessageDigest.getInstance("SHA-256")
-        val expectedHash = digest.digest(rawKey.toByteArray()).joinToString("") { "%02x".format(it) }
+        val expectedHash = TokenHashing(TokenHashing.DEFAULT_PEPPER).hash(rawKey)
 
         val disabledKey =
             ApiKey(
@@ -220,8 +218,7 @@ class SecurityServiceTest {
     @Test
     fun `authenticateApiKey returns null for disabled user`() {
         val rawKey = "osk_abcdef1234567890abcdef1234567890"
-        val digest = java.security.MessageDigest.getInstance("SHA-256")
-        val expectedHash = digest.digest(rawKey.toByteArray()).joinToString("") { "%02x".format(it) }
+        val expectedHash = TokenHashing(TokenHashing.DEFAULT_PEPPER).hash(rawKey)
 
         val apiKey =
             ApiKey(id = 3L, userId = testUser.id, keyHash = expectedHash, keyPrefix = "osk_abcd", name = "test-key")

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PasswordResetFlowIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PasswordResetFlowIntegrationTest.kt
@@ -148,7 +148,7 @@ class PasswordResetFlowIntegrationTest : WebTest() {
                 .first()
 
         assertNotEquals(rawToken, storedToken, "Raw reset token must not be stored")
-        assertTrue(storedToken.matches(Regex("[0-9a-f]{64}")), "Stored reset token should be a SHA-256 hex hash")
+        assertTrue(storedToken.length == 44, "Stored reset token should be an HMAC-SHA256 Base64 hash (44 chars)")
     }
 
     @Test


### PR DESCRIPTION
Audit M4 (full): `TokenHashing` converted from un-keyed SHA-256 to HMAC-SHA256 keyed by a configurable `tokenPepper` (env `TOKEN_PEPPER`, YAML `tokenPepper`, masked in `toString()`). A DB-read attacker can no longer use stored hashes directly, and the pepper is rotatable. Injected via `SecurityComponents` into SessionService/ApiKeyService/PasswordResetService. Dead `hashKey` duplicate deleted. No migration (no users). Gate green (§425).