### PR TITLE
fix: use valid email in OAuthIntegrationTest register call

### DIFF
--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
@@ -336,7 +336,7 @@ class OAuthIntegrationTest : WebTest() {
     @Test
     fun `findOrCreateOAuthUser generates unique username when base is already taken`() {
         // Create a user whose username will collide with the derived OAuth username
-        localAuthService.register("alice", testPassword())
+        localAuthService.register("alice@test.com", testPassword())
 
         val oauthUser = testOAuthService.findOrCreateOAuthUser("apple", "apple.sub.alice", "alice@example.com")
 


### PR DESCRIPTION
One-line fix: OAuthIntegrationTest:339 called register("alice") which fails EMAIL_REGEX validation. Fixed to register("alice@test.com").