### PR TITLE
fix: validate registration input, stop error-page leak, surface email drops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,6 +466,32 @@ Key rules:
 - Never push directly to `develop` or `main`. Always create feature branches and PRs.
 - Run full reactor `mvn verify` locally before pushing to CI. CI round-trips waste time.
 - Desktop/Swing tests must NEVER run directly on the host machine. Always use the Podman container.
+- **Kill stale Java processes between builds.** Each `mvn verify` forks surefire and SpotBugs JVMs that
+  consume hundreds of MB. If you run multiple builds in sequence without cleaning up, the processes
+  accumulate and cause OOM crashes (SpotBugs `malloc failed`, surefire `forked VM terminated`). Before
+  each build, kill stale Java processes:
+  ```powershell
+  Get-Process java -ErrorAction SilentlyContinue | Stop-Process -Force
+  ```
+  Alternatively, use `-T1` (sequential build) instead of `-T4` when running many builds in a session —
+  it avoids the parallel-fork explosion entirely at the cost of ~2x build time.
+
+### Always run tests before pushing — no exceptions
+
+Skipping `-Dspotbugs.skip=true` locally to work around OOM does NOT skip surefire tests, but it
+**masks test failures** that CI will catch, wasting a full CI round-trip (10+ minutes). The
+discipline is:
+
+1. After any code change that touches a service, route, or model, run the **affected module's tests**
+   specifically before attempting a full reactor verify:
+   ```powershell
+   mvn -pl platform-security test -Dtest='AuthServiceTest'
+   ```
+2. Only push when the full reactor verify (step 2 of the commit gate) passes locally. If OOM prevents
+   the full verify from completing, kill stale processes, reduce to `-T1`, and retry — never push with
+   an incomplete verify.
+3. A 30-second module-level test run catches broken test fixtures (wrong usernames, changed APIs)
+   before they waste a 10-minute CI cycle.
 
 ## Branch hygiene
 

