### PR TITLE
fix(i18n): pin platform messages bundle to platform classloader (#594)

### DIFF
--- a/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/di/DesktopComponents.kt
+++ b/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/di/DesktopComponents.kt
@@ -86,7 +86,9 @@ fun createDesktopComponents(): DesktopComponents {
             transactionManager = persistence.transactionManager,
             auditRepository = persistence.auditRepository,
         )
-    val i18nService = I18nService.create("messages")
+    // Pin the bundle to the platform's own classloader, not the thread context classloader — see ShellRenderer
+    // for rationale (#594). Keeps the desktop client consistent with the web/host load path.
+    val i18nService = I18nService.create("messages", DesktopComponents::class.java.classLoader)
     val analyticsService = createAnalyticsService(appConfig)
     val clients = createHttpClients(appConfig)
     val modules =

--- a/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/SyncDialogs.kt
+++ b/platform-desktop/src/main/kotlin/io/github/rygel/outerstellar/platform/swing/SyncDialogs.kt
@@ -369,7 +369,10 @@ internal class SyncDialogs(
             val selectedLang = languages[langCombo.selectedIndex].first
             val newLocale = Locale.of(selectedLang)
             Locale.setDefault(newLocale)
-            onRefreshTranslations(I18nService.create("messages").also { it.setLocale(newLocale) })
+            // Pin the bundle to the platform's own classloader (#594); see ShellRenderer for rationale.
+            onRefreshTranslations(
+                I18nService.create("messages", SyncDialogs::class.java.classLoader).also { it.setLocale(newLocale) }
+            )
             onSaveState()
             frame.revalidate()
             frame.repaint()

--- a/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ShellRenderer.kt
+++ b/platform-web/src/main/kotlin/io/github/rygel/outerstellar/platform/web/ShellRenderer.kt
@@ -63,7 +63,15 @@ class ShellRenderer(
             Caffeine.newBuilder().maximumSize(500).expireAfterWrite(5, TimeUnit.MINUTES).build()
 
         fun cachedI18n(lang: String): I18nService =
-            i18nCache.computeIfAbsent(lang) { I18nService.create("messages").also { it.setLocale(Locale.of(lang)) } }
+            // Pin the bundle to the platform's own classloader rather than the thread context classloader.
+            // In a host app the TCCL may not see platform-core's messages.properties, or may find a host-shipped
+            // root-level messages.properties first and shadow it — either way every web.* key misses and renders raw
+            // (#594). The platform's classloader always resolves the platform's bundle, independent of host wiring.
+            i18nCache.computeIfAbsent(lang) {
+                I18nService.create("messages", ShellRenderer::class.java.classLoader).also {
+                    it.setLocale(Locale.of(lang))
+                }
+            }
     }
 
     val i18n: I18nService by lazy { cachedI18n(ctx.lang) }

--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ShellRendererTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/ShellRendererTest.kt
@@ -95,4 +95,44 @@ class ShellRendererTest {
         assertNull(extensionShell.profileUrl)
         assertNull(extensionShell.changePasswordUrl)
     }
+
+    /**
+     * Regression for #594: the platform must resolve its own web.* bundle regardless of the host's thread context
+     * classloader. If the bundle load falls back to the TCCL, a host app either can't see platform-core's
+     * messages.properties or hits a host-shipped one first, and translate() returns the raw key. Here we assert that
+     * ShellRenderer.i18n resolves localized text for both English and French rather than echoing the key.
+     */
+    @Test
+    fun `platform i18n bundle resolves web keys for english and french`() {
+        val englishRenderer = ShellRenderer(requestContextForLang("en"))
+        val frenchRenderer = ShellRenderer(requestContextForLang("fr"))
+
+        val englishHeading = englishRenderer.i18n.translate("web.auth.heading")
+        val frenchHeading = frenchRenderer.i18n.translate("web.auth.heading")
+
+        assertEquals("Authentication page examples", englishHeading)
+        assertEquals("Exemples de pages d'authentification", frenchHeading)
+    }
+
+    @Test
+    fun `platform i18n bundle never returns the raw key for known web keys`() {
+        val renderer = ShellRenderer(requestContextForLang("en"))
+
+        val heading = renderer.i18n.translate("web.auth.heading")
+        val navAuth = renderer.i18n.translate("web.nav.auth")
+
+        assertFalse(heading.startsWith("web."), "Expected resolved text, got raw key: $heading")
+        assertFalse(navAuth.startsWith("web."), "Expected resolved text, got raw key: $navAuth")
+    }
+
+    private fun requestContextForLang(lang: String): RequestContext {
+        val sessionService = mockk<SessionService>()
+        every { sessionService.lookupSession("session-token") } returns SessionLookup.Active(user)
+        return RequestContext(
+            Request(GET, "/repoquality?lang=$lang")
+                .cookie(Cookie(RequestContext.SESSION_COOKIE, "session-token"))
+                .cookie(Cookie(RequestContext.SHELL_COOKIE, "sidebar")),
+            sessionService = sessionService,
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #594.

The platform-rendered `/auth` page (and any platform-rendered page) emitted **raw i18n keys** (`web.auth.heading`, `web.app.title`, …) instead of resolved text when the platform was consumed as a library by a host app.

### Root cause

`ShellRenderer.cachedI18n` loaded the platform `web.*` bundle via `I18nService.create("messages")`, which captures `Thread.currentThread().contextClassLoader` at the moment of first render. In a host app the TCCL either:
- can't see `platform-core`'s `messages.properties`, or
- finds a host-shipped root-level `messages.properties` first and **shadows** the platform's bundle (`ResourceBundle.getBundle` returns one bundle, no merge).

Either way every `web.*` key misses `findTemplate` and is echoed verbatim. Reproduces identically in JVM and native-image (native registration is already correct — this is a classloader-resolution bug, not a native-resource bug).

### Fix

Pin the bundle to the **platform's own classloader** via `I18nService.create("messages", ShellRenderer::class.java.classLoader)`. The platform classloader always resolves `platform-core`'s bundle regardless of host wiring, and stays locale-aware (`messages_fr.properties` still resolves via `ResourceBundle.getBundle` with the fallback-suppressing control — no French regression).

Rejected alternative: registering the bundle through `I18nService.loadFromClasspath` overlay would load a single default-locale file that shadows per-locale resolution — a French regression. The classloader-pin approach needs no change to the published `outerstellar-i18n` library (the `create(baseName, classLoader)` overload already exists).

## Changes

- `platform-web/.../ShellRenderer.kt` — the one-line core fix + rationale comment.
- `platform-web/.../ShellRendererTest.kt` — 2 regression tests asserting `web.*` keys resolve in **English and French**. The suite previously never asserted translated text.
- `platform-desktop/.../DesktopComponents.kt`, `SyncDialogs.kt` — same classloader-pin pattern for consistency (desktop is standalone, not host-consumed; defensive alignment, not a bug fix).

## Verification

- ✅ `ShellRendererTest` 4/4, `TextResolverTest` 9/9, `ExtensionTextOverrideTest` 6/6
- ✅ Full non-desktop reactor: **760/761 pass**

## Pre-existing failure (NOT caused by this PR)

`OAuthIntegrationTest.findOrCreateOAuthUser generates unique username when base is already taken` fails on this branch **and on clean `origin/develop`** (verified by stashing these changes and re-running). It is unrelated to i18n. The fix already exists on `main` as **#581** (`3b0f42e9`, *"fix: OAuthIntegrationTest unique-username test uses repo save instead of register"*) but has not been merged into develop. This PR should not be blocked on it; merging #581 into develop separately will turn the reactor green.

## Out of scope

- No `outerstellar-i18n` library change (the needed overload already exists).
- No native-image metadata change (already correct).
- No host SPI for bundle merging (the issue asks the platform to self-provide, which this does).

Closes #594.