### PR TITLE
release: v3.6.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
+## [3.6.20] – 2026-07-07
 
 ### Fixed
 
-- **Platform Flyway migrations namespaced under `db/migration/platform/`** — the platform's own migrations moved out of the shared `db/migration/` root into a platform-owned subdirectory, and `DatabaseInfra.migrate()` now scans `classpath:db/migration/platform` instead of the shared parent. Before this, a host app bundling the platform alongside other migration-bearing modules failed to boot with `Found more than one migration with version 1`: Flyway recursed into sibling subtrees (`db/migration/audit/`, `db/migration/<extension>/`, …) and collided on `V1`, and discarded nested extension locations as sub-locations of the parent. Existing databases validate unchanged (history rows are keyed by version + checksum, not path). Enacts ADR-0004 (#601).
+- **Platform Flyway migrations namespaced under `db/migration/platform/`** *(boot-blocking regression in v3.6.19)* — the platform's own migrations moved out of the shared `db/migration/` root into a platform-owned subdirectory, and `DatabaseInfra.migrate()` now scans `classpath:db/migration/platform` instead of the shared parent. Before this, a host app bundling the platform alongside other migration-bearing modules failed to boot with `Found more than one migration with version 1`: Flyway recursed into sibling subtrees (`db/migration/audit/`, `db/migration/<extension>/`, …) and collided on `V1`, and discarded nested extension locations as sub-locations of the parent. Existing databases validate unchanged (history rows are keyed by version + checksum, not path). Enacts ADR-0004 (#601).
+- **`UrlValidator` over-broad catch** — `catch (e: Exception)` narrowed to `catch (e: URISyntaxException)`; `URI(...)` only throws `URISyntaxException`, so the broad catch no longer swallows unrelated runtime exceptions and misreports them as URL parse failures.
+- **`OutboxProcessor` dead local store** — `var batchSize` now initialized at declaration (`= 0`).
+- **`ContactExportProvider` defensive copy** — the exported row's `emails` list is now copied (`.toList()`) at construction.
+
+### Changed
+
+- **SpotBugs exclusion filter documented** — `config/spotbugs-exclude.xml` reorganized into 7 commented sections (generated code, Kotlin idiom false positives, Kotlin-collection exposure, companion false positives, interface contracts, Kotlin `use {}` resource analysis, desktop/JavaFX scaffold) with a per-entry rationale and a policy header. Two stale `AppKt` suppressions (referencing code that no longer exists) removed. The audit found most existing suppressions were legitimate SpotBugs/Kotlin-idiom false positives, not hidden bugs.
+- **Supply-chain hardening** — Dependabot configs gained a 7-day `cooldown` per ecosystem; `.npmrc` adds `min-release-age=7` (npm v11.10.0+); the Gravatar MD5 use in `AvatarUrls.kt` is suppressed with an explicit rule-id (MD5 is spec-mandated by the Gravatar API). The chronic `Semgrep Scan` advisory CI failure is now green.
+- **ADR-0004** added — records the decision that platform Flyway migrations must be namespaced under a platform-owned subdirectory.
+
+### Dependencies
+
+- Bumped `bytebuddy.version`, `junit.version`, `spotless-maven-plugin`, `playwright`, `logback-classic`, graalvm `native-maven-plugin`, and grouped `http4k` / `persistence` / `github-actions` updates via Dependabot.
+
+---
+
+## [Unreleased]
 
 ---
 

--- a/outerstellar-i18n-validator-maven-plugin/pom.xml
+++ b/outerstellar-i18n-validator-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.19</version>
+        <version>3.6.20</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n-validator/pom.xml
+++ b/outerstellar-i18n-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.19</version>
+        <version>3.6.20</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n/pom.xml
+++ b/outerstellar-i18n/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.19</version>
+        <version>3.6.20</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-platform-extension-archetype/pom.xml
+++ b/outerstellar-platform-extension-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.19</version>
+        <version>3.6.20</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-archetype</artifactId>

--- a/outerstellar-platform-extension-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/outerstellar-platform-extension-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <maven.compiler.release>\${java.version}</maven.compiler.release>
-        <outerstellar-platform.version>3.6.19</outerstellar-platform.version>
+        <outerstellar-platform.version>3.6.20</outerstellar-platform.version>
         <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
         <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>
         <maven.shade.plugin.version>3.6.2</maven.shade.plugin.version>

--- a/outerstellar-platform-extension-parent/pom.xml
+++ b/outerstellar-platform-extension-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.19</version>
+        <version>3.6.20</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-parent</artifactId>

--- a/platform-core/pom.xml
+++ b/platform-core/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.19</version>
+        <version>3.6.20</version>
 
     </parent>
 

--- a/platform-desktop-javafx/pom.xml
+++ b/platform-desktop-javafx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.19</version>
+        <version>3.6.20</version>
     </parent>
 
     <artifactId>outerstellar-platform-desktop-javafx</artifactId>

--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.19</version>
+        <version>3.6.20</version>
 
     </parent>
 

--- a/platform-extension-api/pom.xml
+++ b/platform-extension-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.19</version>
+        <version>3.6.20</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-api</artifactId>

--- a/platform-jte-extensions/pom.xml
+++ b/platform-jte-extensions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.19</version>
+        <version>3.6.20</version>
     </parent>
 
     <artifactId>outerstellar-platform-jte-extensions</artifactId>

--- a/platform-persistence-jdbi/pom.xml
+++ b/platform-persistence-jdbi/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.19</version>
+        <version>3.6.20</version>
 
     </parent>
 

--- a/platform-security/pom.xml
+++ b/platform-security/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.19</version>
+        <version>3.6.20</version>
 
     </parent>
 

--- a/platform-seeder/pom.xml
+++ b/platform-seeder/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.19</version>
+        <version>3.6.20</version>
 
     </parent>
 

--- a/platform-sync-client/pom.xml
+++ b/platform-sync-client/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.19</version>
+        <version>3.6.20</version>
 
     </parent>
 

--- a/platform-testkit/pom.xml
+++ b/platform-testkit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.19</version>
+        <version>3.6.20</version>
     </parent>
 
     <artifactId>outerstellar-platform-testkit</artifactId>

--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.19</version>
+        <version>3.6.20</version>
 
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.rygel</groupId>
     <artifactId>outerstellar-platform-parent</artifactId>
 
-    <version>3.6.19</version>
+    <version>3.6.20</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Summary

Version bump and CHANGELOG entry for the **v3.6.20** release.

## Changes
- `pom.xml` root + 17 module poms: `3.6.19` → `3.6.20` (via `versions:set -DprocessAllModules`).
- Extension archetype template: `outerstellar-platform.version` `3.6.19` → `3.6.20`.
- `CHANGELOG.md`: new `## [3.6.20] – 2026-07-07` entry.

## Contents of v3.6.20
- **#601 fix** — namespace platform Flyway migrations under `db/migration/platform/` (boot-blocking regression in v3.6.19 for host apps with colliding migration subtrees). Enacts ADR-0004.
- **SpotBugs cleanup** — `UrlValidator` narrow catch, `OutboxProcessor` dead store, `ContactExportProvider` defensive copy; documented `spotbugs-exclude.xml`.
- **Supply-chain hardening** — Dependabot cooldowns, npm `min-release-age`, Gravatar MD5 suppression; chronic Semgrep Scan advisory red now green.
- **ADR-0004**, plus Dependabot dependency bumps.

## After merge
Once on main + CI green on the merge commit, dispatch `Release and Publish` with `release_version=3.6.20`, `confirm_release_version=3.6.20`.

No production code changes in this PR — version strings and CHANGELOG only.