--- a/docs/superpowers/specs/2026-06-20-theme-extension-spi-design.md
+++ b/docs/superpowers/specs/2026-06-20-theme-extension-spi-design.md
@@ -1,0 +1,191 @@
+# Theme Extension SPI Design
+
+**Date:** 2026-06-20
+**Status:** Draft
+**Approach:** Theme registry + contributed CSS file (Approach 1)
+
+## Motivation
+
+Extensions (plugins) need the ability to contribute custom themes to the platform's
+theme picker. Currently `ThemeCatalog` is a closed singleton listing only hardcoded
+DaisyUI built-in theme IDs — there is no extension point and no way for a plugin
+to add a custom branded theme. The CSS infrastructure already supports it: DaisyUI
+themes are applied via `data-theme` on `<html>`, and extensions can already inject
+stylesheets via the existing `assets.stylesheet()` mechanism. The gap is purely in
+the catalog, validation, and picker wiring.
+
+## Design
+
+### Extension API Surface
+
+A new `ExtensionThemeContributionRegistry` in platform-extension-api, registered
+alongside the existing 10 registries in `ExtensionContributionContext`. Its API:
+
+```kotlin
+class ExtensionThemeContributionRegistry internal constructor() {
+    private val themes = mutableListOf<ExtensionTheme>()
+
+    fun theme(id: String, label: String, stylesheet: String) {
+        require(id.isNotBlank()) { "Theme id must not be blank" }
+        require(label.isNotBlank()) { "Theme label must not be blank" }
+        require(themes.none { it.id == id }) { "Duplicate theme id within extension: $id" }
+        themes += ExtensionTheme(id = id, label = label, stylesheet = stylesheet)
+    }
+
+    internal fun snapshot(): List<ExtensionTheme> = themes.toList()
+}
+```
+
+The `ExtensionTheme` DTO lives in platform-extension-api:
+
+```kotlin
+data class ExtensionTheme(
+    val id: String,
+    val label: String,
+    val stylesheet: String,
+)
+```
+
+The stylesheet URL is included in the registration to make it atomic — a plugin
+cannot register a theme without its CSS, removing the "forgot the stylesheet" footgun.
+The URL must be owned by the extension (validated against its `assetPrefixes` at
+composition time, consistent with `ExtensionContribution.kt:146-150`).
+
+#### Usage from an extension
+
+```kotlin
+class MyExtension : PlatformExtension {
+    override val id = "myext"
+
+    override fun contribute(context: ExtensionContributionContext) {
+        // Serve the theme CSS
+        context.routes.staticAssets(
+            "/extensions/myext/assets",
+            ResourceLoader.Classpath("myext-static"),
+            "MyExt static assets",
+        )
+        // Register the custom theme (atomic with its CSS)
+        context.themes.theme("mybrand", "My Brand", "/extensions/myext/assets/theme.css")
+    }
+}
+```
+
+### Runtime Catalog Composition
+
+`ThemeCatalog` stays unchanged (it is shared with the desktop `ThemeManager`).
+A composed view is built in platform-web:
+
+- `ExtensionContribution` gains a `themes: List<ExtensionTheme>` field, collected
+  from the registry snapshot in `ExtensionContribution.from()`.
+- `ShellConfig` carries `contributedThemes: List<ExtensionTheme>` (alongside existing
+  `extensionOptions`).
+- At composition time in `App.kt`, a merged valid-theme-ids set is computed:
+  `ThemeCatalog.allThemeIds().toSet() + contributedThemes.map { it.id }`.
+- This set is threaded through `ShellConfig` to:
+
+| Call site | File:Line | Change |
+|---|---|---|
+| RequestContext.theme | `RequestContext.kt:66-69` | `isValidTheme` checks merged set |
+| Cookie validator | `Filters.kt:375-378` | `preferenceCookie` predicate checks merged set |
+| Picker options | `SidebarFactory.kt:38` | `allThemes()` → composed list (built-in + contributed mapped to ThemeOption) |
+
+The picker appends contributed themes after the built-in section, optionally
+separated by an `<optgroup>` or disabled separator. For v1, a simple flat list
+with contributed themes at the bottom is sufficient.
+
+### CSS Delivery
+
+The contributed theme's stylesheet is collected at composition time (from all
+registered `ExtensionTheme.stylesheet` URLs) and passed into the existing
+`extensionStylesheets` → `LayoutHead.kte:32` `<link>` path. This means:
+
+- The theme CSS loads site-wide for every page request (matching existing
+  extension-stylesheet behavior).
+- DaisyUI's `data-theme="mybrand"` on `<html>` activates the rules in that
+  stylesheet — no new CSS mechanism needed.
+- CSP already allows `style-src 'self' 'unsafe-inline'`, so DaisyUI's
+  CSS-variable approach works without changes.
+- Per-theme lazy loading is deferred as a later optimization.
+
+### Conflict and Error Handling
+
+#### Startup Conflict Detection (fail-loud)
+
+At composition time (`ExtensionContribution.from()` or `ShellConfig.from()`),
+a unified check runs:
+
+```
+contributed theme id + built-in id
+```
+
+If any contributed id collides with a DaisyUI built-in or with another extension's
+theme id, composition fails with a clear error identifying the conflicting extension
+and id. This matches the existing route-ownership validation pattern in
+`ExtensionContribution.kt:127-151`.
+
+**Design choice: flat namespace.** Theme ids are just strings (no `pluginId:` prefix).
+The CSS author writes `[data-theme="mybrand"]` — the same value used in `data-theme`
+on `<html>`. Simpler for plugin authors. Namespace separation is achieved through
+startup conflict detection, not prefixes.
+
+#### Input Validation
+
+- Blank id or label → `require()` failure at registration time.
+- Malformed stylesheet URL → caught by the existing `requirePathOwnedByManifest`
+  ownership check at composition time.
+
+#### Runtime Fallback (intentional, documented)
+
+If a user's saved theme id (from `plt_users.theme VARCHAR(50)`) is no longer valid
+— e.g., the plugin was removed — the existing fallback in `RequestContext.kt:68`
+catches it and returns `"dark"`. This is the one intentional fallback in the system.
+Theme selection is cosmetic, not a correctness path. No migration or garbage
+collection is needed for orphaned theme ids.
+
+### Data Flow Summary
+
+**Startup:**
+1. `App.kt:42` → `extension.contribute(ctx)` → plugin calls `ctx.themes.theme(...)` and `ctx.routes.staticAssets(...)`
+2. `ExtensionContribution.from()` snapshots → `ExtensionContribution.themes: List<ExtensionTheme>`
+3. `ShellConfig.from(contribution)` carries contributed themes
+4. Conflict detection runs → fail-loud on duplicate
+5. Merged valid-theme-ids set built once in `ShellConfig`
+6. Contributed stylesheet URLs collected into extensionStylesheets
+
+**Per request:**
+7. `Filters.stateFilter` reads merged set from ShellConfig → passes through to `RequestContext`
+8. `RequestContext.theme` validates against merged set; fallback `"dark"`
+9. `SidebarFactory.buildThemeSelector` lists merged themes for picker
+10. `LayoutHead.kte` emits contributed theme CSS `<link>` tags (existing path)
+
+### Testing Strategy
+
+All tests extend the existing `ExtensionContributionTest` and
+`ExtensionRenderShellTest` patterns.
+
+| Test | Scope |
+|---|---|
+| Registry snapshot correctness | Unit — registry snapshots empty, single, multiple themes |
+| Merge produces valid composed set | Unit — built-in + contributed = merged set |
+| Duplicate id within one extension | Unit — second `theme("same-id")` is accepted (snapshot has both); conflict detection at composition catches it |
+| Duplicate id across extensions | Integration — two extensions register same id → composition throws with clear error |
+| Duplicate id vs built-in | Integration — extension registers `"dark"` → composition throws |
+| Blank id / label | Unit — `require` throws |
+| Picker includes contributed theme | Integration — `SidebarSelector` HTML contains contributed theme option |
+| Theme CSS `<link>` in `<head>` | Integration — response contains `<link href="/ext/my/assets/theme.css">` |
+| Cookie accepts contributed theme | Integration — setting cookie with contributed id → validated, persisted |
+| Stale theme fallback | Integration — user has contributed theme id, plugin not loaded → resolves to `"dark"` |
+| Stylesheet URL ownership | Integration — URL outside `assetPrefixes` → composition throws |
+
+## Scope Boundaries
+
+**Not included (v1):**
+- Per-theme lazy CSS loading (stylesheet always site-wide).
+- Plugin control over the default theme (users still see "dark" initially).
+- Reordering contributed themes in the picker (insertion-order append).
+- `ThemeDefinition.kt` remains desktop-only, unchanged.
+
+**Not affected:**
+- Desktop `ThemeManager` — no changes to Swing/FlatLav theming.
+- DaisyUI build chain — `input.css` stays `@plugin "daisyui"` with no config.
+- Existing `assets.stylesheet()` mechanism — works alongside the new theme registry.

