### PR TITLE
release: v3.6.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
+## [3.6.21] – 2026-07-08
 
 ### Fixed
 
 - **Extension migrations run in an isolated Flyway pass with their own history table** *(boot-blocking regression in v3.6.19–v3.6.20)* — `DatabaseInfra.migrate()` previously merged the platform's and the extension's migration locations into a single Flyway pass against the default `flyway_schema_history`, so a platform `V1` and an extension `V1` collided and host apps failed to boot with `Found more than one migration with version 1`. The extension's declared `ExtensionMigrations.historyTable` was ignored. Migrations now run as **two** isolated `Flyway.migrate()` calls: the platform pass against `flyway_schema_history`, the extension pass against the extension's declared history table (baselined at 0). The two V1s never share a resolver. `ExtensionMigrations.historyTable` is no longer deprecated. The legacy `repairLegacyExtensionHistoryTable` consolidation step (added in #453) is removed — it was the opposite of the separate-table design and would destroy an extension's active table (#611).
+
+---
+
+## [Unreleased]
 
 ---
 

--- a/outerstellar-i18n-validator-maven-plugin/pom.xml
+++ b/outerstellar-i18n-validator-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.20</version>
+        <version>3.6.21</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n-validator/pom.xml
+++ b/outerstellar-i18n-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.20</version>
+        <version>3.6.21</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-i18n/pom.xml
+++ b/outerstellar-i18n/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.20</version>
+        <version>3.6.21</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/outerstellar-platform-extension-archetype/pom.xml
+++ b/outerstellar-platform-extension-archetype/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.20</version>
+        <version>3.6.21</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-archetype</artifactId>

--- a/outerstellar-platform-extension-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/outerstellar-platform-extension-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>21</java.version>
         <maven.compiler.release>\${java.version}</maven.compiler.release>
-        <outerstellar-platform.version>3.6.20</outerstellar-platform.version>
+        <outerstellar-platform.version>3.6.21</outerstellar-platform.version>
         <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
         <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>
         <maven.shade.plugin.version>3.6.2</maven.shade.plugin.version>

--- a/outerstellar-platform-extension-parent/pom.xml
+++ b/outerstellar-platform-extension-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.20</version>
+        <version>3.6.21</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-parent</artifactId>

--- a/platform-core/pom.xml
+++ b/platform-core/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.20</version>
+        <version>3.6.21</version>
 
     </parent>
 

--- a/platform-desktop-javafx/pom.xml
+++ b/platform-desktop-javafx/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.20</version>
+        <version>3.6.21</version>
     </parent>
 
     <artifactId>outerstellar-platform-desktop-javafx</artifactId>

--- a/platform-desktop/pom.xml
+++ b/platform-desktop/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.20</version>
+        <version>3.6.21</version>
 
     </parent>
 

--- a/platform-extension-api/pom.xml
+++ b/platform-extension-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.20</version>
+        <version>3.6.21</version>
     </parent>
 
     <artifactId>outerstellar-platform-extension-api</artifactId>

--- a/platform-jte-extensions/pom.xml
+++ b/platform-jte-extensions/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.20</version>
+        <version>3.6.21</version>
     </parent>
 
     <artifactId>outerstellar-platform-jte-extensions</artifactId>

--- a/platform-persistence-jdbi/pom.xml
+++ b/platform-persistence-jdbi/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.20</version>
+        <version>3.6.21</version>
 
     </parent>
 

--- a/platform-security/pom.xml
+++ b/platform-security/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.20</version>
+        <version>3.6.21</version>
 
     </parent>
 

--- a/platform-seeder/pom.xml
+++ b/platform-seeder/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.20</version>
+        <version>3.6.21</version>
 
     </parent>
 

--- a/platform-sync-client/pom.xml
+++ b/platform-sync-client/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.20</version>
+        <version>3.6.21</version>
 
     </parent>
 

--- a/platform-testkit/pom.xml
+++ b/platform-testkit/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
-        <version>3.6.20</version>
+        <version>3.6.21</version>
     </parent>
 
     <artifactId>outerstellar-platform-testkit</artifactId>

--- a/platform-web/pom.xml
+++ b/platform-web/pom.xml
@@ -7,7 +7,7 @@
         <groupId>io.github.rygel</groupId>
         <artifactId>outerstellar-platform-parent</artifactId>
 
-        <version>3.6.20</version>
+        <version>3.6.21</version>
 
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.rygel</groupId>
     <artifactId>outerstellar-platform-parent</artifactId>
 
-    <version>3.6.20</version>
+    <version>3.6.21</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Release version bump to 3.6.21.

Merges the `release/v3.6.21` branch (pom version bump across 19 modules + CHANGELOG entry) into `main` so the Release and Publish workflow can run.

- Version bump: `3.6.20` → `3.6.21` (all module poms + archetype-resources pom + extension parent)
- CHANGELOG: `## [Unreleased]` → `## [3.6.21] – 2026-07-08` with a fresh `## [Unreleased]` placeholder above the previous section
- Clean fast-forward of `main` (single commit `165335ca`)

This mirrors the established release flow used for v3.6.20 (PR #609). After this merges and CI passes on `main`, the Release and Publish workflow will be dispatched with `release_version=3.6.21`.