### PR TITLE
fix: use valid email in NotificationsIntegrationTest bell badge test

### DIFF
--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/NotificationsIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/NotificationsIntegrationTest.kt
@@ -160,7 +160,7 @@ class NotificationsIntegrationTest : WebTest() {
 
     @Test
     fun `GET notification bell shows unread count badge`() {
-        val (userId, _) = registerAndLogin("belluser${UUID.randomUUID().toString().take(5)}")
+        val (userId, _) = registerAndLogin("belluser${UUID.randomUUID().toString().take(5)}@test.com")
         notificationService.create(userId, "Unread", "Body")
 
         // The bell fragment counts per-user; anonymous request shows 0


### PR DESCRIPTION
One-line fix: the bell badge test passed a bare username `belluser${random}` to registerAndLogin, which now fails EMAIL_REGEX validation. Fixed to `belluser${random}@test.com`.