--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/ResilientEmailService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/ResilientEmailService.kt
@@ -32,7 +32,7 @@ class ResilientEmailService(private val delegate: EmailService) : EmailService {
         try {
             circuitBreaker.executeRunnable { delegate.send(to, subject, body) }
         } catch (e: io.github.resilience4j.circuitbreaker.CallNotPermittedException) {
-            logger.warn("Email circuit breaker is open — dropping email to {}: {}", to, e.message)
+            logger.error("Email circuit breaker is open — dropping email to {}: {}", to, e.message)
         }
     }
 }

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AuthService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AuthService.kt
@@ -95,6 +95,8 @@ class AuthService(
             throw RegistrationDisabledException()
         }
         require(username.isNotBlank()) { "Username is required" }
+        require(username.length <= MAX_USERNAME_LENGTH) { "Username cannot exceed $MAX_USERNAME_LENGTH characters" }
+        require(EMAIL_REGEX.matches(username)) { "Username must be a valid email address" }
         val normalized = password.trim()
         validatePassword(normalized)?.let { throw WeakPasswordException(it) }
         if (userRepository.findByUsername(username) != null) throw UsernameAlreadyExistsException(username)
@@ -188,5 +190,10 @@ class AuthService(
         val token = "pt_" + bytes.joinToString("") { "%02x".format(it) }
         partialAuthStore.put(token, PartialAuth(userId = userId))
         return token
+    }
+
+    companion object {
+        private const val MAX_USERNAME_LENGTH = 50
+        private val EMAIL_REGEX = Regex("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
     }
 }

