### PR TITLE
release: v3.6.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [3.6.19] – 2026-07-07
+
+### Fixed
+
+- **Platform-rendered pages resolve their own i18n bundle** — `ShellRenderer.cachedI18n` now loads the platform `web.*` message bundle through the platform's own classloader instead of the thread context classloader. When the platform is consumed as a library by a host app, the TCCL may not see `platform-core`'s `messages.properties`, or may find a host-shipped root-level `messages.properties` first and shadow it — either way every `web.*` key rendered raw on platform pages (`/auth` showed `web.auth.heading`, `web.app.title`, …). Pinning to the platform classloader resolves the bundle regardless of host wiring and stays locale-aware (`messages_fr.properties` still resolves). Also aligns the two desktop i18n load sites to the same pattern (#594, #595).
+
+---
+
 ## [Unreleased]
 
 ---

--- a/outerstellar-i18n-validator-maven-plugin/pom.xml
+++ b/outerstellar-i18n-validator-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.18</version>
+        <version>3.6.19</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n-validator/pom.xml
+++ b/outerstellar-i18n-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.18</version>
+        <version>3.6.19</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n/pom.xml
+++ b/outerstellar-i18n/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.18</version>
+        <version>3.6.19</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-platform-extension-archetype/pom.xml
+++ b/outerstellar-platform-extension-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.18</version>
+        <version>3.6.19</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-archetype</artifactId>

--- a/outerstellar-platform-extension-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/outerstellar-platform-extension-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <maven.compiler.release>\${java.version}</maven.compiler.release>
-        <outerstellar-platform.version>3.6.18</outerstellar-platform.version>
+        <outerstellar-platform.version>3.6.19</outerstellar-platform.version>
         <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
         <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>
         <maven.shade.plugin.version>3.6.2</maven.shade.plugin.version>

--- a/outerstellar-platform-extension-parent/pom.xml
+++ b/outerstellar-platform-extension-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.18</version>
+        <version>3.6.19</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-parent</artifactId>

--- a/platform-core/pom.xml
+++ b/platform-core/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.18</version>
+        <version>3.6.19</version>
 
     </parent>
 

--- a/platform-desktop-javafx/pom.xml
+++ b/platform-desktop-javafx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.18</version>
+        <version>3.6.19</version>
     </parent>
 
     <artifactId>outerstellar-platform-desktop-javafx</artifactId>

--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.18</version>
+        <version>3.6.19</version>
 
     </parent>
 

--- a/platform-extension-api/pom.xml
+++ b/platform-extension-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.18</version>
+        <version>3.6.19</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-api</artifactId>

--- a/platform-jte-extensions/pom.xml
+++ b/platform-jte-extensions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.18</version>
+        <version>3.6.19</version>
     </parent>
 
     <artifactId>outerstellar-platform-jte-extensions</artifactId>

--- a/platform-persistence-jdbi/pom.xml
+++ b/platform-persistence-jdbi/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.18</version>
+        <version>3.6.19</version>
 
     </parent>
 

--- a/platform-security/pom.xml
+++ b/platform-security/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.18</version>
+        <version>3.6.19</version>
 
     </parent>
 

--- a/platform-seeder/pom.xml
+++ b/platform-seeder/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.18</version>
+        <version>3.6.19</version>
 
     </parent>
 

--- a/platform-sync-client/pom.xml
+++ b/platform-sync-client/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.18</version>
+        <version>3.6.19</version>
 
     </parent>
 

--- a/platform-testkit/pom.xml
+++ b/platform-testkit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.18</version>
+        <version>3.6.19</version>
     </parent>
 
     <artifactId>outerstellar-platform-testkit</artifactId>

--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.18</version>
+        <version>3.6.19</version>
 
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.rygel</groupId>
     <artifactId>outerstellar-platform-parent</artifactId>
 
-    <version>3.6.18</version>
+    <version>3.6.19</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Summary

Version bump and CHANGELOG entry for the **v3.6.19** release.

## Changes

- `pom.xml` root + 17 module poms: `3.6.18` → `3.6.19` (via `versions:set -DprocessAllModules`).
- Extension archetype template: `outerstellar-platform.version` `3.6.18` → `3.6.19`.
- `CHANGELOG.md`: new `## [3.6.19] – 2026-07-07` entry.

## Contents of v3.6.19

- **Platform-rendered pages resolve their own i18n bundle** — `ShellRenderer.cachedI18n` loads the platform `web.*` bundle through the platform's own classloader instead of the host TCCL. Fixes raw `web.*` keys on `/auth` (and other platform pages) when the platform is consumed as a library by a host app (#594, #595). Also aligns the two desktop i18n load sites.

## After merge

Once this lands on main and CI is green on the merge commit, dispatch the `Release and Publish` workflow with `release_version = 3.6.19`, `confirm_release_version = 3.6.19`. The workflow guard verifies pom version match, CHANGELOG heading present, and a successful CI run on the exact main commit.

No production code changes in this PR — version strings and CHANGELOG only.