### PR TITLE
fix: wrap TOTP/OAuth writes in transactions + fix cache invalidation on lockout

### DIFF
--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AuthService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AuthService.kt
@@ -9,6 +9,7 @@ import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.model.UsernameAlreadyExistsException
 import io.github.rygel.outerstellar.platform.model.WeakPasswordException
 import io.github.rygel.outerstellar.platform.persistence.AuditRepository
+import io.github.rygel.outerstellar.platform.persistence.TransactionManager
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import java.security.SecureRandom
 import java.time.Instant
@@ -24,6 +25,7 @@ class AuthService(
     private val auditRepository: AuditRepository? = null,
     private val config: SecurityConfig = SecurityConfig(),
     private val totpService: TOTPService,
+    private val transactionManager: TransactionManager? = null,
 ) {
     private val logger = LoggerFactory.getLogger(AuthService::class.java)
     private val secureRandom = SecureRandom()
@@ -157,13 +159,27 @@ class AuthService(
     }
 
     fun enableTotp(userId: UUID, secret: String, backupCodes: String) {
-        userRepository.updateTotpSecret(userId, secret, backupCodes)
-        userRepository.enableTotp(userId)
+        // Both writes must be atomic — a partial failure leaves 2FA in an inconsistent state
+        // (secret stored but not enabled, or enabled with no secret).
+        transactionManager?.inTransaction {
+            userRepository.updateTotpSecret(userId, secret, backupCodes)
+            userRepository.enableTotp(userId)
+        }
+            ?: run {
+                userRepository.updateTotpSecret(userId, secret, backupCodes)
+                userRepository.enableTotp(userId)
+            }
     }
 
     fun disableTotp(userId: UUID) {
-        userRepository.updateTotpSecret(userId, null, null)
-        userRepository.disableTotp(userId)
+        transactionManager?.inTransaction {
+            userRepository.updateTotpSecret(userId, null, null)
+            userRepository.disableTotp(userId)
+        }
+            ?: run {
+                userRepository.updateTotpSecret(userId, null, null)
+                userRepository.disableTotp(userId)
+            }
     }
 
     private fun generatePartialAuthToken(userId: UUID): String {

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/CachingUserRepository.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/CachingUserRepository.kt
@@ -89,4 +89,33 @@ class CachingUserRepository(private val delegate: UserRepository, maximumSize: L
         delegate.disableTotp(userId)
         cache.invalidate(userId)
     }
+
+    // --- Lockout / failed-attempt methods: must invalidate cache so security-critical state
+    // (lockedUntil, failedLoginAttempts, failedTotpAttempts) isn't served stale for up to 60s.
+    // Without these overrides, a locked account's stale cached User still has lockedUntil=null.
+
+    override fun incrementFailedLoginAttempts(userId: UUID): Int {
+        cache.invalidate(userId)
+        return delegate.incrementFailedLoginAttempts(userId)
+    }
+
+    override fun resetFailedLoginAttempts(userId: UUID) {
+        cache.invalidate(userId)
+        delegate.resetFailedLoginAttempts(userId)
+    }
+
+    override fun incrementFailedTotpAttempts(userId: UUID): Int {
+        cache.invalidate(userId)
+        return delegate.incrementFailedTotpAttempts(userId)
+    }
+
+    override fun resetFailedTotpAttempts(userId: UUID) {
+        cache.invalidate(userId)
+        delegate.resetFailedTotpAttempts(userId)
+    }
+
+    override fun updateLockedUntil(userId: UUID, lockedUntil: java.time.Instant?) {
+        cache.invalidate(userId)
+        delegate.updateLockedUntil(userId, lockedUntil)
+    }
 }

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/OAuthService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/OAuthService.kt
@@ -5,6 +5,7 @@ import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.persistence.AuditRepository
 import io.github.rygel.outerstellar.platform.persistence.OAuthConnection
 import io.github.rygel.outerstellar.platform.persistence.OAuthRepository
+import io.github.rygel.outerstellar.platform.persistence.TransactionManager
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import java.util.UUID
 import org.slf4j.LoggerFactory
@@ -14,6 +15,7 @@ class OAuthService(
     private val passwordEncoder: PasswordEncoder,
     private val oauthRepository: OAuthRepository? = null,
     private val auditRepository: AuditRepository? = null,
+    private val transactionManager: TransactionManager? = null,
 ) {
     private val logger = LoggerFactory.getLogger(OAuthService::class.java)
 
@@ -45,11 +47,32 @@ class OAuthService(
                 passwordHash = passwordEncoder.encode(UUID.randomUUID().toString()),
                 role = UserRole.USER,
             )
-        userRepository.save(user)
-
-        repo.save(
-            OAuthConnection(id = 0L, userId = user.id, provider = providerName, subject = oauthSubject, email = email)
-        )
+        // Both writes must be atomic — a failure between save(user) and save(connection) leaves an
+        // orphaned User with no OAuth linkage, permanently locking the user out of OAuth login.
+        transactionManager?.inTransaction {
+            userRepository.save(user)
+            repo.save(
+                OAuthConnection(
+                    id = 0L,
+                    userId = user.id,
+                    provider = providerName,
+                    subject = oauthSubject,
+                    email = email,
+                )
+            )
+        }
+            ?: run {
+                userRepository.save(user)
+                repo.save(
+                    OAuthConnection(
+                        id = 0L,
+                        userId = user.id,
+                        provider = providerName,
+                        subject = oauthSubject,
+                        email = email,
+                    )
+                )
+            }
         logger.info("Created new user {} via OAuth provider {}", sanitize(username), providerName)
         auditRepository?.logAction("OAUTH_USER_CREATED", actor = user, detail = "provider=$providerName")
         return user

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/SecurityComponents.kt
@@ -6,6 +6,7 @@ import io.github.rygel.outerstellar.platform.persistence.AuditRepository
 import io.github.rygel.outerstellar.platform.persistence.OAuthRepository
 import io.github.rygel.outerstellar.platform.persistence.PasswordResetRepository
 import io.github.rygel.outerstellar.platform.persistence.SessionRepository
+import io.github.rygel.outerstellar.platform.persistence.TransactionManager
 import io.github.rygel.outerstellar.platform.persistence.UserRepository
 import io.github.rygel.outerstellar.platform.service.EmailService
 import io.github.rygel.outerstellar.platform.service.NoOpEmailService
@@ -59,6 +60,7 @@ fun createSecurityComponents(
     emailService: EmailService,
     oauthRepository: OAuthRepository? = null,
     sessionRepository: SessionRepository? = null,
+    transactionManager: TransactionManager? = null,
 ): SecurityComponents {
     val passwordEncoder = BCryptPasswordEncoder()
     val jwtService = JwtService(config.jwt)
@@ -88,6 +90,7 @@ fun createSecurityComponents(
             auditRepository = auditRepository,
             config = securityConfig,
             totpService = totpService,
+            transactionManager = transactionManager,
         )
 
     val accountService =
@@ -120,6 +123,7 @@ fun createSecurityComponents(
             passwordEncoder = passwordEncoder,
             oauthRepository = oauthRepository,
             auditRepository = auditRepository,
+            transactionManager = transactionManager,
         )
     val permissionResolver = RoleBasedPermissionResolver()
     val authRealms = listOf(SessionRealm(sessionService), ApiKeyRealm(apiKeyService))

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/ServerComponents.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/ServerComponents.kt
@@ -54,6 +54,7 @@ fun createServerComponents(config: AppConfig, extension: PlatformExtension? = nu
             emailService = emailService,
             oauthRepository = persistence.oAuthRepository,
             sessionRepository = persistence.sessionRepository,
+            transactionManager = persistence.transactionManager,
         )
     val syncWebSocket = SyncWebSocket(security.sessionService)
 


### PR DESCRIPTION
Audit C1 (TOTP enable/disable non-transactional → wrapped), C2 (OAuth user+connection non-transactional → wrapped), H1 (CachingUserRepository missing 5 cache-invalidation overrides for lockout/failed-attempt methods → added). TransactionManager threaded through createSecurityComponents. Gate green (§425).