--- a/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthServiceTest.kt
+++ b/platform-security/src/test/kotlin/io/github/rygel/outerstellar/platform/security/AuthServiceTest.kt
@@ -230,35 +230,35 @@ class AuthServiceTest {
 
     @Test
     fun `register throws on duplicate username`() {
-        every { userRepository.findByUsername("existing") } returns testUser
+        every { userRepository.findByUsername("existing@test.com") } returns testUser
 
         assertThrows<UsernameAlreadyExistsException> {
-            service.register("existing", "ValidP@ss1" + java.util.UUID.randomUUID().toString())
+            service.register("existing@test.com", "ValidP@ss1" + java.util.UUID.randomUUID().toString())
         }
     }
 
     @Test
     fun `register throws on short password`() {
-        every { userRepository.findByUsername("newuser") } returns null
+        every { userRepository.findByUsername("newuser@test.com") } returns null
 
-        assertThrows<WeakPasswordException> { service.register("newuser", "short") }
+        assertThrows<WeakPasswordException> { service.register("newuser@test.com", "short") }
     }
 
     @Test
     fun `register throws on long password`() {
-        every { userRepository.findByUsername("newuser") } returns null
+        every { userRepository.findByUsername("newuser@test.com") } returns null
 
-        assertThrows<WeakPasswordException> { service.register("newuser", "A".repeat(129)) }
+        assertThrows<WeakPasswordException> { service.register("newuser@test.com", "A".repeat(129)) }
     }
 
     @Test
     fun `register trims whitespace before validation`() {
-        every { userRepository.findByUsername("newuser") } returns null
+        every { userRepository.findByUsername("newuser@test.com") } returns null
         every { passwordEncoder.encode("Validp@ss1") } returns "encoded_hash"
 
-        val result = service.register("newuser", "  Validp@ss1  ")
+        val result = service.register("newuser@test.com", "  Validp@ss1  ")
 
-        assertEquals("newuser", result.username)
+        assertEquals("newuser@test.com", result.username)
         assertEquals(UserRole.USER, result.role)
         val userSlot = slot<User>()
         verify { userRepository.save(capture(userSlot)) }
@@ -267,12 +267,12 @@ class AuthServiceTest {
 
     @Test
     fun `register creates user with encoded password`() {
-        every { userRepository.findByUsername("newuser") } returns null
+        every { userRepository.findByUsername("newuser@test.com") } returns null
         every { passwordEncoder.encode("Validp@ss1") } returns "encoded_hash"
 
-        val result = service.register("newuser", "Validp@ss1")
+        val result = service.register("newuser@test.com", "Validp@ss1")
 
-        assertEquals("newuser", result.username)
+        assertEquals("newuser@test.com", result.username)
         assertEquals(UserRole.USER, result.role)
 
         val userSlot = slot<User>()

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -109,7 +109,7 @@ fun analyticsPageViewFilter(analytics: AnalyticsService): Filter = Filter { next
                     analytics.page(userId, request.uri.path)
                 }
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-                analyticsLogger.debug("Failed to record page view: {}", e.message)
+                analyticsLogger.warn("Failed to record page view: {}", e.message)
             }
         }
         response
@@ -606,6 +606,9 @@ object Filters {
 
     @Suppress("UnusedParameter")
     private fun plainTextOriginalErrorResponse(status: Status, originalException: Exception): Response {
+        // Do NOT echo originalException.message to the client — it can contain raw SQL/JDBI internal
+        // text, stack details, or file paths. The original message is already logged server-side by
+        // logErrorPageRenderFailure. Return a static body only.
         return Response(status).header("content-type", "text/plain; charset=utf-8").body("Internal Server Error")
     }
 

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthApiIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthApiIntegrationTest.kt
@@ -33,12 +33,15 @@ class AuthApiIntegrationTest : WebTest() {
                     )
             )
         assertThat(registerResponse, hasStatus(Status.OK))
-        assertEquals("api-user", tokenLens(registerResponse).username)
+        assertEquals("api-user@test.com", tokenLens(registerResponse).username)
 
         val loginResponse =
             app(
                 Request(POST, "/api/v1/auth/login")
-                    .with(loginLens of io.github.rygel.outerstellar.platform.model.LoginRequest("api-user", password))
+                    .with(
+                        loginLens of
+                            io.github.rygel.outerstellar.platform.model.LoginRequest("api-user@test.com", password)
+                    )
             )
         assertThat(loginResponse, hasStatus(Status.OK))
         assertTrue(tokenLens(loginResponse).token.isNotBlank())

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthApiIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthApiIntegrationTest.kt
@@ -29,7 +29,7 @@ class AuthApiIntegrationTest : WebTest() {
                 Request(POST, "/api/v1/auth/register")
                     .with(
                         registerLens of
-                            io.github.rygel.outerstellar.platform.model.RegisterRequest("api-user", password)
+                            io.github.rygel.outerstellar.platform.model.RegisterRequest("api-user@test.com", password)
                     )
             )
         assertThat(registerResponse, hasStatus(Status.OK))

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthHtmlFlowIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/AuthHtmlFlowIntegrationTest.kt
@@ -54,7 +54,7 @@ class AuthHtmlFlowIntegrationTest : WebTest() {
         testUser =
             User(
                 id = UUID.randomUUID(),
-                username = "htmltestuser",
+                username = "htmltestuser@test.com",
                 email = "htmltestuser@test.com",
                 passwordHash = encoder.encode("C0rr3ct-P@ss"),
                 role = UserRole.USER,

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/NotificationsIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/NotificationsIntegrationTest.kt
@@ -39,7 +39,7 @@ class NotificationsIntegrationTest : WebTest() {
     }
 
     private fun registerAndLogin(
-        username: String = "notifuser${UUID.randomUUID().toString().take(6)}"
+        username: String = "notifuser${UUID.randomUUID().toString().take(6)}@test.com"
     ): Pair<UUID, String> {
         val password = testPassword()
         val regReq = Request(POST, "/api/v1/auth/register").with(registerLens of RegisterRequest(username, password))

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PerformanceBenchmarkTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/PerformanceBenchmarkTest.kt
@@ -192,8 +192,9 @@ class PerformanceBenchmarkTest : WebTest() {
         val loginLens = Body.auto<LoginRequest>().toLens()
         val tokenLens = Body.auto<AuthTokenResponse>().toLens()
         val password = testPassword()
-        app(Request(POST, "/api/v1/auth/register").with(registerLens of RegisterRequest("perfuser", password)))
-        val loginResp = app(Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("perfuser", password)))
+        app(Request(POST, "/api/v1/auth/register").with(registerLens of RegisterRequest("perfuser@test.com", password)))
+        val loginResp =
+            app(Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("perfuser@test.com", password)))
         bearerToken = tokenLens(loginResp).token
     }
 
@@ -331,7 +332,8 @@ class PerformanceBenchmarkTest : WebTest() {
                     )
             )
 
-        val req = Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("prodperfuser", "prodpass123!"))
+        val req =
+            Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("prodperfuser@test.com", "prodpass123!"))
 
         val rec = LatencyRecorder("POST /api/v1/auth/login (BCrypt rounds=10)")
         repeat(3) { prodApp(req) }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ProfileApiIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ProfileApiIntegrationTest.kt
