### PR TITLE
fix: vote race guard, duplicate-key handling, open-redirect bypass

### DIFF
--- a/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/VoteService.kt
+++ b/platform-core/src/main/kotlin/io/github/rygel/outerstellar/platform/service/VoteService.kt
@@ -3,11 +3,16 @@ package io.github.rygel.outerstellar.platform.service
 import io.github.rygel.outerstellar.platform.model.MessageVote
 import io.github.rygel.outerstellar.platform.model.VoteScore
 import io.github.rygel.outerstellar.platform.persistence.MessageRepository
+import io.github.rygel.outerstellar.platform.persistence.TransactionManager
 import io.github.rygel.outerstellar.platform.persistence.VoteRepository
 import java.util.UUID
 import org.slf4j.LoggerFactory
 
-class VoteService(private val voteRepository: VoteRepository, private val messageRepository: MessageRepository) {
+class VoteService(
+    private val voteRepository: VoteRepository,
+    private val messageRepository: MessageRepository,
+    private val transactionManager: TransactionManager? = null,
+) {
     private val logger = LoggerFactory.getLogger(VoteService::class.java)
 
     fun vote(messageSyncId: String, userId: UUID, direction: Int): VoteScore? {
@@ -15,14 +20,19 @@ class VoteService(private val voteRepository: VoteRepository, private val messag
             logger.warn("Vote attempted on non-existent message: {}", messageSyncId)
             return null
         }
-        val existing = voteRepository.findByUserAndMessage(userId, messageSyncId)
-        if (existing == null) {
-            voteRepository.save(MessageVote(messageSyncId = messageSyncId, userId = userId, direction = direction))
-        } else if (existing.direction == direction) {
-            voteRepository.delete(userId, messageSyncId)
-        } else {
-            voteRepository.updateDirection(userId, messageSyncId, direction)
+        // Wrap the read-then-write in a transaction so two concurrent identical votes don't both pass
+        // the findByUserAndMessage check and race on save (unique-constraint violation → 500).
+        val doVote = {
+            val existing = voteRepository.findByUserAndMessage(userId, messageSyncId)
+            if (existing == null) {
+                voteRepository.save(MessageVote(messageSyncId = messageSyncId, userId = userId, direction = direction))
+            } else if (existing.direction == direction) {
+                voteRepository.delete(userId, messageSyncId)
+            } else {
+                voteRepository.updateDirection(userId, messageSyncId, direction)
+            }
         }
+        transactionManager?.inTransaction { doVote() } ?: doVote()
         return voteRepository.findScoreByMessage(messageSyncId, userId)
     }
 

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AccountService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/AccountService.kt
@@ -62,7 +62,18 @@ class AccountService(
             UrlValidator.validate(sanitizedUrl)
         }
         val updated = user.copy(email = newEmail, username = resolvedUsername, avatarUrl = sanitizedUrl)
-        userRepository.save(updated)
+        try {
+            userRepository.save(updated)
+        } catch (e: Exception) {
+            // Concurrent profile update raced past the findByEmail/findByUsername check and hit the
+            // DB unique constraint. Translate to a user-facing UsernameAlreadyExistsException instead
+            // of a raw 500.
+            val msg = e.message ?: ""
+            if (msg.contains("23505") || msg.contains("duplicate key") || msg.contains("unique constraint")) {
+                throw UsernameAlreadyExistsException(resolvedUsername)
+            }
+            throw e
+        }
         logger.info("Profile updated for user {}", sanitize(updated.username))
     }
 

--- a/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/OAuthService.kt
+++ b/platform-security/src/main/kotlin/io/github/rygel/outerstellar/platform/security/OAuthService.kt
@@ -48,20 +48,10 @@ class OAuthService(
                 role = UserRole.USER,
             )
         // Both writes must be atomic — a failure between save(user) and save(connection) leaves an
-        // orphaned User with no OAuth linkage, permanently locking the user out of OAuth login.
-        transactionManager?.inTransaction {
-            userRepository.save(user)
-            repo.save(
-                OAuthConnection(
-                    id = 0L,
-                    userId = user.id,
-                    provider = providerName,
-                    subject = oauthSubject,
-                    email = email,
-                )
-            )
-        }
-            ?: run {
+        // orphaned User with no OAuth linkage. If a concurrent OAuth callback for the same (provider,
+        // subject) wins the race, the second repo.save hits the unique constraint — catch it and re-read.
+        try {
+            transactionManager?.inTransaction {
                 userRepository.save(user)
                 repo.save(
                     OAuthConnection(
@@ -73,6 +63,29 @@ class OAuthService(
                     )
                 )
             }
+                ?: run {
+                    userRepository.save(user)
+                    repo.save(
+                        OAuthConnection(
+                            id = 0L,
+                            userId = user.id,
+                            provider = providerName,
+                            subject = oauthSubject,
+                            email = email,
+                        )
+                    )
+                }
+        } catch (e: Exception) {
+            val msg = e.message ?: ""
+            if (msg.contains("23505") || msg.contains("duplicate key") || msg.contains("unique constraint")) {
+                val winner = repo.findByProviderSubject(providerName, oauthSubject)
+                if (winner != null) {
+                    return userRepository.findById(winner.userId)
+                        ?: error("OAuth user record found but linked user missing: ${winner.userId}")
+                }
+            }
+            throw e
+        }
         logger.info("Created new user {} via OAuth provider {}", sanitize(username), providerName)
         auditRepository?.logAction("OAUTH_USER_CREATED", actor = user, detail = "provider=$providerName")
         return user

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AuthRoutes.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/AuthRoutes.kt
@@ -176,6 +176,9 @@ class AuthRoutes(
             returnTo.isNullOrBlank() -> "/"
             !returnTo.startsWith("/") -> "/"
             returnTo.startsWith("//") -> "/"
+            // Backslash bypass: some browsers normalize /\ to //, yielding a protocol-relative redirect
+            // to an attacker-controlled host (e.g. /\evil.com).
+            returnTo.startsWith("/\\") -> "/"
             else -> returnTo
         }
     }

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/Filters.kt
@@ -604,11 +604,9 @@ object Filters {
         }
     }
 
+    @Suppress("UnusedParameter")
     private fun plainTextOriginalErrorResponse(status: Status, originalException: Exception): Response {
-        val message = originalException.message ?: "An unexpected error occurred"
-        return Response(status)
-            .header("content-type", "text/plain; charset=utf-8")
-            .body("Internal Server Error: $message")
+        return Response(status).header("content-type", "text/plain; charset=utf-8").body("Internal Server Error")
     }
 
     private fun logErrorPageRenderFailure(

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/GlobalErrorHandlerTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/GlobalErrorHandlerTest.kt
@@ -31,7 +31,7 @@ class GlobalErrorHandlerTest {
 
         assertThat(response, hasStatus(Status.INTERNAL_SERVER_ERROR))
         assertThat(response, hasHeader("content-type", "text/plain; charset=utf-8"))
-        assertThat(response, hasBody("Internal Server Error: something broke in the handler"))
+        assertThat(response, hasBody("Internal Server Error"))
     }
 
     @Test
@@ -42,7 +42,7 @@ class GlobalErrorHandlerTest {
 
         assertThat(response, hasStatus(Status.INTERNAL_SERVER_ERROR))
         assertThat(response, hasHeader("content-type", "text/plain; charset=utf-8"))
-        assertThat(response, hasBody("Internal Server Error: An unexpected error occurred"))
+        assertThat(response, hasBody("Internal Server Error"))
     }
 
     @Test


### PR DESCRIPTION
Audit H3 (VoteService vote check-then-act → optional TransactionManager), M1 (AccountService duplicate-key → UsernameAlreadyExistsException), M2 (OAuthService duplicate-subject → catch-and-retry), M4 (open-redirect backslash bypass blocked). Gate green (§425).