### PR TITLE
test(oauth): backport unique-username test fix to develop (#581)

### DIFF
--- a/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
+++ b/platform-web/src/test/kotlin/io/github/rygel/outerstellar/platform/web/OAuthIntegrationTest.kt
@@ -1,6 +1,8 @@
 package io.github.rygel.outerstellar.platform.web
 
 import com.natpryce.hamkrest.assertion.assertThat
+import io.github.rygel.outerstellar.platform.model.User
+import io.github.rygel.outerstellar.platform.model.UserRole
 import io.github.rygel.outerstellar.platform.security.AuthService
 import io.github.rygel.outerstellar.platform.security.BCryptPasswordEncoder
 import io.github.rygel.outerstellar.platform.security.OAuthService
@@ -335,8 +337,17 @@ class OAuthIntegrationTest : WebTest() {
 
     @Test
     fun `findOrCreateOAuthUser generates unique username when base is already taken`() {
-        // Create a user whose username will collide with the derived OAuth username
-        localAuthService.register("alice@test.com", testPassword())
+        // Create a user whose username "alice" collides with the OAuth-derived username.
+        // Save via repository directly since register() now requires email-format usernames.
+        userRepository.save(
+            User(
+                id = java.util.UUID.randomUUID(),
+                username = "alice",
+                email = "alice@test.com",
+                passwordHash = "\$2a\$04\$dummy",
+                role = UserRole.USER,
+            )
+        )
 
         val oauthUser = testOAuthService.findOrCreateOAuthUser("apple", "apple.sub.alice", "alice@example.com")
 


### PR DESCRIPTION
## Summary

Backport of #581 to `develop`. No production-code change — test-only.

`OAuthIntegrationTest.findOrCreateOAuthUser generates unique username when base is already taken` fails on `develop` because the test still calls `localAuthService.register("alice@test.com", ...)`, but `register()` now requires email-format usernames (enforced by #573). #581 fixed this on `main` by saving the colliding user via the repository directly, but that fix never reached `develop`.

This cherry-picks commit `3b0f42e9` (#581's merge) onto develop so the web test suite is green on develop. Verified locally: `OAuthIntegrationTest` 25/25 pass (was failing).

## Why now

Prerequisite for the v3.6.19 release path (#595 → develop → main). The release workflow gates on a green `CI` run on `main`, and `Unit Tests (web)` runs `OAuthIntegrationTest`. Without this backport, promoting develop→main would carry the failing test onto main and block the release gate.

## Verification

- `mvn -pl platform-web test -Dtest=OAuthIntegrationTest` → 25/25 pass on this branch.
- Test-only change; no production code touched.

Refs #581.