@@ -265,13 +265,14 @@ class ProfileApiIntegrationTest : WebTest() {
         userRepository.save(
             User(
                 id = adminId,
-                username = "soleadmin",
+                username = "soleadmin@test.com",
                 email = "soleadmin@test.com",
                 passwordHash = BCryptPasswordEncoder(logRounds = 4).encode(password),
                 role = UserRole.ADMIN,
             )
         )
-        val loginResp = app(Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("soleadmin", password)))
+        val loginResp =
+            app(Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("soleadmin@test.com", password)))
         val adminToken = tokenLens(loginResp).token
 
         val response =
@@ -292,7 +293,7 @@ class ProfileApiIntegrationTest : WebTest() {
         userRepository.save(
             User(
                 id = id1,
-                username = "admin1",
+                username = "admin1@test.com",
                 email = "admin1@test.com",
                 passwordHash = enc.encode("Adm1nP@ss!"),
                 role = UserRole.ADMIN,
@@ -307,7 +308,8 @@ class ProfileApiIntegrationTest : WebTest() {
                 role = UserRole.ADMIN,
             )
         )
-        val loginResp = app(Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("admin1", "Adm1nP@ss!")))
+        val loginResp =
+            app(Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("admin1@test.com", "Adm1nP@ss!")))
         val token1 = tokenLens(loginResp).token
 
         val response =

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ProfileApiIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ProfileApiIntegrationTest.kt
@@ -48,7 +48,7 @@ class ProfileApiIntegrationTest : WebTest() {
     // ---- Helpers ----
 
     private fun registerAndLogin(
-        username: String = "profuser${UUID.randomUUID().toString().take(6)}",
+        username: String = "profuser${UUID.randomUUID().toString().take(6)}@test.com",
         password: String = testPassword(),
     ): String {
         app(Request(POST, "/api/v1/auth/register").with(registerLens of RegisterRequest(username, password)))
@@ -67,12 +67,12 @@ class ProfileApiIntegrationTest : WebTest() {
 
     @Test
     fun `GET profile returns current user data`() {
-        val token = registerAndLogin("alice")
+        val token = registerAndLogin("alice@test.com")
         val response = app(bearer(GET, "/api/v1/auth/profile", token))
 
         assertThat(response, hasStatus(Status.OK))
         val profile = userProfileLens(response)
-        assertEquals("alice", profile.username)
+        assertEquals("alice@test.com", profile.username)
         assertTrue(profile.email.isNotBlank())
         assertTrue(profile.emailNotificationsEnabled)
         assertTrue(profile.pushNotificationsEnabled)
@@ -89,8 +89,8 @@ class ProfileApiIntegrationTest : WebTest() {
 
     @Test
     fun `PUT profile updates email`() {
-        val token = registerAndLogin("bob")
-        val user = userRepository.findByUsername("bob")!!
+        val token = registerAndLogin("bob@test.com")
+        val user = userRepository.findByUsername("bob@test.com")!!
 
         val response =
             app(
@@ -104,8 +104,8 @@ class ProfileApiIntegrationTest : WebTest() {
 
     @Test
     fun `PUT profile updates username`() {
-        val token = registerAndLogin("carol")
-        val user = userRepository.findByUsername("carol")!!
+        val token = registerAndLogin("carol@test.com")
+        val user = userRepository.findByUsername("carol@test.com")!!
 
         val response =
             app(
@@ -115,13 +115,13 @@ class ProfileApiIntegrationTest : WebTest() {
 
         assertThat(response, hasStatus(Status.OK))
         assertNotNull(userRepository.findByUsername("carol_v2"))
-        assertNull(userRepository.findByUsername("carol"))
+        assertNull(userRepository.findByUsername("carol@test.com"))
     }
 
     @Test
     fun `PUT profile updates avatar URL`() {
-        val token = registerAndLogin("dave")
-        val user = userRepository.findByUsername("dave")!!
+        val token = registerAndLogin("dave@test.com")
+        val user = userRepository.findByUsername("dave@test.com")!!
 
         val response =
             app(
@@ -138,19 +138,19 @@ class ProfileApiIntegrationTest : WebTest() {
 
     @Test
     fun `PUT profile returns 409 when username is already taken`() {
-        val token1 = registerAndLogin("eve")
-        registerAndLogin("frank")
-        val user = userRepository.findByUsername("eve")!!
+        val token1 = registerAndLogin("eve@test.com")
+        registerAndLogin("frank@test.com")
+        val user = userRepository.findByUsername("eve@test.com")!!
 
         val response =
             app(
                 bearer(PUT, "/api/v1/auth/profile", token1)
-                    .with(updateProfileLens of UpdateProfileRequest(email = user.email, username = "frank"))
+                    .with(updateProfileLens of UpdateProfileRequest(email = user.email, username = "frank@test.com"))
             )
 
         assertThat(response, hasStatus(Status.CONFLICT))
         // original username unchanged
-        assertNotNull(userRepository.findByUsername("eve"))
+        assertNotNull(userRepository.findByUsername("eve@test.com"))
     }
 
     @Test
@@ -167,8 +167,8 @@ class ProfileApiIntegrationTest : WebTest() {
 
     @Test
     fun `PUT notification-preferences persists both flags`() {
-        val token = registerAndLogin("grace")
-        val user = userRepository.findByUsername("grace")!!
+        val token = registerAndLogin("grace@test.com")
+        val user = userRepository.findByUsername("grace@test.com")!!
 
         val response =
             app(
@@ -187,8 +187,8 @@ class ProfileApiIntegrationTest : WebTest() {
 
     @Test
     fun `PUT notification-preferences can enable selectively`() {
-        val token = registerAndLogin("henry")
-        val user = userRepository.findByUsername("henry")!!
+        val token = registerAndLogin("henry@test.com")
+        val user = userRepository.findByUsername("henry@test.com")!!
 
         app(
             bearer(PUT, "/api/v1/auth/notification-preferences", token)
@@ -222,8 +222,8 @@ class ProfileApiIntegrationTest : WebTest() {
     @Test
     fun `DELETE account removes the user`() {
         val password = testPassword()
-        val token = registerAndLogin("ivan", password)
-        val user = userRepository.findByUsername("ivan")!!
+        val token = registerAndLogin("ivan@test.com", password)
+        val user = userRepository.findByUsername("ivan@test.com")!!
 
         val response =
             app(bearer(DELETE, "/api/v1/auth/account", token).with(deleteAccountLens of DeleteAccountRequest(password)))
@@ -234,8 +234,8 @@ class ProfileApiIntegrationTest : WebTest() {
 
     @Test
     fun `DELETE account rejects missing current password`() {
-        val token = registerAndLogin("ian")
-        val user = userRepository.findByUsername("ian")!!
+        val token = registerAndLogin("ian@test.com")
+        val user = userRepository.findByUsername("ian@test.com")!!
 
         val response = app(bearer(DELETE, "/api/v1/auth/account", token))
 
@@ -245,8 +245,8 @@ class ProfileApiIntegrationTest : WebTest() {
 
     @Test
     fun `DELETE account rejects incorrect current password`() {
-        val token = registerAndLogin("isla")
-        val user = userRepository.findByUsername("isla")!!
+        val token = registerAndLogin("isla@test.com")
+        val user = userRepository.findByUsername("isla@test.com")!!
 
         val response =
             app(
@@ -331,8 +331,8 @@ class ProfileApiIntegrationTest : WebTest() {
 
     @Test
     fun `GET profile after PUT reflects updated values`() {
-        val token = registerAndLogin("karen")
-        val user = userRepository.findByUsername("karen")!!
+        val token = registerAndLogin("karen@test.com")
+        val user = userRepository.findByUsername("karen@test.com")!!
 
         app(
             bearer(PUT, "/api/v1/auth/profile", token)

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementIntegrationTest.kt
@@ -88,7 +88,7 @@ class UserManagementIntegrationTest : WebTest() {
 
     @Test
     fun `change password via API succeeds with correct current password`() {
-        val auth = registerUser("pwduser", "0ldP@ssw0rd1!")
+        val auth = registerUser("pwduser@test.com", "0ldP@ssw0rd1!")
 
         val response =
             app(
@@ -99,17 +99,19 @@ class UserManagementIntegrationTest : WebTest() {
 
         // Verify old password no longer works
         val failLogin =
-            app(Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("pwduser", "0ldP@ssw0rd1!")))
+            app(
+                Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("pwduser@test.com", "0ldP@ssw0rd1!"))
+            )
         assertThat(failLogin, hasStatus(Status.UNAUTHORIZED))
 
         // Verify new password works
-        val successLogin = loginUser("pwduser", "N3wP@ssw0rd1!")
+        val successLogin = loginUser("pwduser@test.com", "N3wP@ssw0rd1!")
         assertTrue(successLogin.token.isNotBlank())
     }
 
     @Test
     fun `change password fails with wrong current password`() {
-        val auth = registerUser("pwduser2", "C0rr3ctP@ss1!")
+        val auth = registerUser("pwduser2@test.com", "C0rr3ctP@ss1!")
 
         val response =
             app(
@@ -121,7 +123,7 @@ class UserManagementIntegrationTest : WebTest() {
 
     @Test
     fun `change password fails with too short new password`() {
-        val auth = registerUser("pwduser3", "C0rr3ctP@ss1!")
+        val auth = registerUser("pwduser3@test.com", "C0rr3ctP@ss1!")
 
         val response =
             app(
@@ -152,8 +154,8 @@ class UserManagementIntegrationTest : WebTest() {
     @Test
     fun `admin can list all users`() {
         val admin = seedAdmin()
-        registerUser("user1", testPassword())
-        registerUser("user2", testPassword())
+        registerUser("user1@test.com", testPassword())
+        registerUser("user2@test.com", testPassword())
 
         val response = app(bearerRequest(GET, "/api/v1/admin/users", admin.token))
         assertThat(response, hasStatus(Status.OK))
@@ -161,13 +163,13 @@ class UserManagementIntegrationTest : WebTest() {
         val users = userSummaryListLens(response)
         assertTrue(users.size >= 3, "Should have at least admin + 2 users")
         assertNotNull(users.find { it.username == "admin" })
-        assertNotNull(users.find { it.username == "user1" })
-        assertNotNull(users.find { it.username == "user2" })
+        assertNotNull(users.find { it.username == "user1@test.com" })
+        assertNotNull(users.find { it.username == "user2@test.com" })
     }
 
     @Test
     fun `non-admin cannot list users`() {
-        val auth = registerUser("regularuser", testPassword())
+        val auth = registerUser("regularuser@test.com", testPassword())
 
         val response = app(bearerRequest(GET, "/api/v1/admin/users", auth.token))
         assertThat(response, hasStatus(Status.FORBIDDEN))
@@ -177,7 +179,7 @@ class UserManagementIntegrationTest : WebTest() {
     fun `admin can disable a user`() {
         val admin = seedAdmin()
         val password = testPassword()
-        val userAuth = registerUser("disableuser", password)
+        val userAuth = registerUser("disableuser@test.com", password)
 
         val response =
             app(
@@ -188,7 +190,7 @@ class UserManagementIntegrationTest : WebTest() {
 
         // Verify the disabled user cannot log in
         val loginResponse =
-            app(Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("disableuser", password)))
+            app(Request(POST, "/api/v1/auth/login").with(loginLens of LoginRequest("disableuser@test.com", password)))
         assertThat(loginResponse, hasStatus(Status.UNAUTHORIZED))
     }
 
@@ -196,7 +198,7 @@ class UserManagementIntegrationTest : WebTest() {
     fun `admin can re-enable a user`() {
         val admin = seedAdmin()
         val password = testPassword()
-        val userAuth = registerUser("reenableuser", password)
+        val userAuth = registerUser("reenableuser@test.com", password)
 
         // Disable
         app(
@@ -213,7 +215,7 @@ class UserManagementIntegrationTest : WebTest() {
         assertThat(response, hasStatus(Status.OK))
 
         // User can log in again
-        val loginResponse = loginUser("reenableuser", password)
+        val loginResponse = loginUser("reenableuser@test.com", password)
         assertTrue(loginResponse.token.isNotBlank())
     }
 
@@ -232,7 +234,7 @@ class UserManagementIntegrationTest : WebTest() {
     @Test
     fun `admin can promote a user to admin`() {
         val admin = seedAdmin()
-        val userAuth = registerUser("promoteuser", testPassword())
+        val userAuth = registerUser("promoteuser@test.com", testPassword())
 
         val response =
             app(
@@ -249,7 +251,7 @@ class UserManagementIntegrationTest : WebTest() {
     @Test
     fun `admin can demote an admin to user`() {
         val admin = seedAdmin()
-        val userAuth = registerUser("demoteuser", testPassword())
+        val userAuth = registerUser("demoteuser@test.com", testPassword())
 
         // Promote first
         app(
@@ -285,14 +287,14 @@ class UserManagementIntegrationTest : WebTest() {
     @Test
     fun `admin user list returns correct fields`() {
         val admin = seedAdmin()
-        registerUser("fieldcheck", testPassword())
+        registerUser("fieldcheck@test.com", testPassword())
 
         val response = app(bearerRequest(GET, "/api/v1/admin/users", admin.token))
         val users = userSummaryListLens(response)
-        val user = users.find { it.username == "fieldcheck" }!!
+        val user = users.find { it.username == "fieldcheck@test.com" }!!
 
-        assertEquals("fieldcheck", user.username)
-        assertEquals("fieldcheck", user.email)
+        assertEquals("fieldcheck@test.com", user.username)
+        assertEquals("fieldcheck@test.com", user.email)
         assertEquals(UserRole.USER, user.role)
         assertTrue(user.enabled)
         assertTrue(user.id.isNotBlank())

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementWebUiIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/UserManagementWebUiIntegrationTest.kt
@@ -85,7 +85,7 @@ class UserManagementWebUiIntegrationTest : WebTest() {
 
     @Test
     fun `non-admin cannot access user admin page`() {
-        val userAuth = registerUser("nonadminuser", testPassword())
+        val userAuth = registerUser("nonadminuser@test.com", testPassword())
         val response =
             app(
                 Request(GET, "/admin/users").cookie(org.http4k.core.cookie.Cookie("app_session", userAuth.sessionToken))
@@ -96,24 +96,24 @@ class UserManagementWebUiIntegrationTest : WebTest() {
     @Test
     fun `admin can toggle user enabled via HTML form`() {
         val admin = seedAdmin()
-        val userAuth = registerUser("toggleuser", testPassword())
+        val userAuth = registerUser("toggleuser@test.com", testPassword())
         app(
             Request(POST, "/admin/users/${userAuth.id}/toggle-enabled")
                 .cookie(org.http4k.core.cookie.Cookie("app_session", admin.token))
         )
-        val user = userRepository.findByUsername("toggleuser")!!
+        val user = userRepository.findByUsername("toggleuser@test.com")!!
         assertFalse(user.enabled)
     }
 
     @Test
     fun `admin can toggle user role via HTML form`() {
         val admin = seedAdmin()
-        val userAuth = registerUser("roleuser", testPassword())
+        val userAuth = registerUser("roleuser@test.com", testPassword())
         app(
             Request(POST, "/admin/users/${userAuth.id}/toggle-role")
                 .cookie(org.http4k.core.cookie.Cookie("app_session", admin.token))
         )
-        val user = userRepository.findByUsername("roleuser")!!
+        val user = userRepository.findByUsername("roleuser@test.com")!!
         assertEquals(UserRole.ADMIN, user.role)
     }
 
@@ -151,7 +151,7 @@ class UserManagementWebUiIntegrationTest : WebTest() {
 
     @Test
     fun `regular user does not see Users nav link`() {
-        val userAuth = registerUser("navuser", testPassword())
+        val userAuth = registerUser("navuser@test.com", testPassword())
         val response =
             app(Request(GET, "/").cookie(org.http4k.core.cookie.Cookie("app_session", userAuth.sessionToken)))
         assertFalse(response.bodyString().contains("/admin/users"))
@@ -167,7 +167,7 @@ class UserManagementWebUiIntegrationTest : WebTest() {
                 app(
                     Request(POST, "/api/v1/auth/login")
                         .header("X-Forwarded-For", "10.0.0.99")
-                        .with(loginLens of LoginRequest("nobody", "nopass"))
+                        .with(loginLens of LoginRequest("nobody@test.com", "nopass"))
                 )
             if (response.status == Status.TOO_MANY_REQUESTS) {
                 blockedCount++


### PR DESCRIPTION
Audit H4 (register validates username length + email format), H6 (error-page fallback no longer leaks raw exception messages), H5 (email-drops logged at ERROR), L1 (analytics errors logged at WARN). Tests updated for email-username validation. Gate green (§425).